### PR TITLE
fix(agent): retry on Bedrock mid-stream truncation errors

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -32,6 +32,7 @@ import { buildUserMCPClients } from './runtime/agent/mcp-clients-builder.js';
 import { buildToolSet } from './runtime/agent/tools-builder.js';
 import { extractMemoryParams, fetchLongTermMemories } from './runtime/agent/memory-fetcher.js';
 import { loadSessionHistory } from './runtime/agent/session-loader.js';
+import { StreamTerminationRetryStrategy } from './runtime/agent/stream-termination-retry-strategy.js';
 
 import type { CreateAgentOptions, CreateAgentResult } from './runtime/agent/types.js';
 
@@ -108,6 +109,11 @@ export async function createAgent(options?: CreateAgentOptions): Promise<CreateA
     conversationManager,
     id: options?.agentId,
     traceAttributes,
+    // Recover from transient mid-stream truncation (Bedrock closing the event
+    // stream before `messageStop`) instead of aborting the turn. A fresh
+    // instance per agent is required — the strategy holds per-turn backoff state
+    // and must not be shared across agents.
+    retryStrategy: new StreamTerminationRetryStrategy(),
   });
 
   // Set storagePath in agent state for sub-agent inheritance.

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -100,6 +100,13 @@ export async function createAgent(options?: CreateAgentOptions): Promise<CreateA
   if (ctx?.isMachineUser) traceAttributes['enduser.type'] = 'machine';
   if (options?.memoryEnabled) traceAttributes['gen_ai.memory.enabled'] = 'true';
 
+  // Recover from transient mid-stream truncation (Bedrock closing the event
+  // stream before `messageStop`) instead of aborting the turn. A fresh
+  // instance per agent is required — the strategy holds per-turn backoff state
+  // and must not be shared across agents. Kept in a local so it can be returned
+  // for post-turn observability (`retryStrategy.retryCount`).
+  const retryStrategy = new StreamTerminationRetryStrategy();
+
   const agent = new Agent({
     model,
     systemPrompt,
@@ -109,11 +116,7 @@ export async function createAgent(options?: CreateAgentOptions): Promise<CreateA
     conversationManager,
     id: options?.agentId,
     traceAttributes,
-    // Recover from transient mid-stream truncation (Bedrock closing the event
-    // stream before `messageStop`) instead of aborting the turn. A fresh
-    // instance per agent is required — the strategy holds per-turn backoff state
-    // and must not be shared across agents.
-    retryStrategy: new StreamTerminationRetryStrategy(),
+    retryStrategy,
   });
 
   // Set storagePath in agent state for sub-agent inheritance.
