### PR TITLE
feat: add Claude Opus 4.8 to Bedrock model registry

### DIFF
--- a/packages/cdk/config/environment-utils.ts
+++ b/packages/cdk/config/environment-utils.ts
@@ -70,6 +70,11 @@ const DEFAULT_CONFIG = {
    */
   bedrockModels: [
     {
+      id: 'global.anthropic.claude-opus-4-8',
+      name: 'Claude Opus 4.8',
+      provider: 'Anthropic',
+    },
+    {
       id: 'global.anthropic.claude-opus-4-7',
       name: 'Claude Opus 4.7',
       provider: 'Anthropic',

--- a/packages/libs/core/src/bedrock-models.ts
+++ b/packages/libs/core/src/bedrock-models.ts
@@ -36,6 +36,12 @@ export interface BedrockModelDefinition {
  */
 export const BEDROCK_MODEL_DEFINITIONS = [
   {
+    id: 'global.anthropic.claude-opus-4-8',
+    name: 'Claude Opus 4.8',
+    provider: 'Anthropic',
+    maxOutputTokens: 128000, // 128k (AWS Bedrock model card, 2026-05-28)
+  },
+  {
     id: 'global.anthropic.claude-opus-4-7',
     name: 'Claude Opus 4.7',
     provider: 'Anthropic',

--- a/packages/libs/tool-definitions/src/definitions/call-agent.ts
+++ b/packages/libs/tool-definitions/src/definitions/call-agent.ts
@@ -24,6 +24,7 @@ export const callAgentSchema = z.object({
       'Model ID to use (optional, defaults to agent config). ' +
         'Must be a valid Bedrock model ID. Examples: ' +
         '"global.anthropic.claude-sonnet-4-6", ' +
+        '"global.anthropic.claude-opus-4-8", ' +
         '"global.anthropic.claude-opus-4-6-v1", ' +
         '"global.amazon.nova-2-lite-v1:0"'
     ),


### PR DESCRIPTION
## Summary

Adds **Claude Opus 4.8** (released 2026-05-28) to the Bedrock model registry as the newest Anthropic model. Placed first in the list so it becomes the default UI selection.

## Verified Specs (AWS Bedrock model card)

| Item | Value |
|---|---|
| Model ID | `anthropic.claude-opus-4-8` (dateless format) |
| Inference profile (used here) | `global.anthropic.claude-opus-4-8` |
| Max output tokens | **128,000** (same as 4.7) |
| Context window | 1M tokens |
| `ap-northeast-1` support | ✅ In-Region / JP Geo / Global |
| API | Converse + Messages both supported |

Source: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-8.html

## Changes

- `packages/libs/core/src/bedrock-models.ts` — SSoT registry, prepend Opus 4.8 entry
- `packages/cdk/config/environment-utils.ts` — CDK `DEFAULT_CONFIG.bedrockModels`, kept in sync per the file comment in `bedrock-models.ts`
- `packages/libs/tool-definitions/src/definitions/call-agent.ts` — add Opus 4.8 to example list in tool description

## Verification

- ✅ `npm run build:ts` — passed
- ✅ `npm run lint` — passed
- ✅ `npm test` — 34 tests passed

## Notes

- Existing JP/region prefix regex (`/^(global|us|eu|apac|jp)\./`) already accommodates the new entry; no validator changes needed.
- Available alternative inference profiles (not added here, can be switched later if needed): `jp.anthropic.claude-opus-4-8`, `us.anthropic.claude-opus-4-8`, `eu.anthropic.claude-opus-4-8`, `au.anthropic.claude-opus-4-8`.