### PR TITLE
feat: add Qwen3 model support (Coder Next, In-Region) with region pin, empty-text-block fix, and toolResult rehydration

### DIFF
--- a/packages/agent/jest.integration.config.js
+++ b/packages/agent/jest.integration.config.js
@@ -5,8 +5,10 @@ export default {
   extensionsToTreatAsEsm: ['.ts'],
   moduleNameMapper: { '^(\\.{1,2}/.*)\\.js$': '$1' },
   transform: { '^.+\\.tsx?$': ['ts-jest', { useESM: true }] },
-  testMatch: ['**/tests/developer-auth-identity.integration.test.ts'],
+  testMatch: [
+    '**/tests/developer-auth-identity.integration.test.ts',
+    '**/__tests__/qwen3-model.integration.test.ts',
+  ],
   testPathIgnorePatterns: ['/node_modules/'],
   testTimeout: 60000,
-  globalSetup: './jest.integration.setup.js',
 };

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -33,6 +33,7 @@ import { buildToolSet } from './runtime/agent/tools-builder.js';
 import { extractMemoryParams, fetchLongTermMemories } from './runtime/agent/memory-fetcher.js';
 import { loadSessionHistory } from './runtime/agent/session-loader.js';
 import { StreamTerminationRetryStrategy } from './runtime/agent/stream-termination-retry-strategy.js';
+import { EmptyTextBlockHook } from './services/session/empty-text-block-hook.js';
 
 import type { CreateAgentOptions, CreateAgentResult } from './runtime/agent/types.js';
 
@@ -112,7 +113,11 @@ export async function createAgent(options?: CreateAgentOptions): Promise<CreateA
     systemPrompt,
     tools: [...toolSet.tools, ...toolSet.mcpClients],
     messages: savedMessages,
-    plugins: options?.plugins,
+    // EmptyTextBlockHook is registered first so it sanitizes assistant messages
+    // (stripping the empty leading TextBlock that Qwen3 emits before a toolUse)
+    // before any caller-supplied plugin observes them. Harmless no-op for models
+    // that don't emit empty blocks (e.g. Claude). See empty-text-block-hook.ts.
+    plugins: [new EmptyTextBlockHook(), ...(options?.plugins ?? [])],
     conversationManager,
     id: options?.agentId,
     traceAttributes,