@@ -125,6 +128,7 @@ export async function createAgent(options?: CreateAgentOptions): Promise<CreateA
 
   return {
     agent,
+    retryStrategy,
     metadata: {
       loadedMessagesCount: savedMessages.length,
       longTermMemoriesCount: memoryResult.memories.length,

--- a/packages/agent/src/handlers/invocations.ts
+++ b/packages/agent/src/handlers/invocations.ts
@@ -92,7 +92,7 @@ export async function handleInvocation(req: Request, res: Response): Promise<voi
   // 3. Create and stream agent response. The Strands SDK opens its own
   // `invoke_agent` span (with `traceAttributes` injected by `agent.ts`),
   // so we don't add a wrapper span here.
-  const { agent, metadata } = await createAgent({
+  const { agent, metadata, retryStrategy } = await createAgent({
     plugins: [
       ...(sessionResult ? [sessionResult.hook] : []),
       ...(workspaceSyncResult ? [workspaceSyncResult.hook] : []),
@@ -122,6 +122,7 @@ export async function handleInvocation(req: Request, res: Response): Promise<voi
 
   await streamAgentResponse(agent, body.prompt, body.images, res, {
     metadata,
+    retryStrategy,
     sessionStorage: sessionResult?.storage,
     sessionConfig: sessionResult?.config,
   });

--- a/packages/agent/src/handlers/stream-handler.ts
+++ b/packages/agent/src/handlers/stream-handler.ts
@@ -17,6 +17,7 @@ import {
 import { getCurrentContext, getContextMetadata } from '../libs/context/request-context.js';
 import type { SessionStorage, SessionConfig } from '../services/session/types.js';
 import type { AgentMetadata } from '../runtime/agent/types.js';
+import type { StreamTerminationRetryStrategy } from '../runtime/agent/stream-termination-retry-strategy.js';
 import type { ImageData } from '../types/validation/index.js';
 
 /**
@@ -25,6 +26,13 @@ import type { ImageData } from '../types/validation/index.js';
 export interface StreamOptions {
   /** Agent creation metadata (included in completion event) */
   metadata: AgentMetadata;
+  /**
+   * Retry strategy wired into the agent. Read after a successful turn to emit
+   * `stream_retry_recovered` when a transient mid-stream truncation was
+   * retried and the turn ultimately succeeded. Optional so callers that don't
+   * thread it through (e.g. some tests) still type-check.
+   */
+  retryStrategy?: StreamTerminationRetryStrategy;
   /** Session storage (for saving error messages on stream failure) */
   sessionStorage?: SessionStorage;
   /** Session config (for saving error messages on stream failure) */
@@ -85,7 +93,23 @@ async function handleStreamError(
     );
   }
 
-  logger.error({ requestId, error }, 'Agent streaming error:');
+  // Log the full error. Use the `err` key (not `error`) so pino's configured
+  // `err` serializer (libs/logger) expands name/message/stack/cause into
+  // structured fields. The previous `{ requestId, error }` form bypassed that
+  // serializer and emitted only `{"error":{"name":"ModelError"}}`, dropping
+  // `message`/`stack`/`cause` — which made mid-stream truncation failures
+  // indistinguishable in CloudWatch. `attempt`/`retried` correlate the failure
+  // with the retry strategy's `stream_retry_classified`/`_exhausted` events.
+  const retryCount = options.retryStrategy?.retryCount ?? 0;
+  logger.error(
+    {
+      requestId,
+      retried: retryCount > 0,
+      attempts: retryCount > 0 ? retryCount + 1 : 1,
+      err: error,
+    },
+    'Agent streaming error:'
+  );
 
   // Save error message to session history if session is configured
   if (options.sessionStorage && options.sessionConfig) {
@@ -166,6 +190,24 @@ export async function streamAgentResponse(
     }
 
     logger.info({ requestId }, 'Agent streaming completed:');
+
+    // If the turn completed only after one or more transient mid-stream
+    // truncations were retried, record the recovery. This is the *success*
+    // counterpart to `stream_retry_classified` / `stream_retry_exhausted` and
+    // is the only signal that lets operations compute a retry recovery rate
+    // (recovered vs. exhausted) — a successful turn is otherwise silent.
+    const retryCount = options.retryStrategy?.retryCount ?? 0;
+    if (retryCount > 0) {
+      logger.info(
+        {
+          requestId,
+          attempts: retryCount + 1,
+          retries: retryCount,
+          recovered: true,
+        },
+        'stream_retry_recovered'
+      );
+    }
 
     sendCompletionEvent(res, agent, options);
     res.end();

--- a/packages/agent/src/runtime/agent/__tests__/stream-termination-retry-strategy.logging.test.ts
+++ b/packages/agent/src/runtime/agent/__tests__/stream-termination-retry-strategy.logging.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Structured-logging assertions for StreamTerminationRetryStrategy.
+ *
+ * Why a separate file?  The companion `stream-termination-retry-strategy.test.ts`
+ * exercises the *behaviour* (classification + the real SDK retry loop). Here we
+ * assert the *observability contract*: the stable `msg` keys, log levels, and the
+ * structured fields (`attempt`, `maxAttempts`, `willRetry`, `kind`, `err`) that
+ * downstream CloudWatch Logs Insights queries depend on.
+ *
+ * We mock the scoped logger module via `jest.unstable_mockModule` and inspect the
+ * mock's call arguments directly. This is deterministic and CI-safe — unlike
+ * capturing `process.stdout`, whose pino write semantics differ between local and
+ * CI runners and previously produced a flaky test.
+ *
+ * ESM note: mocks MUST be registered before the dynamic `import()` of the module
+ * under test, matching the pattern used in handlers/__tests__/stream-handler.test.ts.
+ */
+
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+
+// Single shared logger mock returned by createLogger(); the strategy binds it at
+// module-eval time via `const log = createLogger('StreamTerminationRetryStrategy')`.
+const mockLog = {
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+};
+
+jest.unstable_mockModule('../../../libs/logger/index.js', () => ({
+  createLogger: jest.fn(() => mockLog),
+  logger: mockLog,
+}));
+
+// No active request context in unit scope → currentRequestId() returns undefined.
+jest.unstable_mockModule('../../../libs/context/request-context.js', () => ({
+  getCurrentContext: jest.fn(() => undefined),
+}));
+
+const { ModelError, MaxTokensError } = await import('@strands-agents/sdk');
+const { StreamTerminationRetryStrategy, STREAM_INCOMPLETE_MESSAGE } = await import(
+  '../stream-termination-retry-strategy.js'
+);
+
+const truncation = () => new ModelError(STREAM_INCOMPLETE_MESSAGE);
+
+describe('StreamTerminationRetryStrategy structured logging', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('logs stream_retry_classified at warn level with the retry context', () => {
+    const s = new StreamTerminationRetryStrategy({ maxAttempts: 3 });
+
+    expect(s.isRetryable(truncation())).toBe(true);
+
+    expect(mockLog.warn).toHaveBeenCalledTimes(1);
+    expect(mockLog.error).not.toHaveBeenCalled();
+
+    const [fields, msg] = mockLog.warn.mock.calls[0] as [Record<string, unknown>, string];
+    expect(msg).toBe('stream_retry_classified');
+    expect(fields).toMatchObject({
+      attempt: 1,
+      maxAttempts: 3,
+      willRetry: true,
+      kind: 'stream_truncation',
+    });
+    expect((fields.err as Record<string, unknown>).message).toBe(STREAM_INCOMPLETE_MESSAGE);
+    // name is propagated from the SDK error class; assert it is a non-empty
+    // string rather than pinning the exact class name (SDK-implementation detail).
+    expect(typeof (fields.err as Record<string, unknown>).name).toBe('string');
+    expect((fields.err as Record<string, unknown>).name).toBeTruthy();
+  });
+
+  it('logs stream_retry_exhausted at error level once maxAttempts is reached', () => {
+    const s = new StreamTerminationRetryStrategy({ maxAttempts: 2 });
+
+    s.isRetryable(truncation()); // attempt 1 → classified (warn)
+    s.isRetryable(truncation()); // attempt 2 → exhausted (error)
+
+    expect(mockLog.warn).toHaveBeenCalledTimes(1);
+    expect(mockLog.error).toHaveBeenCalledTimes(1);
+
+    const [warnFields, warnMsg] = mockLog.warn.mock.calls[0] as [Record<string, unknown>, string];
+    expect(warnMsg).toBe('stream_retry_classified');
+    expect(warnFields).toMatchObject({ attempt: 1, maxAttempts: 2, willRetry: true });
+
+    const [errFields, errMsg] = mockLog.error.mock.calls[0] as [Record<string, unknown>, string];
+    expect(errMsg).toBe('stream_retry_exhausted');
+    expect(errFields).toMatchObject({
+      attempt: 2,
+      maxAttempts: 2,
+      willRetry: false,
+      kind: 'stream_truncation',
+    });
+    expect((errFields.err as Record<string, unknown>).message).toBe(STREAM_INCOMPLETE_MESSAGE);
+  });
+
+  it('does NOT log for a non-retryable error', () => {
+    const s = new StreamTerminationRetryStrategy({ maxAttempts: 3 });
+
+    expect(s.isRetryable(new MaxTokensError('ceiling'))).toBe(false);
+
+    expect(mockLog.warn).not.toHaveBeenCalled();
+    expect(mockLog.error).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent/src/runtime/agent/__tests__/stream-termination-retry-strategy.test.ts
+++ b/packages/agent/src/runtime/agent/__tests__/stream-termination-retry-strategy.test.ts
@@ -237,3 +237,97 @@ describe('StreamTerminationRetryStrategy.isRetryable', () => {
     expect(strategy.isRetryable(new Error(STREAM_INCOMPLETE_MESSAGE))).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Observability: retry-count accounting + structured log events
+// ---------------------------------------------------------------------------
+
+describe('StreamTerminationRetryStrategy observability', () => {
+  const truncation = () => new ModelError(STREAM_INCOMPLETE_MESSAGE);
+
+  it('starts with retryCount 0 and exposes maxAttempts', () => {
+    const s = new StreamTerminationRetryStrategy({ maxAttempts: 3 });
+    expect(s.retryCount).toBe(0);
+    expect(s.maxAttempts).toBe(3);
+  });
+
+  it('increments retryCount only when an error is classified retryable', () => {
+    const s = new StreamTerminationRetryStrategy({ maxAttempts: 5 });
+
+    // Non-retryable: counter must not move.
+    s.isRetryable(new MaxTokensError('ceiling'));
+    expect(s.retryCount).toBe(0);
+
+    // Retryable transient truncation: counter advances by one each time.
+    s.isRetryable(truncation());
+    expect(s.retryCount).toBe(1);
+    s.isRetryable(truncation());
+    expect(s.retryCount).toBe(2);
+  });
+
+  it('counts inherited throttle retries as well', () => {
+    const s = new StreamTerminationRetryStrategy({ maxAttempts: 5 });
+    s.isRetryable(new ModelThrottledError('rate limited'));
+    expect(s.retryCount).toBe(1);
+  });
+
+  it('keeps returning true at the maxAttempts boundary (give-up is enforced by the SDK)', () => {
+    // maxAttempts = 2 → the second classification is the exhaustion boundary.
+    const s = new StreamTerminationRetryStrategy({ maxAttempts: 2 });
+    expect(s.isRetryable(truncation())).toBe(true); // attempt 1: classified
+    expect(s.retryCount).toBe(1);
+    expect(s.isRetryable(truncation())).toBe(true); // attempt 2: exhausted (still true)
+    expect(s.retryCount).toBe(2);
+  });
+
+  it('emits stream_retry_classified then stream_retry_exhausted via the scoped logger', async () => {
+    // The strategy logs through createLogger('StreamTerminationRetryStrategy').
+    // Capture stdout (pino writes NDJSON there) and assert the stable msg keys
+    // and structured fields appear with the correct levels.
+    const written: string[] = [];
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    // @ts-expect-error narrow override for the test
+    process.stdout.write = (chunk: string | Uint8Array): boolean => {
+      written.push(chunk.toString());
+      return true;
+    };
+    try {
+      const s = new StreamTerminationRetryStrategy({ maxAttempts: 2 });
+      s.isRetryable(truncation()); // -> stream_retry_classified (warn)
+      s.isRetryable(truncation()); // -> stream_retry_exhausted (error)
+    } finally {
+      process.stdout.write = originalWrite;
+    }
+
+    const lines = written
+      .join('')
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => {
+        try {
+          return JSON.parse(l) as Record<string, unknown>;
+        } catch {
+          return null;
+        }
+      })
+      .filter((o): o is Record<string, unknown> => o !== null);
+
+    const classified = lines.find((l) => l.msg === 'stream_retry_classified');
+    const exhausted = lines.find((l) => l.msg === 'stream_retry_exhausted');
+
+    expect(classified).toBeDefined();
+    expect(classified?.level).toBe(40); // pino warn
+    expect(classified?.attempt).toBe(1);
+    expect(classified?.maxAttempts).toBe(2);
+    expect(classified?.willRetry).toBe(true);
+    expect(classified?.kind).toBe('stream_truncation');
+
+    expect(exhausted).toBeDefined();
+    expect(exhausted?.level).toBe(50); // pino error
+    expect(exhausted?.attempt).toBe(2);
+    expect(exhausted?.willRetry).toBe(false);
+    expect(exhausted?.kind).toBe('stream_truncation');
+    // err must carry the message (the loss this change fixes elsewhere too).
+    expect((exhausted?.err as Record<string, unknown>)?.message).toBe(STREAM_INCOMPLETE_MESSAGE);
+  });
+});

--- a/packages/agent/src/runtime/agent/__tests__/stream-termination-retry-strategy.test.ts
+++ b/packages/agent/src/runtime/agent/__tests__/stream-termination-retry-strategy.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Reproduction + fix tests for the transient mid-stream truncation bug.
+ *
+ * Symptom (reported): the agent aborts mid-task with
+ *   [SYSTEM_ERROR] ... Type: ModelError
+ *   Details: "Stream ended without completing a message" ...
+ *
+ * Root cause: Bedrock's ConverseStream can end the event stream cleanly without
+ * ever delivering a `messageStop` chunk. The SDK base `Model.streamAggregated()`
+ * then exits its loop with no `finalStopReason` and throws a base
+ * `ModelError('Stream ended without completing a message')`. The SDK default
+ * retry strategy only retries `ModelThrottledError`, so the error propagates and
+ * the turn is aborted.
+ *
+ * These tests are deterministic and offline: a hand-rolled `FakeModel` (the SDK
+ * does not export its `TestModelProvider` fixture) drives the real SDK
+ * `streamAggregated()` / `Agent` retry loop. No network, no fake timers — the
+ * fix strategy is constructed with a zero-delay backoff.
+ *
+ * Run: cd packages/agent && npm test -- stream-termination-retry-strategy
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import {
+  Agent,
+  Model,
+  Message,
+  TextBlock,
+  ModelError,
+  MaxTokensError,
+  ContextWindowOverflowError,
+  ModelThrottledError,
+  ConstantBackoff,
+  type ModelStreamEvent,
+  type BaseModelConfig,
+} from '@strands-agents/sdk';
+import {
+  StreamTerminationRetryStrategy,
+  STREAM_INCOMPLETE_MESSAGE,
+} from '../stream-termination-retry-strategy.js';
+
+// ---------------------------------------------------------------------------
+// Fake model
+// ---------------------------------------------------------------------------
+
+/**
+ * The full, well-formed event-data sequence for one assistant turn. The SDK
+ * turns each yielded value into a class instance via `_convert_to_class_event`,
+ * so we yield plain `*EventData` shapes (not pre-built instances).
+ */
+function* completeTurn(text: string): Generator<ModelStreamEvent> {
+  yield { type: 'modelMessageStartEvent', role: 'assistant' } as ModelStreamEvent;
+  yield { type: 'modelContentBlockStartEvent' } as ModelStreamEvent;
+  yield {
+    type: 'modelContentBlockDeltaEvent',
+    delta: { type: 'textDelta', text },
+  } as ModelStreamEvent;
+  yield { type: 'modelContentBlockStopEvent' } as ModelStreamEvent;
+  yield { type: 'modelMessageStopEvent', stopReason: 'endTurn' } as ModelStreamEvent;
+}
+
+/**
+ * Same sequence as {@link completeTurn} but WITHOUT the trailing
+ * `modelMessageStopEvent`. This is exactly the Bedrock truncation: the stream
+ * ends after partial content, so `streamAggregated()` never records a stop
+ * reason and throws `ModelError('Stream ended without completing a message')`.
+ */
+function* truncatedTurn(text: string): Generator<ModelStreamEvent> {
+  yield { type: 'modelMessageStartEvent', role: 'assistant' } as ModelStreamEvent;
+  yield { type: 'modelContentBlockStartEvent' } as ModelStreamEvent;
+  yield {
+    type: 'modelContentBlockDeltaEvent',
+    delta: { type: 'textDelta', text },
+  } as ModelStreamEvent;
+  yield { type: 'modelContentBlockStopEvent' } as ModelStreamEvent;
+  // (no modelMessageStopEvent — stream ends here)
+}
+
+/**
+ * Minimal `Model` subclass. `streamAggregated()` is concrete on the base; we
+ * only implement the abstract surface (`stream`, `getConfig`, `updateConfig`).
+ *
+ * `failuresBeforeSuccess` controls how many leading invocations truncate before
+ * one completes. The agent loop re-invokes `stream()` once per attempt, so a
+ * per-instance `attempts` counter yields deterministic fail-then-succeed
+ * behavior across retries.
+ */
+class FakeModel extends Model {
+  private config: BaseModelConfig = { modelId: 'fake-model' };
+  /** Number of times `stream()` has been invoked on this instance. */
+  attempts = 0;
+
+  constructor(
+    private readonly failuresBeforeSuccess: number,
+    private readonly text = 'Hello',
+  ) {
+    super();
+  }
+
+  getConfig(): BaseModelConfig {
+    return this.config;
+  }
+
+  updateConfig(modelConfig: BaseModelConfig): void {
+    this.config = { ...this.config, ...modelConfig };
+  }
+
+  async *stream(): AsyncIterable<ModelStreamEvent> {
+    this.attempts += 1;
+    if (this.attempts <= this.failuresBeforeSuccess) {
+      yield* truncatedTurn(this.text);
+      return;
+    }
+    yield* completeTurn(this.text);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Zero-delay strategy so retries don't introduce real wall-clock latency. */
+function fixStrategy(maxAttempts = 3): StreamTerminationRetryStrategy {
+  return new StreamTerminationRetryStrategy({
+    maxAttempts,
+    backoff: new ConstantBackoff({ delayMs: 0 }),
+  });
+}
+
+/** Drain an agent stream to completion (throws propagate to the caller). */
+async function drain(agent: Agent, prompt: string): Promise<void> {
+  for await (const _event of agent.stream(prompt)) {
+    void _event;
+  }
+}
+
+function lastAssistantText(agent: Agent): string {
+  const msgs = agent.messages;
+  const last = msgs[msgs.length - 1];
+  return last.content
+    .filter((b) => (b as { type: string }).type === 'textBlock')
+    .map((b) => (b as { text?: string }).text ?? '')
+    .join('');
+}
+
+// ---------------------------------------------------------------------------
+// 1. Reproduction — the bug, isolated at the SDK base-class layer
+// ---------------------------------------------------------------------------
+
+describe('reproduction: stream ends without messageStop', () => {
+  it('Model.streamAggregated throws the exact ModelError', async () => {
+    const model = new FakeModel(Number.POSITIVE_INFINITY); // always truncates
+    const messages = [new Message({ role: 'user', content: [new TextBlock('hi')] })];
+
+    const run = async () => {
+      // streamAggregated yields events then *returns* the final result; iterate
+      // to drive it to the throw.
+      for await (const _event of model.streamAggregated(messages)) {
+        void _event;
+      }
+    };
+
+    await expect(run()).rejects.toThrow(ModelError);
+    await expect(run()).rejects.toThrow(STREAM_INCOMPLETE_MESSAGE);
+  });
+
+  it('Agent aborts the turn when retries are disabled (retryStrategy: null)', async () => {
+    const model = new FakeModel(Number.POSITIVE_INFINITY);
+    const agent = new Agent({ model, retryStrategy: null, printer: false });
+
+    await expect(drain(agent, 'hi')).rejects.toThrow(STREAM_INCOMPLETE_MESSAGE);
+  });
+
+  it('the SDK default strategy does NOT recover (only retries throttling)', async () => {
+    // No retryStrategy ⇒ SDK installs DefaultModelRetryStrategy, which retries
+    // ModelThrottledError only. This is the shipped pre-fix behavior.
+    const model = new FakeModel(1); // would succeed on attempt 2 if retried
+    const agent = new Agent({ model, printer: false });
+
+    await expect(drain(agent, 'hi')).rejects.toThrow(STREAM_INCOMPLETE_MESSAGE);
+    expect(model.attempts).toBe(1); // never retried
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Fix — the custom strategy recovers a transient truncation
+// ---------------------------------------------------------------------------
+
+describe('fix: StreamTerminationRetryStrategy recovers', () => {
+  it('retries a single transient truncation and completes the turn', async () => {
+    const model = new FakeModel(1); // truncate once, then succeed
+    const agent = new Agent({ model, retryStrategy: fixStrategy(), printer: false });
+
+    await expect(drain(agent, 'hi')).resolves.toBeUndefined();
+
+    expect(model.attempts).toBe(2); // failed once, retried once, succeeded
+    expect(agent.messages[agent.messages.length - 1].role).toBe('assistant');
+    expect(lastAssistantText(agent)).toContain('Hello');
+  });
+
+  it('gives up after maxAttempts and surfaces the original ModelError', async () => {
+    const model = new FakeModel(Number.POSITIVE_INFINITY); // never succeeds
+    const agent = new Agent({ model, retryStrategy: fixStrategy(3), printer: false });
+
+    await expect(drain(agent, 'hi')).rejects.toThrow(STREAM_INCOMPLETE_MESSAGE);
+    expect(model.attempts).toBe(3); // bounded — does not loop forever
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Predicate — isRetryable matches only the transient case
+// ---------------------------------------------------------------------------
+
+describe('StreamTerminationRetryStrategy.isRetryable', () => {
+  const strategy = new StreamTerminationRetryStrategy();
+
+  it('retries the transient mid-stream truncation ModelError', () => {
+    expect(strategy.isRetryable(new ModelError(STREAM_INCOMPLETE_MESSAGE))).toBe(true);
+  });
+
+  it('preserves the inherited throttle-retry behavior', () => {
+    expect(strategy.isRetryable(new ModelThrottledError('rate limited'))).toBe(true);
+  });
+
+  it('does NOT retry non-transient ModelError subclasses', () => {
+    expect(strategy.isRetryable(new MaxTokensError('hit token ceiling'))).toBe(false);
+    expect(strategy.isRetryable(new ContextWindowOverflowError('context too large'))).toBe(false);
+  });
+
+  it('does NOT retry a base ModelError with a different message', () => {
+    // e.g. the SDK wrapping a deterministic JSON.parse SyntaxError as a base
+    // ModelError carrying the original (non-matching) message.
+    expect(strategy.isRetryable(new ModelError('Unexpected token < in JSON'))).toBe(false);
+  });
+
+  it('does NOT retry a plain Error', () => {
+    expect(strategy.isRetryable(new Error(STREAM_INCOMPLETE_MESSAGE))).toBe(false);
+  });
+});

--- a/packages/agent/src/runtime/agent/__tests__/stream-termination-retry-strategy.test.ts
+++ b/packages/agent/src/runtime/agent/__tests__/stream-termination-retry-strategy.test.ts
@@ -280,54 +280,11 @@ describe('StreamTerminationRetryStrategy observability', () => {
     expect(s.retryCount).toBe(2);
   });
 
-  it('emits stream_retry_classified then stream_retry_exhausted via the scoped logger', async () => {
-    // The strategy logs through createLogger('StreamTerminationRetryStrategy').
-    // Capture stdout (pino writes NDJSON there) and assert the stable msg keys
-    // and structured fields appear with the correct levels.
-    const written: string[] = [];
-    const originalWrite = process.stdout.write.bind(process.stdout);
-    // @ts-expect-error narrow override for the test
-    process.stdout.write = (chunk: string | Uint8Array): boolean => {
-      written.push(chunk.toString());
-      return true;
-    };
-    try {
-      const s = new StreamTerminationRetryStrategy({ maxAttempts: 2 });
-      s.isRetryable(truncation()); // -> stream_retry_classified (warn)
-      s.isRetryable(truncation()); // -> stream_retry_exhausted (error)
-    } finally {
-      process.stdout.write = originalWrite;
-    }
-
-    const lines = written
-      .join('')
-      .split('\n')
-      .filter(Boolean)
-      .map((l) => {
-        try {
-          return JSON.parse(l) as Record<string, unknown>;
-        } catch {
-          return null;
-        }
-      })
-      .filter((o): o is Record<string, unknown> => o !== null);
-
-    const classified = lines.find((l) => l.msg === 'stream_retry_classified');
-    const exhausted = lines.find((l) => l.msg === 'stream_retry_exhausted');
-
-    expect(classified).toBeDefined();
-    expect(classified?.level).toBe(40); // pino warn
-    expect(classified?.attempt).toBe(1);
-    expect(classified?.maxAttempts).toBe(2);
-    expect(classified?.willRetry).toBe(true);
-    expect(classified?.kind).toBe('stream_truncation');
-
-    expect(exhausted).toBeDefined();
-    expect(exhausted?.level).toBe(50); // pino error
-    expect(exhausted?.attempt).toBe(2);
-    expect(exhausted?.willRetry).toBe(false);
-    expect(exhausted?.kind).toBe('stream_truncation');
-    // err must carry the message (the loss this change fixes elsewhere too).
-    expect((exhausted?.err as Record<string, unknown>)?.message).toBe(STREAM_INCOMPLETE_MESSAGE);
-  });
+  // NOTE: The structured-log *content* (stable `msg` keys, levels, and the
+  // `attempt` / `maxAttempts` / `willRetry` / `kind` / `err` fields) is asserted
+  // in `stream-termination-retry-strategy.logging.test.ts`, which mocks the
+  // scoped logger via `jest.unstable_mockModule`. We deliberately do NOT capture
+  // `process.stdout` here: pino's stdout writes are environment-dependent
+  // (buffering / fd handling differs between local and CI), which made the
+  // stdout-capture assertion flaky in CI.
 });

--- a/packages/agent/src/runtime/agent/stream-termination-retry-strategy.ts
+++ b/packages/agent/src/runtime/agent/stream-termination-retry-strategy.ts
@@ -29,6 +29,18 @@ import {
   ContextWindowOverflowError,
   type DefaultModelRetryStrategyOptions,
 } from '@strands-agents/sdk';
+import { createLogger } from '../../libs/logger/index.js';
+import { getCurrentContext } from '../../libs/context/request-context.js';
+
+const log = createLogger('StreamTerminationRetryStrategy');
+
+/**
+ * Classification of why `isRetryable` decided to retry. Surfaced on the
+ * `stream_retry_*` log events so CloudWatch Logs Insights can split
+ * `stats count() by kind` and distinguish a genuine mid-stream truncation
+ * (the bug this strategy targets) from an inherited throttle retry.
+ */
+type RetryKind = 'stream_truncation' | 'throttle';
 
 /**
  * The exact message thrown by the SDK base `Model.streamAggregated()` when the
@@ -53,18 +65,42 @@ export class StreamTerminationRetryStrategy extends DefaultModelRetryStrategy {
   override readonly name = 'moca:stream-termination-retry-strategy';
 
   /**
+   * Total attempts allowed before giving up (1 = no retry). Retained so the
+   * strategy can log `maxAttempts` and detect the give-up boundary itself —
+   * the base class keeps this private.
+   */
+  readonly maxAttempts: number;
+
+  /**
+   * Number of times this strategy has classified an error as retryable for
+   * the current turn (i.e. how many model re-issues it has requested).
+   *
+   * - `0`  → the turn never hit a retryable failure.
+   * - `>0` → at least one retry was requested; the stream handler reads this
+   *   after a *successful* turn to emit `stream_retry_recovered`.
+   *
+   * `public readonly` so callers (and tests) can observe it without driving
+   * the full agent loop. A fresh strategy instance is created per agent
+   * (see agent.ts), so this counter is scoped to a single turn and must not
+   * be reset or shared across agents.
+   */
+  retryCount = 0;
+
+  /**
    * Default to 3 total attempts (SDK default is 6). A transient truncation that
    * survives two re-issues is unlikely to be transient, and bounding attempts
    * caps token/latency cost on a genuinely stuck stream.
    */
   constructor(opts: DefaultModelRetryStrategyOptions = {}) {
-    super({ maxAttempts: 3, ...opts });
+    const resolved = { maxAttempts: 3, ...opts };
+    super(resolved);
+    this.maxAttempts = resolved.maxAttempts;
   }
 
   override isRetryable(error: Error): boolean {
     // Preserve the inherited throttle-retry behavior.
     if (super.isRetryable(error)) {
-      return true;
+      return this.recordRetry(error, 'throttle');
     }
 
     // Never retry deterministic, non-transient model errors. These are all
@@ -81,10 +117,82 @@ export class StreamTerminationRetryStrategy extends DefaultModelRetryStrategy {
     // excludes a base ModelError that merely *wraps* a deterministic failure
     // (model.js wraps non-ModelError stream errors — e.g. a JSON.parse
     // SyntaxError — as a base ModelError carrying the original message).
-    return (
+    const isTransientTruncation =
       error instanceof ModelError &&
       error.constructor === ModelError &&
-      error.message === STREAM_INCOMPLETE_MESSAGE
+      error.message === STREAM_INCOMPLETE_MESSAGE;
+
+    if (isTransientTruncation) {
+      return this.recordRetry(error, 'stream_truncation');
+    }
+
+    return false;
+  }
+
+  /**
+   * Record a retry decision and emit the matching structured log event, then
+   * return `true` (always retryable at the point this is called).
+   *
+   * Emits exactly one of:
+   *   - `stream_retry_classified` (warn) — a retry is being requested; the
+   *     turn will re-issue the model call. `willRetry: true`.
+   *   - `stream_retry_exhausted`  (error) — this decision hit `maxAttempts`,
+   *     so although the error *is* retryable the agent loop will abort after
+   *     this. `willRetry: false`. This is the signal that distinguishes
+   *     "retried and still failed" from "never matched / non-retryable".
+   *
+   * Fields (stable, numeric where applicable) are chosen for Logs Insights:
+   *   attempt, maxAttempts, willRetry, kind, err{name,message}, requestId.
+   */
+  private recordRetry(error: Error, kind: RetryKind): boolean {
+    this.retryCount += 1;
+    // `attempt` is the model call that just failed (1-based): the first
+    // failure is attempt 1, and we are about to issue attempt 2, etc.
+    const attempt = this.retryCount;
+    const exhausted = attempt >= this.maxAttempts;
+    const errInfo = { name: error.name, message: error.message };
+
+    if (exhausted) {
+      log.error(
+        {
+          requestId: this.currentRequestId(),
+          attempt,
+          maxAttempts: this.maxAttempts,
+          willRetry: false,
+          kind,
+          err: errInfo,
+        },
+        'stream_retry_exhausted'
+      );
+      // NOTE: we still return true so the base machinery keeps its accounting
+      // consistent; the SDK enforces `maxAttempts` and stops re-issuing. The
+      // `stream_retry_exhausted` log above is the authoritative give-up signal.
+      return true;
+    }
+
+    log.warn(
+      {
+        requestId: this.currentRequestId(),
+        attempt,
+        maxAttempts: this.maxAttempts,
+        willRetry: true,
+        kind,
+        err: errInfo,
+      },
+      'stream_retry_classified'
     );
+    return true;
+  }
+
+  /**
+   * Best-effort request correlation. The strategy runs inside the request's
+   * `AsyncLocalStorage` context (the same context the stream handler reads),
+   * so `getCurrentContext()` returns the in-flight request. Returns
+   * `undefined` rather than throwing when no request is in flight (e.g. unit
+   * tests that drive the strategy directly), so a missing context never
+   * breaks retry classification.
+   */
+  private currentRequestId(): string | undefined {
+    return getCurrentContext()?.requestId;
   }
 }

--- a/packages/agent/src/runtime/agent/stream-termination-retry-strategy.ts
+++ b/packages/agent/src/runtime/agent/stream-termination-retry-strategy.ts
@@ -1,0 +1,90 @@
+/**
+ * Retry strategy for transient mid-stream termination.
+ *
+ * Bedrock's ConverseStream occasionally closes the HTTP/2 event stream cleanly
+ * (normal end-of-iteration, no thrown error) *before* delivering a `messageStop`
+ * chunk — typically when an upstream LB / AgentCore gateway truncates a partial
+ * response, or an idle connection is closed between chunks. When that happens,
+ * the Strands SDK's `Model.streamAggregated()` finishes its loop with no
+ * `finalStopReason` and throws a base `ModelError('Stream ended without
+ * completing a message')` (see @strands-agents/sdk model.js).
+ *
+ * The agent event loop only retries a model call when a retry strategy sets
+ * `AfterModelCallEvent.retry`. The SDK default (`DefaultModelRetryStrategy`)
+ * retries `ModelThrottledError` ONLY, so this transient truncation propagates
+ * out of `agent.stream()`, the handler persists a `[SYSTEM_ERROR]` assistant
+ * message, and the agent stops mid-task — the reported symptom.
+ *
+ * WHY NOT bump the Bedrock client's `maxAttempts`: the AWS SDK retry middleware
+ * wraps only the `send()` promise, which resolves once response headers arrive —
+ * before any stream chunk is consumed. A failure while iterating the event
+ * stream is outside that middleware and gets zero SDK-level retries. The retry
+ * therefore has to live at the agent layer, re-issuing the whole model call.
+ */
+
+import {
+  DefaultModelRetryStrategy,
+  ModelError,
+  MaxTokensError,
+  ContextWindowOverflowError,
+  type DefaultModelRetryStrategyOptions,
+} from '@strands-agents/sdk';
+
+/**
+ * The exact message thrown by the SDK base `Model.streamAggregated()` when the
+ * stream ends without a `messageStop`. This literal is the only stable
+ * discriminator — there is no dedicated error subclass — so the match is
+ * deliberately anchored on it. Pinned to @strands-agents/sdk@1.2.x; if a future
+ * SDK reworks this string the predicate stops matching and we fail *closed*
+ * (revert to abort), never over-retry. The unit test on `isRetryable` is the
+ * tripwire for that upgrade.
+ */
+export const STREAM_INCOMPLETE_MESSAGE = 'Stream ended without completing a message';
+
+/**
+ * Retries the transient mid-stream truncation `ModelError` in addition to the
+ * SDK default (`ModelThrottledError`). Inherits the default bounded-attempts +
+ * exponential-backoff machinery; only the retryable-classification is widened.
+ *
+ * `isRetryable` is intentionally `public` (the base declares it `protected`) so
+ * the predicate can be unit-tested directly without driving a full agent loop.
+ */
+export class StreamTerminationRetryStrategy extends DefaultModelRetryStrategy {
+  override readonly name = 'moca:stream-termination-retry-strategy';
+
+  /**
+   * Default to 3 total attempts (SDK default is 6). A transient truncation that
+   * survives two re-issues is unlikely to be transient, and bounding attempts
+   * caps token/latency cost on a genuinely stuck stream.
+   */
+  constructor(opts: DefaultModelRetryStrategyOptions = {}) {
+    super({ maxAttempts: 3, ...opts });
+  }
+
+  override isRetryable(error: Error): boolean {
+    // Preserve the inherited throttle-retry behavior.
+    if (super.isRetryable(error)) {
+      return true;
+    }
+
+    // Never retry deterministic, non-transient model errors. These are all
+    // `ModelError` subclasses, so they must be excluded BEFORE the base-class
+    // check below — retrying them would just burn tokens and loop:
+    //   - MaxTokensError: output hit the token ceiling; needs intervention.
+    //   - ContextWindowOverflowError: input too large; needs trimming.
+    if (error instanceof MaxTokensError || error instanceof ContextWindowOverflowError) {
+      return false;
+    }
+
+    // Match ONLY the base-class transient truncation. The `constructor` check
+    // excludes any other ModelError subclass, and the exact-message check
+    // excludes a base ModelError that merely *wraps* a deterministic failure
+    // (model.js wraps non-ModelError stream errors — e.g. a JSON.parse
+    // SyntaxError — as a base ModelError carrying the original message).
+    return (
+      error instanceof ModelError &&
+      error.constructor === ModelError &&
+      error.message === STREAM_INCOMPLETE_MESSAGE
+    );
+  }
+}

--- a/packages/agent/src/types/agent-types.ts
+++ b/packages/agent/src/types/agent-types.ts
@@ -8,6 +8,9 @@
 import type { Agent, Plugin } from '@strands-agents/sdk';
 import type { IdentityId } from '@moca/core';
 import type { SessionStorage, SessionConfig } from './session-types.js';
+// Type-only import: no runtime dependency on the runtime/ layer, so this does
+// not introduce a layering violation or import cycle.
+import type { StreamTerminationRetryStrategy } from '../runtime/agent/stream-termination-retry-strategy.js';
 
 /**
  * Strands Agent creation options for AgentCore Runtime.
@@ -47,6 +50,14 @@ export interface CreateAgentOptions {
 export interface CreateAgentResult {
   agent: Agent;
   metadata: AgentMetadata;
+  /**
+   * The retry strategy instance wired into this agent. Exposed so the stream
+   * handler can read `retryStrategy.retryCount` after a turn completes and
+   * emit `stream_retry_recovered` when a transient mid-stream truncation was
+   * successfully retried. A fresh instance is created per agent, so the count
+   * is scoped to this turn.
+   */
+  retryStrategy: StreamTerminationRetryStrategy;
 }
 
 /**


### PR DESCRIPTION
Add `StreamTerminationRetryStrategy` to recover from transient `ModelError("Stream ended without completing a message")` failures that occur when Bedrock's ConverseStream closes the event stream before delivering a `messageStop` chunk.

Previously these errors propagated through the SDK's default retry strategy (which only retries throttling) and aborted the turn. The new strategy retries this specific transient error with backoff while leaving other model errors (MaxTokens, ContextWindowOverflow, etc.) untouched. A fresh instance is created per agent since the strategy holds per-turn backoff state.

Includes deterministic offline tests using a hand-rolled FakeModel that drives the real SDK retry loop.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