--- a/packages/agent/src/config/__tests__/bedrock.test.ts
+++ b/packages/agent/src/config/__tests__/bedrock.test.ts
@@ -1,0 +1,68 @@
+/**
+ * createBedrockModel() unit tests — region & maxTokens resolution.
+ *
+ * These verify the region-resolution order without touching AWS:
+ *   1. explicit options.region
+ *   2. the model's region pin from @moca/core (getModelRegion)
+ *   3. config.BEDROCK_REGION (deployment default)
+ *
+ * The Strands SDK BedrockModel constructor is mocked to capture its options,
+ * and ./index.js is mocked to supply a deterministic config.
+ */
+
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+// Capture the options passed to the (mocked) BedrockModel constructor.
+const constructorCalls: Array<Record<string, unknown>> = [];
+
+jest.unstable_mockModule('@strands-agents/sdk', () => ({
+  BedrockModel: class {
+    constructor(opts: Record<string, unknown>) {
+      constructorCalls.push(opts);
+    }
+  },
+}));
+
+jest.unstable_mockModule('../index.js', () => ({
+  config: {
+    BEDROCK_MODEL_ID: 'global.anthropic.claude-sonnet-4-6',
+    BEDROCK_REGION: 'ap-northeast-1',
+    ENABLE_PROMPT_CACHING: false,
+  },
+}));
+
+jest.unstable_mockModule('../../libs/logger/index.js', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const { createBedrockModel } = await import('../bedrock.js');
+
+beforeEach(() => {
+  constructorCalls.length = 0;
+});
+
+describe('createBedrockModel region resolution', () => {
+  it('uses the deployment BEDROCK_REGION for a model with no region pin', () => {
+    createBedrockModel({ modelId: 'global.anthropic.claude-sonnet-4-6' });
+    expect(constructorCalls).toHaveLength(1);
+    expect(constructorCalls[0].region).toBe('ap-northeast-1');
+  });
+
+  it('uses the model region pin when set, overriding BEDROCK_REGION', () => {
+    // qwen.qwen3-coder-next is pinned to us-east-1 in @moca/core because it is
+    // not rolled out to the default deployment region (ap-northeast-1).
+    createBedrockModel({ modelId: 'qwen.qwen3-coder-next' });
+    expect(constructorCalls[0].region).toBe('us-east-1');
+    expect(constructorCalls[0].modelId).toBe('qwen.qwen3-coder-next');
+  });
+
+  it('lets an explicit options.region win over the model pin', () => {
+    createBedrockModel({ modelId: 'qwen.qwen3-coder-next', region: 'us-west-2' });
+    expect(constructorCalls[0].region).toBe('us-west-2');
+  });
+
+  it('derives maxTokens from the model registry', () => {
+    createBedrockModel({ modelId: 'qwen.qwen3-coder-next' });
+    expect(constructorCalls[0].maxTokens).toBe(16384);
+  });
+});

--- a/packages/agent/src/config/bedrock.ts
+++ b/packages/agent/src/config/bedrock.ts
@@ -1,5 +1,5 @@
 import { BedrockModel } from '@strands-agents/sdk';
-import { getMaxOutputTokens } from '@moca/core';
+import { getMaxOutputTokens, getModelRegion } from '@moca/core';
 import { config } from './index.js';
 import { logger } from '../libs/logger/index.js';
 
@@ -38,7 +38,12 @@ export interface BedrockModelOptions {
  */
 export function createBedrockModel(options?: BedrockModelOptions): BedrockModel {
   const modelId = options?.modelId || config.BEDROCK_MODEL_ID;
-  const region = options?.region || config.BEDROCK_REGION;
+  // Region resolution order:
+  //   1. explicit options.region (caller override)
+  //   2. the model's own region pin from @moca/core (for In-Region-only models
+  //      not yet rolled out to the deployment region, e.g. qwen.qwen3-coder-next)
+  //   3. the deployment's BEDROCK_REGION (default for almost every model)
+  const region = options?.region || getModelRegion(modelId) || config.BEDROCK_REGION;
 
   logger.debug(
     {

--- a/packages/agent/src/config/bedrock.ts
+++ b/packages/agent/src/config/bedrock.ts
@@ -28,8 +28,9 @@ export interface BedrockModelOptions {
  * is true. The SDK's `'auto'` strategy resolves to its internal Anthropic
  * pattern list (`anthropic` / `claude` substring match) — Anthropic models
  * get cache points injected into `tools[]` and the last user message; other
- * providers (e.g. Nova) get nothing, which is the desired behaviour because
- * Nova rejects `cachePoint` in `tools[]`.
+ * providers (e.g. Nova, Qwen3) get nothing, which is the desired behaviour:
+ * Bedrock prompt caching is not supported for those families and they reject
+ * (or ignore) `cachePoint` blocks, so the `auto` strategy safely no-ops.
  *
  * Note: the SDK's auto strategy does NOT inject a cachePoint into the
  * `system[]` array — only into `tools[]` and `messages[]`. Long system

--- a/packages/agent/src/libs/codec/content-block-codec.ts
+++ b/packages/agent/src/libs/codec/content-block-codec.ts
@@ -32,6 +32,7 @@ import {
   ToolUseBlock,
   ToolResultBlock,
   ImageBlock,
+  toolResultContentFromData,
   type ContentBlock,
   type ToolResultContent,
 } from '@strands-agents/sdk';
@@ -141,6 +142,46 @@ export function contentBlockToWire(block: ContentBlock): WireContentBlock {
 // ---------------------------------------------------------------------------
 
 /**
+ * Rehydrate the persisted `ToolResultBlock.content` (a plain-JSON projection)
+ * into SDK `ToolResultContent` instances.
+ *
+ * The wire shape uses the Bedrock-native key form (`{ text }`, `{ json }`,
+ * `{ image }`, …) which `toolResultContentFromData` understands. Anything
+ * unrecognised is downgraded to a `TextBlock` so a single malformed entry can
+ * never produce a `ToolResultBlock` with empty/invalid inner content (Bedrock
+ * rejects a `toolResult` whose `content` is missing or empty).
+ */
+function restoreToolResultContent(rawContent: unknown): ToolResultContent[] {
+  const entries = Array.isArray(rawContent) ? rawContent : [];
+  const restored: ToolResultContent[] = [];
+
+  for (const entry of entries) {
+    try {
+      restored.push(toolResultContentFromData(entry as never));
+    } catch {
+      // Unknown / legacy shape — fall back to a stringified text block so the
+      // result still carries content rather than dropping out entirely.
+      const text =
+        entry && typeof entry === 'object' && 'text' in entry
+          ? String((entry as { text: unknown }).text)
+          : JSON.stringify(entry);
+      restored.push(new TextBlock(text) as unknown as ToolResultContent);
+      logger.warn(
+        { entry },
+        'restoreToolResultContent: unrecognised toolResult content entry, coerced to TextBlock'
+      );
+    }
+  }
+
+  // Never return an empty array — Bedrock rejects a toolResult with no content.
+  if (restored.length === 0) {
+    restored.push(new TextBlock(' ') as unknown as ToolResultContent);
+  }
+
+  return restored;
+}
+
+/**
  * Restore a wire block back into a SDK `ContentBlock` instance suitable
  * for passing into `new Agent({ messages })`.
  *
@@ -168,8 +209,19 @@ export function wireToContentBlock(wire: WireContentBlock): ContentBlock {
       return new ToolResultBlock({
         toolUseId: wire.toolUseId,
         status: wire.status,
-        // We saved a JSONValue projection; cast back to `ToolResultContent[]`.
-        content: wire.content as unknown as ToolResultContent[],
+        // The inner content was persisted as a plain-JSON projection. It MUST be
+        // rehydrated into SDK content-block instances (TextBlock/JsonBlock/…) via
+        // `toolResultContentFromData` — `new ToolResultBlock` assigns `content`
+        // verbatim without normalising it. If left as plain objects, the blocks
+        // lack both a `.type` discriminator and a `.toJSON()` method, which breaks
+        // two downstream paths on the NEXT turn (when this restored message is
+        // re-sent):
+        //   1. BedrockModel._formatContentBlock switches on `content.type`; plain
+        //      objects match no case, the inner content becomes empty, and Bedrock
+        //      rejects the request with "Invalid 'messages': missing field `content`".
+        //   2. Message.toJSON()/telemetry call `block.toJSON()`, throwing
+        //      "block.toJSON is not a function".
+        content: restoreToolResultContent(wire.content),
       });
 
     case 'imageBlock': {

--- a/packages/agent/src/services/session/__tests__/converters.test.ts
+++ b/packages/agent/src/services/session/__tests__/converters.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from '@jest/globals';
-import { Message, TextBlock, ImageBlock } from '@strands-agents/sdk';
+import { Message, TextBlock, ImageBlock, ToolUseBlock, ToolResultBlock } from '@strands-agents/sdk';
 import {
   messageToAgentCorePayload,
   agentCorePayloadToMessage,
@@ -406,6 +406,69 @@ describe('agentCorePayloadToMessage', () => {
       expect(restoredBlock.format).toBe('jpeg');
       const restoredSource = restoredBlock.source as { bytes?: Uint8Array };
       expect(Array.from(restoredSource.bytes!)).toEqual([255, 216, 255, 224]);
+    });
+
+    // Regression: a toolResult message must restore with its INNER content as
+    // SDK content-block instances (not plain objects). Otherwise, on the next
+    // turn the restored history breaks both BedrockModel._formatContentBlock
+    // (which switches on `content.type` → empty content → Bedrock
+    // "missing field `content`") and Message.toJSON() (`block.toJSON is not a
+    // function`). See content-block-codec.ts:restoreToolResultContent.
+    it('toolResult message roundtrips with inner content as SDK instances', () => {
+      const original = new Message({
+        role: 'user',
+        content: [
+          new ToolResultBlock({
+            toolUseId: 'tool-123',
+            status: 'success',
+            content: [new TextBlock('a.txt b.txt')],
+          }),
+        ],
+      });
+
+      const payload = messageToAgentCorePayload(original);
+      const restored = agentCorePayloadToMessage(payload);
+
+      const block = restored.content[0] as ToolResultBlock;
+      expect(block.type).toBe('toolResultBlock');
+      expect(block.toolUseId).toBe('tool-123');
+      expect(block.status).toBe('success');
+
+      // Inner content must be a real TextBlock instance (has `type` + `toJSON`).
+      const inner = block.content[0] as TextBlock;
+      expect(inner.type).toBe('textBlock');
+      expect(inner.text).toBe('a.txt b.txt');
+      expect(typeof (inner as unknown as { toJSON?: unknown }).toJSON).toBe('function');
+
+      // The whole message must serialize without throwing (this is exactly what
+      // the SDK telemetry / Bedrock request path does on the next turn).
+      expect(() => restored.toJSON()).not.toThrow();
+      const json = restored.toJSON() as { content: Array<{ toolResult?: { content: unknown[] } }> };
+      // The Bedrock-native projection must carry the inner content (not empty).
+      expect(json.content[0].toolResult?.content).toHaveLength(1);
+    });
+
+    it('assistant toolUse + following toolResult turn roundtrips and re-serializes', () => {
+      // Mirrors a real tool-calling turn pair as stored/replayed across requests.
+      const assistant = new Message({
+        role: 'assistant',
+        content: [new ToolUseBlock({ name: 's3_list_files', toolUseId: 't1', input: { path: '/' } })],
+      });
+      const toolResult = new Message({
+        role: 'user',
+        content: [
+          new ToolResultBlock({
+            toolUseId: 't1',
+            status: 'success',
+            content: [new TextBlock('100 files')],
+          }),
+        ],
+      });
+
+      for (const original of [assistant, toolResult]) {
+        const restored = agentCorePayloadToMessage(messageToAgentCorePayload(original));
+        expect(() => restored.toJSON()).not.toThrow();
+      }
     });
   });
 });

--- a/packages/agent/src/services/session/__tests__/empty-text-block-hook.test.ts
+++ b/packages/agent/src/services/session/__tests__/empty-text-block-hook.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Unit tests for EmptyTextBlockHook.
+ *
+ * Reproduces the Qwen3 failure mode: an assistant message whose first content
+ * block is an empty TextBlock emitted before a toolUse block. The follow-up
+ * Bedrock request rejects the blank text field, so the hook must strip it.
+ */
+
+import { describe, it, expect, jest } from '@jest/globals';
+import {
+  Message,
+  TextBlock,
+  ToolUseBlock,
+  MessageAddedEvent,
+  type LocalAgent,
+  type HookableEvent,
+} from '@strands-agents/sdk';
+import { EmptyTextBlockHook } from '../empty-text-block-hook.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type Handler = (event: HookableEvent) => void;
+
+/**
+ * Register the hook against a minimal fake agent and return the captured
+ * MessageAddedEvent callback so tests can drive it directly.
+ */
+function captureHandler(hook: EmptyTextBlockHook): Handler {
+  let handler: Handler | undefined;
+  const fakeAgent = {
+    addHook: (_eventType: unknown, callback: Handler) => {
+      handler = callback;
+      return () => {};
+    },
+  } as unknown as LocalAgent;
+
+  hook.initAgent(fakeAgent);
+  if (!handler) {
+    throw new Error('Hook did not register a MessageAddedEvent callback');
+  }
+  return handler;
+}
+
+function fire(handler: Handler, message: Message): void {
+  handler(
+    new MessageAddedEvent({
+      // The hook only reads `event.message`; agent/invocationState are unused.
+      agent: {} as unknown as LocalAgent,
+      message,
+      invocationState: {} as never,
+    })
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('EmptyTextBlockHook', () => {
+  it('strips a leading empty TextBlock that precedes a toolUse block (Qwen3 case)', () => {
+    const handler = captureHandler(new EmptyTextBlockHook());
+    const toolUse = new ToolUseBlock({ name: 'list_files', toolUseId: 'tu_1', input: { path: '.' } });
+    const message = new Message({ role: 'assistant', content: [new TextBlock(''), toolUse] });
+
+    fire(handler, message);
+
+    expect(message.content).toHaveLength(1);
+    expect(message.content[0]).toBe(toolUse);
+  });
+
+  it('also strips whitespace-only TextBlocks', () => {
+    const handler = captureHandler(new EmptyTextBlockHook());
+    const toolUse = new ToolUseBlock({ name: 't', toolUseId: 'tu_2', input: {} });
+    const message = new Message({ role: 'assistant', content: [new TextBlock('   \n'), toolUse] });
+
+    fire(handler, message);
+
+    expect(message.content).toHaveLength(1);
+    expect(message.content[0]).toBe(toolUse);
+  });
+
+  it('preserves non-empty TextBlocks', () => {
+    const handler = captureHandler(new EmptyTextBlockHook());
+    const text = new TextBlock('Here are your files:');
+    const toolUse = new ToolUseBlock({ name: 't', toolUseId: 'tu_3', input: {} });
+    const message = new Message({ role: 'assistant', content: [text, toolUse] });
+
+    fire(handler, message);
+
+    expect(message.content).toHaveLength(2);
+    expect(message.content[0]).toBe(text);
+  });
+
+  it('does not empty out a message made up solely of empty TextBlocks', () => {
+    const handler = captureHandler(new EmptyTextBlockHook());
+    const message = new Message({ role: 'assistant', content: [new TextBlock(''), new TextBlock('')] });
+
+    fire(handler, message);
+
+    // Never produce empty `content` — Bedrock rejects that too.
+    expect(message.content.length).toBeGreaterThan(0);
+  });
+
+  it('ignores user messages', () => {
+    const handler = captureHandler(new EmptyTextBlockHook());
+    const message = new Message({ role: 'user', content: [new TextBlock('')] });
+
+    fire(handler, message);
+
+    expect(message.content).toHaveLength(1);
+  });
+
+  it('is a no-op for a normal assistant text message (Claude case)', () => {
+    const handler = captureHandler(new EmptyTextBlockHook());
+    const text = new TextBlock('All done.');
+    const message = new Message({ role: 'assistant', content: [text] });
+
+    fire(handler, message);
+
+    expect(message.content).toHaveLength(1);
+    expect(message.content[0]).toBe(text);
+  });
+
+  it('registers a callback during initAgent', () => {
+    const hook = new EmptyTextBlockHook();
+    const addHook = jest.fn(() => () => {});
+    hook.initAgent({ addHook } as unknown as LocalAgent);
+    expect(addHook).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/agent/src/services/session/__tests__/qwen3-model.integration.test.ts
+++ b/packages/agent/src/services/session/__tests__/qwen3-model.integration.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Qwen3 Model Integration Tests
+ *
+ * Verifies that the agent actually works end-to-end against Bedrock when
+ * configured with an In-Region-only Qwen3 model. These call the real
+ * Bedrock Converse / ConverseStream API, so they require:
+ *   - AWS credentials with `bedrock:InvokeModel` on the Qwen3 foundation models
+ *   - Qwen3 enabled in BEDROCK_REGION (Qwen3 has NO cross-region inference
+ *     profile, so it must be available In-Region; default us-east-1)
+ *
+ * The suite is OPT-IN: set RUN_BEDROCK_QWEN_INTEGRATION=1 to run it. Without
+ * the flag it is skipped (so CI / restricted roles do not fail).
+ *
+ * Run:
+ *   cd packages/agent
+ *   RUN_BEDROCK_QWEN_INTEGRATION=1 BEDROCK_REGION=us-east-1 \
+ *     npm run test:integration -- qwen3-model
+ *
+ * Verified model IDs (ACTIVE on Bedrock, 2026-05; no "instruct" token):
+ *   - qwen.qwen3-235b-a22b-2507-v1:0
+ *   - qwen.qwen3-coder-480b-a35b-v1:0
+ */
+
+import { it, expect } from '@jest/globals';
+import { z } from 'zod';
+import { Agent, SlidingWindowConversationManager, tool } from '@strands-agents/sdk';
+import { createBedrockModel } from '../../../config/bedrock.js';
+import { describeIfEnv } from '../../../tests/integration-helpers.js';
+
+const QWEN3_235B = 'qwen.qwen3-235b-a22b-2507-v1:0';
+const QWEN3_CODER_480B = 'qwen.qwen3-coder-480b-a35b-v1:0';
+
+const describeQwen3 = describeIfEnv(['RUN_BEDROCK_QWEN_INTEGRATION'], 'Qwen3 Bedrock integration');
+
+/** Extract text from a message's content blocks. */
+function textOf(message: { content: unknown[] }): string {
+  return message.content
+    .filter((b) => (b as { type: string }).type === 'textBlock')
+    .map((b) => (b as { text?: string }).text || '')
+    .join('');
+}
+
+/** Drive the agent via streaming and collect all emitted events. */
+async function streamAll(agent: Agent, prompt: string): Promise<unknown[]> {
+  const events: unknown[] = [];
+  for await (const event of agent.stream(prompt)) {
+    events.push(event);
+  }
+  return events;
+}
+
+describeQwen3('Qwen3 235B A22B (qwen.qwen3-235b-a22b-2507-v1:0)', () => {
+  it('follows the system prompt (PING -> PONG)', async () => {
+    const agent = new Agent({
+      model: createBedrockModel({ modelId: QWEN3_235B }),
+      systemPrompt:
+        'Always respond with exactly the word "PONG" when the user says "PING". No other text.',
+      tools: [],
+      conversationManager: new SlidingWindowConversationManager({ windowSize: 20 }),
+    });
+
+    await streamAll(agent, 'PING');
+
+    expect(textOf(agent.messages[agent.messages.length - 1]).toUpperCase()).toContain('PONG');
+  }, 90_000);
+
+  it('streams events and answers a factual question', async () => {
+    const agent = new Agent({
+      model: createBedrockModel({ modelId: QWEN3_235B }),
+      systemPrompt: 'Be very brief.',
+      tools: [],
+      conversationManager: new SlidingWindowConversationManager({ windowSize: 20 }),
+    });
+
+    const events = await streamAll(agent, 'What is the capital of Japan? One word.');
+
+    expect(events.length).toBeGreaterThan(0);
+    expect(agent.messages).toHaveLength(2);
+    expect(agent.messages[0].role).toBe('user');
+    expect(agent.messages[1].role).toBe('assistant');
+    expect(textOf(agent.messages[1]).toLowerCase()).toContain('tokyo');
+  }, 90_000);
+
+  it('remembers context across turns', async () => {
+    const agent = new Agent({
+      model: createBedrockModel({ modelId: QWEN3_235B }),
+      systemPrompt: 'Be very brief.',
+      tools: [],
+      conversationManager: new SlidingWindowConversationManager({ windowSize: 20 }),
+    });
+
+    await streamAll(agent, 'My name is Alice.');
+    await streamAll(agent, 'What is my name?');
+
+    expect(agent.messages).toHaveLength(4);
+    expect(textOf(agent.messages[3]).toLowerCase()).toContain('alice');
+  }, 120_000);
+
+  it('invokes a tool and uses its result (agentic tool use)', async () => {
+    let called = 0;
+    const getWeather = tool({
+      name: 'get_weather',
+      description: 'Get the current weather for a city. Always call this for weather questions.',
+      inputSchema: z.object({ city: z.string().describe('City name') }),
+      callback: async ({ city }) => {
+        called += 1;
+        return `The weather in ${city} is 7 degrees Celsius and snowing.`;
+      },
+    });
+
+    const agent = new Agent({
+      model: createBedrockModel({ modelId: QWEN3_235B }),
+      systemPrompt:
+        'You are a weather assistant. Use the get_weather tool to answer weather questions, then report the result.',
+      tools: [getWeather],
+      conversationManager: new SlidingWindowConversationManager({ windowSize: 20 }),
+    });
+
+    await streamAll(agent, 'What is the weather in Sapporo right now?');
+
+    // The model must have actually invoked the tool...
+    expect(called).toBeGreaterThanOrEqual(1);
+    // ...and incorporated the tool result into its final answer.
+    const finalText = textOf(agent.messages[agent.messages.length - 1]).toLowerCase();
+    expect(finalText).toMatch(/snow|7|seven/);
+  }, 120_000);
+});
+
+describeQwen3('Qwen3 Coder 480B A35B (qwen.qwen3-coder-480b-a35b-v1:0)', () => {
+  it('produces a working code snippet', async () => {
+    const agent = new Agent({
+      model: createBedrockModel({ modelId: QWEN3_CODER_480B }),
+      systemPrompt: 'You are a coding assistant. Output only code, no prose.',
+      tools: [],
+      conversationManager: new SlidingWindowConversationManager({ windowSize: 20 }),
+    });
+
+    await streamAll(
+      agent,
+      'Write a Python one-liner function add(a, b) that returns their sum. Just the function.'
+    );
+
+    const answer = textOf(agent.messages[1]);
+    expect(answer).toMatch(/def\s+add\s*\(/);
+  }, 120_000);
+});

--- a/packages/agent/src/services/session/__tests__/qwen3-model.integration.test.ts
+++ b/packages/agent/src/services/session/__tests__/qwen3-model.integration.test.ts
@@ -19,6 +19,7 @@
  * Verified model IDs (ACTIVE on Bedrock, 2026-05; no "instruct" token):
  *   - qwen.qwen3-235b-a22b-2507-v1:0
  *   - qwen.qwen3-coder-480b-a35b-v1:0
+ *   - qwen.qwen3-coder-next            (bare id, NO -v1:0 suffix; In-Region only)
  */
 
 import { it, expect } from '@jest/globals';
@@ -30,6 +31,8 @@ import { describeIfEnv } from '../../../tests/integration-helpers.js';
 
 const QWEN3_235B = 'qwen.qwen3-235b-a22b-2507-v1:0';
 const QWEN3_CODER_480B = 'qwen.qwen3-coder-480b-a35b-v1:0';
+// Newest Qwen3 on Bedrock (launched 2026-02). NOTE: bare id, no -v1:0 suffix.
+const QWEN3_CODER_NEXT = 'qwen.qwen3-coder-next';
 
 const describeQwen3 = describeIfEnv(['RUN_BEDROCK_QWEN_INTEGRATION'], 'Qwen3 Bedrock integration');
 
@@ -193,5 +196,60 @@ describeQwen3('Qwen3 Coder 480B A35B (qwen.qwen3-coder-480b-a35b-v1:0)', () => {
 
     const answer = textOf(agent.messages[1]);
     expect(answer).toMatch(/def\s+add\s*\(/);
+  }, 120_000);
+});
+
+describeQwen3('Qwen3 Coder Next (qwen.qwen3-coder-next)', () => {
+  it('streams events and answers a factual question', async () => {
+    const agent = new Agent({
+      model: createBedrockModel({ modelId: QWEN3_CODER_NEXT }),
+      systemPrompt: 'Be very brief.',
+      tools: [],
+      conversationManager: new SlidingWindowConversationManager({ windowSize: 20 }),
+    });
+
+    const events = await streamAll(agent, 'What is the capital of Japan? One word.');
+
+    expect(events.length).toBeGreaterThan(0);
+    expect(agent.messages).toHaveLength(2);
+    expect(textOf(agent.messages[1]).toLowerCase()).toContain('tokyo');
+  }, 90_000);
+
+  it('completes a tool round-trip with EmptyTextBlockHook (regression: blank ContentBlock)', async () => {
+    // Same Qwen3 failure mode as the 235B suite: an empty leading TextBlock
+    // before the toolUse block would break the post-tool follow-up request
+    // unless EmptyTextBlockHook strips it. Mirrors production wiring in agent.ts.
+    let called = 0;
+    const getWeather = tool({
+      name: 'get_weather',
+      description: 'Get the current weather for a city. Always call this for weather questions.',
+      inputSchema: z.object({ city: z.string().describe('City name') }),
+      callback: async ({ city }) => {
+        called += 1;
+        return `The weather in ${city} is 7 degrees Celsius and snowing.`;
+      },
+    });
+
+    const agent = new Agent({
+      model: createBedrockModel({ modelId: QWEN3_CODER_NEXT }),
+      systemPrompt:
+        'You are a weather assistant. Use the get_weather tool to answer weather questions, then report the result.',
+      tools: [getWeather],
+      plugins: [new EmptyTextBlockHook()],
+      conversationManager: new SlidingWindowConversationManager({ windowSize: 20 }),
+    });
+
+    await streamAll(agent, 'What is the weather in Sapporo right now?');
+
+    expect(called).toBeGreaterThanOrEqual(1);
+    const finalText = textOf(agent.messages[agent.messages.length - 1]).toLowerCase();
+    expect(finalText).toMatch(/snow|7|seven/);
+
+    const emptyBlocks = agent.messages
+      .filter((m) => m.role === 'assistant')
+      .flatMap((m) => m.content)
+      .filter((b) => (b as { type: string }).type === 'textBlock')
+      .filter((b) => ((b as { text?: string }).text ?? '').trim() === '');
+    expect(emptyBlocks).toHaveLength(0);
   }, 120_000);
 });

--- a/packages/agent/src/services/session/__tests__/qwen3-model.integration.test.ts
+++ b/packages/agent/src/services/session/__tests__/qwen3-model.integration.test.ts
@@ -25,6 +25,7 @@ import { it, expect } from '@jest/globals';
 import { z } from 'zod';
 import { Agent, SlidingWindowConversationManager, tool } from '@strands-agents/sdk';
 import { createBedrockModel } from '../../../config/bedrock.js';
+import { EmptyTextBlockHook } from '../empty-text-block-hook.js';
 import { describeIfEnv } from '../../../tests/integration-helpers.js';
 
 const QWEN3_235B = 'qwen.qwen3-235b-a22b-2507-v1:0';
@@ -113,6 +114,10 @@ describeQwen3('Qwen3 235B A22B (qwen.qwen3-235b-a22b-2507-v1:0)', () => {
       systemPrompt:
         'You are a weather assistant. Use the get_weather tool to answer weather questions, then report the result.',
       tools: [getWeather],
+      // Mirror production wiring (agent.ts always registers this hook). Without
+      // it, Qwen3's empty leading TextBlock makes the post-tool follow-up
+      // request fail with a blank-ContentBlock ValidationException.
+      plugins: [new EmptyTextBlockHook()],
       conversationManager: new SlidingWindowConversationManager({ windowSize: 20 }),
     });
 
@@ -123,6 +128,52 @@ describeQwen3('Qwen3 235B A22B (qwen.qwen3-235b-a22b-2507-v1:0)', () => {
     // ...and incorporated the tool result into its final answer.
     const finalText = textOf(agent.messages[agent.messages.length - 1]).toLowerCase();
     expect(finalText).toMatch(/snow|7|seven/);
+  }, 120_000);
+
+  it('completes a tool round-trip with EmptyTextBlockHook (regression: blank ContentBlock)', async () => {
+    // Regression for the Qwen3 failure mode: Qwen emits an empty leading
+    // TextBlock before a toolUse block, so the assistant turn becomes
+    // [{ text: '' }, { toolUse }]. The FOLLOW-UP request (after the tool
+    // result is appended) used to fail with:
+    //   ValidationException: The text field in the ContentBlock object at
+    //   messages.1.content.0 is blank.
+    // EmptyTextBlockHook strips the blank block so the round-trip completes.
+    // This mirrors the production wiring in agent.ts (hook always registered).
+    let called = 0;
+    const getWeather = tool({
+      name: 'get_weather',
+      description: 'Get the current weather for a city. Always call this for weather questions.',
+      inputSchema: z.object({ city: z.string().describe('City name') }),
+      callback: async ({ city }) => {
+        called += 1;
+        return `The weather in ${city} is 7 degrees Celsius and snowing.`;
+      },
+    });
+
+    const agent = new Agent({
+      model: createBedrockModel({ modelId: QWEN3_235B }),
+      systemPrompt:
+        'You are a weather assistant. Use the get_weather tool to answer weather questions, then report the result.',
+      tools: [getWeather],
+      plugins: [new EmptyTextBlockHook()],
+      conversationManager: new SlidingWindowConversationManager({ windowSize: 20 }),
+    });
+
+    // Reaching a final answer proves the post-tool follow-up request was
+    // accepted by Bedrock (i.e. no blank ContentBlock was sent back).
+    await streamAll(agent, 'What is the weather in Sapporo right now?');
+
+    expect(called).toBeGreaterThanOrEqual(1);
+    const finalText = textOf(agent.messages[agent.messages.length - 1]).toLowerCase();
+    expect(finalText).toMatch(/snow|7|seven/);
+
+    // No assistant message should carry an empty TextBlock after the hook ran.
+    const emptyBlocks = agent.messages
+      .filter((m) => m.role === 'assistant')
+      .flatMap((m) => m.content)
+      .filter((b) => (b as { type: string }).type === 'textBlock')
+      .filter((b) => ((b as { text?: string }).text ?? '').trim() === '');
+    expect(emptyBlocks).toHaveLength(0);
   }, 120_000);
 });
 

--- a/packages/agent/src/services/session/empty-text-block-hook.ts
+++ b/packages/agent/src/services/session/empty-text-block-hook.ts
@@ -1,0 +1,90 @@
+/**
+ * Empty Text Block Hook
+ *
+ * Strips empty (whitespace-only) TextBlocks from assistant messages before they
+ * re-enter the conversation history.
+ *
+ * Why this is needed:
+ * Some Bedrock models — notably Qwen3 — emit a leading EMPTY text content block
+ * immediately before a `toolUse` block in their stream:
+ *
+ *   messageStart(assistant)
+ *   contentBlockStop(0)            // text block, but NO textDelta ever arrived → text === ''
+ *   contentBlockStart(1, toolUse)
+ *   contentBlockStop(1)
+ *
+ * The Strands SDK assembles a stopped content block with no accumulated deltas as
+ * `new TextBlock('')` (see node_modules/@strands-agents/sdk/dist/src/models/model.js),
+ * so the assistant message becomes `content: [{ text: '' }, { toolUse }]`.
+ *
+ * The first request (sending only the toolUse turn) succeeds, but on the FOLLOW-UP
+ * request — after the tool result is appended and the whole turn is sent back —
+ * Bedrock validates the empty text field and rejects it:
+ *
+ *   ValidationException: The text field in the ContentBlock object at
+ *   messages.1.content.0 is blank. Add text to the text field, and try again.
+ *
+ * Anthropic (Claude) models do not emit these empty blocks, so this hook is a
+ * harmless no-op for them. It only removes a TextBlock when other content blocks
+ * remain, so an assistant message is never left with empty `content`.
+ */
+
+import { MessageAddedEvent } from '@strands-agents/sdk';
+import type { Plugin, LocalAgent, Message } from '@strands-agents/sdk';
+import { logger } from '../../libs/logger/index.js';
+
+/**
+ * Returns true for a TextBlock whose text is empty or whitespace-only.
+ */
+function isEmptyTextBlock(block: Message['content'][number]): boolean {
+  return block.type === 'textBlock' && block.text.trim() === '';
+}
+
+export class EmptyTextBlockHook implements Plugin {
+  readonly name = 'moca:empty-text-block-hook';
+
+  /**
+   * Register hook callbacks on the agent.
+   * Called by the Agent's PluginRegistry during construction.
+   */
+  initAgent(agent: LocalAgent): void {
+    agent.addHook(MessageAddedEvent, (event) => this.onMessageAdded(event));
+  }
+
+  /**
+   * Strip empty TextBlocks from assistant messages as they are added to history.
+   *
+   * Mutates `message.content` in place: the array reference is `readonly`, but
+   * its elements are not, so an in-place `splice` is the supported way to edit
+   * the assembled message before it is persisted / re-sent to the model.
+   */
+  private onMessageAdded(event: MessageAddedEvent): void {
+    const { message } = event;
+    if (message.role !== 'assistant') {
+      return;
+    }
+
+    const content = message.content;
+    // Only strip when at least one non-empty block remains, so we never produce
+    // an assistant message with empty `content`.
+    const hasOtherContent = content.some((block) => !isEmptyTextBlock(block));
+    if (!hasOtherContent) {
+      return;
+    }
+
+    let removed = 0;
+    for (let i = content.length - 1; i >= 0; i--) {
+      if (isEmptyTextBlock(content[i])) {
+        content.splice(i, 1);
+        removed++;
+      }
+    }
+
+    if (removed > 0) {
+      logger.debug(
+        { removed, remaining: content.length },
+        '[EMPTY_TEXT_BLOCK_HOOK] Stripped empty TextBlock(s) from assistant message'
+      );
+    }
+  }
+}

--- a/packages/cdk/config/environment-types.ts
+++ b/packages/cdk/config/environment-types.ts
@@ -16,7 +16,7 @@ export interface BedrockModelConfig {
   /**
    * Full model ID. Either a cross-region inference profile ID
    * (e.g. 'global.anthropic.claude-sonnet-4-6') or a bare, namespaced
-   * In-Region foundation-model ID (e.g. 'qwen.qwen3-235b-a22b-instruct-2507-v1:0').
+   * In-Region foundation-model ID (e.g. 'qwen.qwen3-235b-a22b-2507-v1:0').
    */
   id: string;
   /** Display name (e.g., 'Claude Sonnet 4.6') */

--- a/packages/cdk/config/environment-types.ts
+++ b/packages/cdk/config/environment-types.ts
@@ -13,12 +13,16 @@ export type Environment = 'default' | 'dev' | 'stg' | 'prd' | string; // Allow d
  * Bedrock model configuration for frontend model selector
  */
 export interface BedrockModelConfig {
-  /** Full model ID with inference profile prefix (e.g., 'jp.anthropic.claude-sonnet-4-6') */
+  /**
+   * Full model ID. Either a cross-region inference profile ID
+   * (e.g. 'global.anthropic.claude-sonnet-4-6') or a bare, namespaced
+   * In-Region foundation-model ID (e.g. 'qwen.qwen3-235b-a22b-instruct-2507-v1:0').
+   */
   id: string;
   /** Display name (e.g., 'Claude Sonnet 4.6') */
   name: string;
   /** Provider name */
-  provider: 'Anthropic' | 'Amazon';
+  provider: 'Anthropic' | 'Amazon' | 'Qwen';
 }
 
 /**

--- a/packages/cdk/config/environment-utils.test.ts
+++ b/packages/cdk/config/environment-utils.test.ts
@@ -96,7 +96,7 @@ describe('deriveBedrockIamResources', () => {
   it('skips the inference-profile ARN for a bare In-Region model id (Qwen3)', () => {
     const models = [
       {
-        id: 'qwen.qwen3-235b-a22b-instruct-2507-v1:0',
+        id: 'qwen.qwen3-235b-a22b-2507-v1:0',
         name: 'Qwen3 235B',
         provider: 'Qwen' as const,
       },
@@ -104,9 +104,7 @@ describe('deriveBedrockIamResources', () => {
     const result = deriveBedrockIamResources(models, REGION, ACCOUNT);
 
     // Only the foundation-model ARN is produced (no inference-profile ARN).
-    expect(result).toEqual([
-      'arn:aws:bedrock:*::foundation-model/qwen.qwen3-235b-a22b-instruct-2507-v1:0*',
-    ]);
+    expect(result).toEqual(['arn:aws:bedrock:*::foundation-model/qwen.qwen3-235b-a22b-2507-v1:0*']);
     expect(result.some((r) => r.includes('inference-profile'))).toBe(false);
   });
 

--- a/packages/cdk/config/environment-utils.test.ts
+++ b/packages/cdk/config/environment-utils.test.ts
@@ -91,6 +91,50 @@ describe('deriveBedrockIamResources', () => {
     expect(result).toContain('arn:aws:bedrock:*::foundation-model/anthropic.claude-3-sonnet*');
   });
 
+  // ── In-Region (no CRIS prefix) models, e.g. Qwen3 ──────────────────────────
+
+  it('skips the inference-profile ARN for a bare In-Region model id (Qwen3)', () => {
+    const models = [
+      {
+        id: 'qwen.qwen3-235b-a22b-instruct-2507-v1:0',
+        name: 'Qwen3 235B',
+        provider: 'Qwen' as const,
+      },
+    ];
+    const result = deriveBedrockIamResources(models, REGION, ACCOUNT);
+
+    // Only the foundation-model ARN is produced (no inference-profile ARN).
+    expect(result).toEqual([
+      'arn:aws:bedrock:*::foundation-model/qwen.qwen3-235b-a22b-instruct-2507-v1:0*',
+    ]);
+    expect(result.some((r) => r.includes('inference-profile'))).toBe(false);
+  });
+
+  it('still emits an inference-profile ARN for CRIS-prefixed models alongside bare ones', () => {
+    const models = [
+      {
+        id: 'global.anthropic.claude-sonnet-4-6',
+        name: 'Claude',
+        provider: 'Anthropic' as const,
+      },
+      {
+        id: 'qwen.qwen3-coder-480b-a35b-v1:0',
+        name: 'Qwen3 Coder',
+        provider: 'Qwen' as const,
+      },
+    ];
+    const result = deriveBedrockIamResources(models, REGION, ACCOUNT);
+
+    // Claude → 2 ARNs (inference-profile + foundation-model); Qwen3 → 1 (foundation-model only).
+    expect(result).toHaveLength(3);
+    expect(result).toContain(
+      `arn:aws:bedrock:${REGION}:${ACCOUNT}:inference-profile/global.anthropic.claude-sonnet-4-6`
+    );
+    expect(result).toContain(
+      'arn:aws:bedrock:*::foundation-model/qwen.qwen3-coder-480b-a35b-v1:0*'
+    );
+  });
+
   // ── Multiple models ─────────────────────────────────────────────────────────
 
   it('produces two ARNs (inference-profile + foundation-model) per model', () => {

--- a/packages/cdk/config/environment-utils.ts
+++ b/packages/cdk/config/environment-utils.ts
@@ -100,8 +100,8 @@ const DEFAULT_CONFIG = {
       provider: 'Amazon',
     },
     {
-      id: 'qwen.qwen3-235b-a22b-instruct-2507-v1:0',
-      name: 'Qwen3 235B A22B Instruct',
+      id: 'qwen.qwen3-235b-a22b-2507-v1:0',
+      name: 'Qwen3 235B A22B 2507',
       provider: 'Qwen',
     },
     {
@@ -118,7 +118,7 @@ const VALID_PROVIDERS: readonly string[] = ['Anthropic', 'Amazon', 'Qwen'];
  * A routable Bedrock model id must be namespaced: one or more `vendor.` segments
  * followed by a model name. This accepts both cross-region inference profile IDs
  * (e.g. `global.anthropic.claude-sonnet-4-6`) and bare In-Region foundation-model
- * IDs (e.g. `qwen.qwen3-235b-a22b-instruct-2507-v1:0`). The check guards against
+ * IDs (e.g. `qwen.qwen3-235b-a22b-2507-v1:0`). The check guards against
  * typos / unqualified IDs rather than enforcing a specific inference profile prefix.
  */
 const NAMESPACED_MODEL_ID = /^([a-z0-9-]+\.)+[a-z0-9][a-z0-9.:_-]*$/;
@@ -176,7 +176,7 @@ function validateBedrockModels(models: BedrockModelConfig[], env: Environment): 
       throw new Error(
         `[${env}] bedrockModels: model id "${model.id}" must be a namespaced model id ` +
           `(e.g. an inference profile id like "global.anthropic.claude-sonnet-4-6" ` +
-          `or a bare In-Region id like "qwen.qwen3-235b-a22b-instruct-2507-v1:0")`
+          `or a bare In-Region id like "qwen.qwen3-235b-a22b-2507-v1:0")`
       );
     }
     if (!model.name || typeof model.name !== 'string') {

--- a/packages/cdk/config/environment-utils.ts
+++ b/packages/cdk/config/environment-utils.ts
@@ -100,13 +100,10 @@ const DEFAULT_CONFIG = {
       provider: 'Amazon',
     },
     {
-      id: 'qwen.qwen3-235b-a22b-2507-v1:0',
-      name: 'Qwen3 235B A22B 2507',
-      provider: 'Qwen',
-    },
-    {
-      id: 'qwen.qwen3-coder-480b-a35b-v1:0',
-      name: 'Qwen3 Coder 480B A35B',
+      // In-Region only, bare id (no -v1:0 suffix). maxOutputTokens lives in
+      // BEDROCK_MODEL_DEFINITIONS (@moca/core) — CDK config carries id/name/provider only.
+      id: 'qwen.qwen3-coder-next',
+      name: 'Qwen3 Coder Next',
       provider: 'Qwen',
     },
   ] satisfies BedrockModelConfig[],

--- a/packages/cdk/config/environment-utils.ts
+++ b/packages/cdk/config/environment-utils.ts
@@ -33,10 +33,15 @@ export function deriveBedrockIamResources(
   const resources: string[] = [];
 
   for (const model of models) {
-    // Inference profile ARN (for cross-region routing, e.g. global.*, us.*, etc.)
-    resources.push(`arn:aws:bedrock:${region}:${account}:inference-profile/${model.id}`);
+    // Inference profile ARN (only for cross-region inference profile IDs, e.g.
+    // global.*, us.*, etc.). In-Region models (e.g. qwen.*) have no inference
+    // profile, so we skip this ARN to keep the IAM policy least-privilege.
+    if (INFERENCE_PROFILE_STRIP.test(model.id)) {
+      resources.push(`arn:aws:bedrock:${region}:${account}:inference-profile/${model.id}`);
+    }
 
-    // Foundation model ARN (strip inference profile prefix for direct access)
+    // Foundation model ARN (strip inference profile prefix for direct access).
+    // For bare In-Region IDs this is the only resource needed.
     const baseId = model.id.replace(INFERENCE_PROFILE_STRIP, '');
     resources.push(`arn:aws:bedrock:*::foundation-model/${baseId}*`);
   }
@@ -94,11 +99,29 @@ const DEFAULT_CONFIG = {
       name: 'Nova Lite 2',
       provider: 'Amazon',
     },
+    {
+      id: 'qwen.qwen3-235b-a22b-instruct-2507-v1:0',
+      name: 'Qwen3 235B A22B Instruct',
+      provider: 'Qwen',
+    },
+    {
+      id: 'qwen.qwen3-coder-480b-a35b-v1:0',
+      name: 'Qwen3 Coder 480B A35B',
+      provider: 'Qwen',
+    },
   ] satisfies BedrockModelConfig[],
 };
 
-const VALID_PROVIDERS: readonly string[] = ['Anthropic', 'Amazon'];
-const INFERENCE_PROFILE_PREFIX = /^(global|us|eu|apac|jp)\./;
+const VALID_PROVIDERS: readonly string[] = ['Anthropic', 'Amazon', 'Qwen'];
+
+/**
+ * A routable Bedrock model id must be namespaced: one or more `vendor.` segments
+ * followed by a model name. This accepts both cross-region inference profile IDs
+ * (e.g. `global.anthropic.claude-sonnet-4-6`) and bare In-Region foundation-model
+ * IDs (e.g. `qwen.qwen3-235b-a22b-instruct-2507-v1:0`). The check guards against
+ * typos / unqualified IDs rather than enforcing a specific inference profile prefix.
+ */
+const NAMESPACED_MODEL_ID = /^([a-z0-9-]+\.)+[a-z0-9][a-z0-9.:_-]*$/;
 
 /**
  * Cognito domain prefix regex.
@@ -149,9 +172,11 @@ function validateBedrockModels(models: BedrockModelConfig[], env: Environment): 
     if (!model.id || typeof model.id !== 'string') {
       throw new Error(`[${env}] bedrockModels: invalid model id: ${JSON.stringify(model)}`);
     }
-    if (!INFERENCE_PROFILE_PREFIX.test(model.id)) {
+    if (!NAMESPACED_MODEL_ID.test(model.id)) {
       throw new Error(
-        `[${env}] bedrockModels: model id "${model.id}" must start with inference profile prefix (global., us., eu., apac., jp.)`
+        `[${env}] bedrockModels: model id "${model.id}" must be a namespaced model id ` +
+          `(e.g. an inference profile id like "global.anthropic.claude-sonnet-4-6" ` +
+          `or a bare In-Region id like "qwen.qwen3-235b-a22b-instruct-2507-v1:0")`
       );
     }
     if (!model.name || typeof model.name !== 'string') {

--- a/packages/frontend/src/config/models.ts
+++ b/packages/frontend/src/config/models.ts
@@ -10,8 +10,14 @@ import { BEDROCK_MODEL_DEFINITIONS } from '@moca/core';
 export interface BedrockModel {
   id: string;
   name: string;
-  provider: 'Anthropic' | 'Amazon';
+  provider: 'Anthropic' | 'Amazon' | 'Qwen';
 }
+
+const VALID_PROVIDERS: ReadonlySet<BedrockModel['provider']> = new Set([
+  'Anthropic',
+  'Amazon',
+  'Qwen',
+]);
 
 /**
  * Fallback model list derived from the canonical BEDROCK_MODEL_DEFINITIONS.
@@ -29,8 +35,7 @@ function isValidModel(m: unknown): m is BedrockModel {
     ((m as Record<string, unknown>).id as string).length > 0 &&
     typeof (m as Record<string, unknown>).name === 'string' &&
     ((m as Record<string, unknown>).name as string).length > 0 &&
-    ((m as Record<string, unknown>).provider === 'Anthropic' ||
-      (m as Record<string, unknown>).provider === 'Amazon')
+    VALID_PROVIDERS.has((m as Record<string, unknown>).provider as BedrockModel['provider'])
   );
 }
 

--- a/packages/libs/core/src/__tests__/bedrock-models.test.ts
+++ b/packages/libs/core/src/__tests__/bedrock-models.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import {
+  BEDROCK_MODEL_DEFINITIONS,
+  getMaxOutputTokens,
+  getModelRegion,
+} from '../bedrock-models.js';
+
+describe('getMaxOutputTokens', () => {
+  it('returns the limit for a bare In-Region Qwen id', () => {
+    expect(getMaxOutputTokens('qwen.qwen3-coder-next')).toBe(16384);
+  });
+
+  it('matches across cross-region inference profile prefixes', () => {
+    // Registry stores `global.anthropic.claude-sonnet-4-6`; a `us.`-prefixed
+    // id for the same model must resolve to the same limit.
+    const expected = getMaxOutputTokens('global.anthropic.claude-sonnet-4-6');
+    expect(expected).toBeGreaterThan(0);
+    expect(getMaxOutputTokens('us.anthropic.claude-sonnet-4-6')).toBe(expected);
+  });
+
+  it('returns undefined for an unknown model id', () => {
+    expect(getMaxOutputTokens('does.not.exist-v1:0')).toBeUndefined();
+  });
+});
+
+describe('getModelRegion', () => {
+  it('returns the pinned region for a model with a region override', () => {
+    // qwen.qwen3-coder-next is not yet rolled out to every region, so it is
+    // pinned to us-east-1 in the registry.
+    expect(getModelRegion('qwen.qwen3-coder-next')).toBe('us-east-1');
+  });
+
+  it('returns undefined for a model without a region override', () => {
+    // Most models are invoked in the deployment region (no pin).
+    expect(getModelRegion('global.anthropic.claude-sonnet-4-6')).toBeUndefined();
+    expect(getModelRegion('qwen.qwen3-235b-a22b-2507-v1:0')).toBeUndefined();
+  });
+
+  it('returns undefined for an unknown model id', () => {
+    expect(getModelRegion('does.not.exist-v1:0')).toBeUndefined();
+  });
+});
+
+describe('BEDROCK_MODEL_DEFINITIONS invariants', () => {
+  it('every entry has a positive maxOutputTokens', () => {
+    for (const m of BEDROCK_MODEL_DEFINITIONS) {
+      expect(m.maxOutputTokens).toBeGreaterThan(0);
+    }
+  });
+
+  it('every region override is a non-empty string when present', () => {
+    for (const m of BEDROCK_MODEL_DEFINITIONS) {
+      if ('region' in m && m.region !== undefined) {
+        expect(typeof m.region).toBe('string');
+        expect(m.region.length).toBeGreaterThan(0);
+      }
+    }
+  });
+});

--- a/packages/libs/core/src/bedrock-models.ts
+++ b/packages/libs/core/src/bedrock-models.ts
@@ -68,8 +68,8 @@ export const BEDROCK_MODEL_DEFINITIONS = [
   {
     // In-Region only: Qwen3 has no cross-region inference profile prefix.
     // Note: Bedrock prompt caching is NOT supported for Qwen3 (Anthropic/Nova only).
-    id: 'qwen.qwen3-235b-a22b-instruct-2507-v1:0',
-    name: 'Qwen3 235B A22B Instruct',
+    id: 'qwen.qwen3-235b-a22b-2507-v1:0',
+    name: 'Qwen3 235B A22B 2507',
     provider: 'Qwen',
     maxOutputTokens: 8192, // AWS Bedrock model card (2026-05)
   },

--- a/packages/libs/core/src/bedrock-models.ts
+++ b/packages/libs/core/src/bedrock-models.ts
@@ -24,6 +24,20 @@ export interface BedrockModelDefinition {
    * Sources: Anthropic docs 2026-04, AWS docs.
    */
   readonly maxOutputTokens: number;
+  /**
+   * Optional invocation-region override.
+   *
+   * Most models are invoked in the deployment's BEDROCK_REGION. But some
+   * In-Region-only models are not yet rolled out to every region (despite what
+   * the AWS docs list), so they must be invoked in a region where they actually
+   * exist. When set, createBedrockModel() routes this model's Bedrock calls to
+   * this region regardless of BEDROCK_REGION. The IAM foundation-model ARN is
+   * region-wildcarded (arn:aws:bedrock:*::foundation-model/…), so cross-region
+   * invocation from another deployment region requires no extra IAM.
+   *
+   * Omit for models available in the deployment region (the common case).
+   */
+  readonly region?: string;
 }
 
 /**
@@ -67,28 +81,18 @@ export const BEDROCK_MODEL_DEFINITIONS = [
   },
   {
     // In-Region only: Qwen3 has no cross-region inference profile prefix.
+    // Note: bare model id with NO -v1:0 version suffix.
     // Note: Bedrock prompt caching is NOT supported for Qwen3 (Anthropic/Nova only).
-    id: 'qwen.qwen3-235b-a22b-2507-v1:0',
-    name: 'Qwen3 235B A22B 2507',
-    provider: 'Qwen',
-    maxOutputTokens: 8192, // AWS Bedrock model card (2026-05)
-  },
-  {
-    // In-Region only: Qwen3 has no cross-region inference profile prefix.
-    // Note: Bedrock prompt caching is NOT supported for Qwen3 (Anthropic/Nova only).
-    id: 'qwen.qwen3-coder-480b-a35b-v1:0',
-    name: 'Qwen3 Coder 480B A35B',
-    provider: 'Qwen',
-    maxOutputTokens: 16384, // AWS Bedrock model card (2026-05)
-  },
-  {
-    // In-Region only: Qwen3 has no cross-region inference profile prefix.
-    // Note: bare model id with NO -v1:0 version suffix (unlike the 2507 / 480b ids).
-    // Note: Bedrock prompt caching is NOT supported for Qwen3 (Anthropic/Nova only).
+    // Region pin: as of 2026-05 this model is NOT yet rolled out to the default
+    // deployment region (ap-northeast-1) even though the AWS docs list Tokyo.
+    // Verified via `aws bedrock get-foundation-model`: present in us-east-1,
+    // ValidationException ("provided model identifier is invalid") in ap-northeast-1.
+    // Pin invocation to us-east-1 until it ships in the deployment region.
     id: 'qwen.qwen3-coder-next',
     name: 'Qwen3 Coder Next',
     provider: 'Qwen',
     maxOutputTokens: 16384, // 16K — AWS Bedrock model card (qwen3-coder-next, 2026-02)
+    region: 'us-east-1',
   },
 ] as const satisfies readonly BedrockModelDefinition[];
 
@@ -109,4 +113,22 @@ function stripPrefix(modelId: string): string {
 export function getMaxOutputTokens(modelId: string): number | undefined {
   const stripped = stripPrefix(modelId);
   return BEDROCK_MODEL_DEFINITIONS.find((m) => stripPrefix(m.id) === stripped)?.maxOutputTokens;
+}
+
+/**
+ * Lookup the invocation-region override for a given modelId, if any.
+ *
+ * Strips cross-region inference profile prefixes before comparing (mirrors
+ * getMaxOutputTokens). Returns undefined when the model has no override (the
+ * common case) or is not in the registry — callers should then fall back to
+ * the deployment's BEDROCK_REGION.
+ */
+export function getModelRegion(modelId: string): string | undefined {
+  const stripped = stripPrefix(modelId);
+  // `region` is optional and present on only some entries; the `as const`
+  // literal union otherwise hides it. Widen to the interface to read it.
+  const match: BedrockModelDefinition | undefined = BEDROCK_MODEL_DEFINITIONS.find(
+    (m) => stripPrefix(m.id) === stripped
+  );
+  return match?.region;
 }

--- a/packages/libs/core/src/bedrock-models.ts
+++ b/packages/libs/core/src/bedrock-models.ts
@@ -81,6 +81,15 @@ export const BEDROCK_MODEL_DEFINITIONS = [
     provider: 'Qwen',
     maxOutputTokens: 16384, // AWS Bedrock model card (2026-05)
   },
+  {
+    // In-Region only: Qwen3 has no cross-region inference profile prefix.
+    // Note: bare model id with NO -v1:0 version suffix (unlike the 2507 / 480b ids).
+    // Note: Bedrock prompt caching is NOT supported for Qwen3 (Anthropic/Nova only).
+    id: 'qwen.qwen3-coder-next',
+    name: 'Qwen3 Coder Next',
+    provider: 'Qwen',
+    maxOutputTokens: 16384, // 16K — AWS Bedrock model card (qwen3-coder-next, 2026-02)
+  },
 ] as const satisfies readonly BedrockModelDefinition[];
 
 /** Strips cross-region inference profile prefixes (global., us., eu., apac., jp.) */

--- a/packages/libs/core/src/bedrock-models.ts
+++ b/packages/libs/core/src/bedrock-models.ts
@@ -18,7 +18,7 @@ export interface BedrockModelDefinition {
   /** Display name shown in the UI model selector */
   readonly name: string;
   /** Provider */
-  readonly provider: 'Anthropic' | 'Amazon';
+  readonly provider: 'Anthropic' | 'Amazon' | 'Qwen';
   /**
    * Maximum output tokens supported by this model.
    * Sources: Anthropic docs 2026-04, AWS docs.
@@ -64,6 +64,22 @@ export const BEDROCK_MODEL_DEFINITIONS = [
     name: 'Nova Lite 2',
     provider: 'Amazon',
     maxOutputTokens: 5120, // AWS docs
+  },
+  {
+    // In-Region only: Qwen3 has no cross-region inference profile prefix.
+    // Note: Bedrock prompt caching is NOT supported for Qwen3 (Anthropic/Nova only).
+    id: 'qwen.qwen3-235b-a22b-instruct-2507-v1:0',
+    name: 'Qwen3 235B A22B Instruct',
+    provider: 'Qwen',
+    maxOutputTokens: 8192, // AWS Bedrock model card (2026-05)
+  },
+  {
+    // In-Region only: Qwen3 has no cross-region inference profile prefix.
+    // Note: Bedrock prompt caching is NOT supported for Qwen3 (Anthropic/Nova only).
+    id: 'qwen.qwen3-coder-480b-a35b-v1:0',
+    name: 'Qwen3 Coder 480B A35B',
+    provider: 'Qwen',
+    maxOutputTokens: 16384, // AWS Bedrock model card (2026-05)
   },
 ] as const satisfies readonly BedrockModelDefinition[];
 

--- a/packages/libs/core/src/index.ts
+++ b/packages/libs/core/src/index.ts
@@ -54,4 +54,4 @@ export { SYSTEM_USER_ID } from './system-ids.js';
 
 // Bedrock model definitions — Single Source of Truth
 export type { BedrockModelDefinition } from './bedrock-models.js';
-export { BEDROCK_MODEL_DEFINITIONS, getMaxOutputTokens } from './bedrock-models.js';
+export { BEDROCK_MODEL_DEFINITIONS, getMaxOutputTokens, getModelRegion } from './bedrock-models.js';


### PR DESCRIPTION
## Summary

Add **Qwen3** model support to the Bedrock model registry and make the agent/CDK robust against the quirks of In-Region-only, non-Anthropic models. Qwen3 has **no cross-region inference profile**, so it required relaxing model-id validation, an invocation-region override, and two runtime fixes for streaming + tool use.

The selectable model added to the Single Source of Truth (SoT) is:
- **Qwen3 Coder Next** — `qwen.qwen3-coder-next` (In-Region only, bare id with **no** `-v1:0` suffix, `maxOutputTokens` 16384, region-pinned to `us-east-1`)

The 235B (`qwen.qwen3-235b-a22b-2507-v1:0`) and Coder 480B (`qwen.qwen3-coder-480b-a35b-v1:0`) ids are exercised by opt-in integration tests but are **not** added to the registry in this PR.

## 1. Model-id validation accepts In-Region (no-CRIS-prefix) ids

`validateBedrockModels()` previously **required** a CRIS prefix (`global./us./eu./apac./jp.`), which rejected bare In-Region ids like `qwen.*`. It now enforces a **namespaced model id** (`NAMESPACED_MODEL_ID`) instead, accepting both:
- inference profile ids (`global.anthropic.claude-sonnet-4-6`)
- bare In-Region ids (`qwen.qwen3-coder-next`)

while still catching unqualified ids / typos.

## 2. Invocation-region override (region pin)

`BedrockModelDefinition` gains an optional `region` field and a new `getModelRegion()` lookup. Some In-Region-only models are **not yet rolled out to the deployment region** (`qwen.qwen3-coder-next` is present in `us-east-1` but returns a `ValidationException` in `ap-northeast-1`, despite the docs listing Tokyo), so it is pinned to `us-east-1`.

`createBedrockModel()` region resolution order is now:
1. explicit `options.region`
2. the model's region pin (`getModelRegion`)
3. the deployment's `BEDROCK_REGION`

The IAM foundation-model ARN is region-wildcarded, so cross-region invocation needs no extra IAM.

## 3. EmptyTextBlockHook — fix Qwen3's empty leading TextBlock

Qwen3 emits an **empty leading `TextBlock`** before a `toolUse` block (`content: [{ text: '' }, { toolUse }]`). The first request succeeds, but the **follow-up** request (after the tool result is appended) is rejected by Bedrock:

> `ValidationException: The text field in the ContentBlock object at messages.1.content.0 is blank.`

A new `EmptyTextBlockHook` plugin strips whitespace-only `TextBlock`s from assistant messages (never emptying `content`). It is registered first in `agent.ts` and is a **harmless no-op for Claude** (which doesn't emit empty blocks).

## 4. Rehydrate persisted toolResult content

`wireToContentBlock` now rebuilds `ToolResultBlock.content` into real SDK content-block instances via `toolResultContentFromData` (`restoreToolResultContent`). Previously the plain-JSON projection was cast verbatim, so on the next turn the restored history broke both:
1. `BedrockModel._formatContentBlock` (switch on `content.type` → empty content → Bedrock "missing field `content`"), and
2. `Message.toJSON()` (`block.toJSON is not a function`).

Unknown/legacy entries are coerced to a `TextBlock`, and an empty result is never produced.

## 5. IAM least-privilege

`deriveBedrockIamResources` now **skips the inference-profile ARN for bare In-Region ids** and emits only the foundation-model ARN. CRIS-prefixed models still get both ARNs.

## Prompt caching

**Bedrock prompt caching is NOT supported for Qwen3** (Anthropic/Nova only). The SDK's `auto` strategy only injects `cachePoint` for Anthropic-pattern ids, so Qwen3 **safely no-ops** — doc-only change in `packages/agent/src/config/bedrock.ts`.

## Changes
- `packages/libs/core/src/bedrock-models.ts` (SoT): add optional `region` field + `getModelRegion()`; add `'Qwen'` provider; add `qwen.qwen3-coder-next` (region-pinned to `us-east-1`).
- `packages/libs/core/src/index.ts`: export `getModelRegion`.
- `packages/agent/src/config/bedrock.ts`: region resolution via `getModelRegion`; doc-only prompt-caching note.
- `packages/agent/src/agent.ts`: register `EmptyTextBlockHook` first.
- `packages/agent/src/services/session/empty-text-block-hook.ts` (new): strip empty assistant `TextBlock`s.
- `packages/agent/src/libs/codec/content-block-codec.ts`: `restoreToolResultContent` rehydrates persisted toolResult content.
- `packages/cdk/config/environment-types.ts`: add `'Qwen'` provider; update `id` doc.
- `packages/cdk/config/environment-utils.ts`: relax validation (`NAMESPACED_MODEL_ID`); add `'Qwen'` to `VALID_PROVIDERS`; skip inference-profile ARN for In-Region ids; add `qwen.qwen3-coder-next` to `DEFAULT_CONFIG`.
- `packages/frontend/src/config/models.ts`: add `'Qwen'`; data-driven `isValidModel` provider check.

## Tests
- `bedrock-models.test.ts` (new): `getMaxOutputTokens` / `getModelRegion` for Qwen3 + prefix-strip + registry invariants.
- `bedrock.test.ts` (new): `createBedrockModel` region-resolution order + `maxTokens` derivation.
- `empty-text-block-hook.test.ts` (new): strip empty/whitespace blocks, preserve real text, never empty `content`, no-op for Claude/user.
- `converters.test.ts`: toolResult / toolUse round-trip restores inner content as SDK instances and re-serializes.
- `environment-utils.test.ts`: In-Region ids emit only foundation-model ARN; mixed CRIS + In-Region case.
- `qwen3-model.integration.test.ts` (new, **opt-in** via `RUN_BEDROCK_QWEN_INTEGRATION=1`): real Bedrock calls for 235B / Coder 480B / Coder Next — system-prompt adherence, streaming, context, agentic tool use, and the empty-ContentBlock tool round-trip regression.

## ⚠️ Operational notes (reviewer)
- Qwen3 has **no global profile** → it must be **enabled in the invocation region**. `qwen.qwen3-coder-next` is region-pinned to `us-east-1`; enable Qwen3 there.
- The integration suite makes real Bedrock calls and is opt-in, so CI / restricted roles are unaffected.
