### PR TITLE
feat(scheduler): raise minimum schedule interval to 10 minutes

### DIFF
--- a/packages/backend/src/services/__tests__/scheduler-service.test.ts
+++ b/packages/backend/src/services/__tests__/scheduler-service.test.ts
@@ -116,10 +116,11 @@ describe('SchedulerService - formatScheduleExpression (via createSchedule mock i
   });
 
   it('trims whitespace from "rate <value>" expression', async () => {
-    await service.createSchedule({ ...BASE_CONFIG, expression: '  rate 5 minutes  ' });
+    // Use a >= 10-minute interval so it clears the minimum-interval guard.
+    await service.createSchedule({ ...BASE_CONFIG, expression: '  rate 15 minutes  ' });
 
     const call = MockCreateScheduleCommand.mock.calls[0][0] as { ScheduleExpression: string };
-    expect(call.ScheduleExpression).toBe('rate(5 minutes)');
+    expect(call.ScheduleExpression).toBe('rate(15 minutes)');
   });
 });
 
@@ -287,9 +288,10 @@ describe('SchedulerService - scheduleExists', () => {
 
 /**
  * Minimum-interval guard: rejects cron / rate expressions that would fire
- * more than once per minute. See
+ * more often than once per 10 minutes. See
  * `docs/adr/event-driven-identity-pool-credentials.md` > Quotas & Rate Limits
- * for the rationale (GetOpenIdTokenForDeveloperIdentity 25 TPS hard quota).
+ * for the rationale (GetOpenIdTokenForDeveloperIdentity 25 TPS hard quota and
+ * per-fire Lambda/Bedrock cost).
  *
  * The matching unit tests for the frontend mirror implementation live at
  * `packages/frontend/src/components/triggers/CronBuilder/__tests__/cronUtils.test.ts`.
@@ -308,8 +310,16 @@ describe('SchedulerService - minimum interval enforcement', () => {
     mockSend.mockImplementation(() => Promise.resolve({}));
   });
 
-  it.each([['rate(30 seconds)'], ['rate(0.5 minutes)'], ['rate(0 seconds)']])(
-    'createSchedule rejects sub-minute expression %s',
+  it.each([
+    ['rate(30 seconds)'],
+    ['rate(0.5 minutes)'],
+    ['rate(0 seconds)'],
+    ['rate(1 minute)'],
+    ['rate(9 minutes)'], // just under the 10-minute floor
+    ['* * * * ? *'], // every minute
+    ['*/5 * * * ? *'], // every 5 minutes
+  ])(
+    'createSchedule rejects sub-10-minute expression %s',
     async (expression) => {
       await expect(service.createSchedule({ ...BASE_CONFIG, expression })).rejects.toBeInstanceOf(
         InvalidScheduleIntervalError
@@ -323,9 +333,9 @@ describe('SchedulerService - minimum interval enforcement', () => {
   );
 
   it.each([
-    ['rate(1 minute)'],
-    ['* * * * ? *'], // every minute (warning, but allowed)
-    ['*/5 * * * ? *'], // every 5 minutes
+    ['rate(10 minutes)'], // exactly the floor
+    ['*/10 * * * ? *'], // every 10 minutes (warning, but allowed)
+    ['*/30 * * * ? *'], // every 30 minutes
     ['0 * * * ? *'], // every hour
     ['0 0 * * ? *'], // every day
   ])('createSchedule allows expression %s', async (expression) => {
@@ -333,7 +343,7 @@ describe('SchedulerService - minimum interval enforcement', () => {
     expect(MockCreateScheduleCommand).toHaveBeenCalledTimes(1);
   });
 
-  it('updateSchedule rejects sub-minute expression when expression is changing', async () => {
+  it('updateSchedule rejects sub-10-minute expression when expression is changing', async () => {
     await expect(
       service.updateSchedule(BASE_CONFIG.payload.triggerId, {
         expression: 'rate(10 seconds)',

--- a/packages/backend/src/services/scheduler-service.ts
+++ b/packages/backend/src/services/scheduler-service.ts
@@ -66,10 +66,12 @@ function formatScheduleExpression(expression: string): string {
  * Hard minimum interval (in minutes). Schedules below this are rejected so
  * that a single user — or a small group sharing a cron pattern — cannot
  * exhaust the `GetOpenIdTokenForDeveloperIdentity` 25 TPS hard quota at
- * event-fire time. 60-min-and-under schedules are still allowed but the
- * frontend surfaces a cost warning with explicit confirmation.
+ * event-fire time, and to bound the per-fire cost (Lambda + Bedrock) of
+ * high-frequency schedules. Schedules between this floor and
+ * `COST_WARNING_THRESHOLD_MINUTES` are still allowed but the frontend
+ * surfaces a cost warning with explicit confirmation.
  */
-const MINIMUM_INTERVAL_MINUTES = 1;
+const MINIMUM_INTERVAL_MINUTES = 10;
 
 /**
  * Thrown when a schedule expression fires more frequently than
@@ -79,7 +81,7 @@ export class InvalidScheduleIntervalError extends Error {
   readonly code = 'INVALID_SCHEDULE_INTERVAL';
   constructor(expression: string, intervalMinutes: number) {
     super(
-      `Schedule interval must be at least ${MINIMUM_INTERVAL_MINUTES} minute ` +
+      `Schedule interval must be at least ${MINIMUM_INTERVAL_MINUTES} minutes ` +
         `(got ~${intervalMinutes.toFixed(2)} min for "${expression}")`
     );
     this.name = 'InvalidScheduleIntervalError';

--- a/packages/frontend/src/components/triggers/CronBuilder/CronBuilder.tsx
+++ b/packages/frontend/src/components/triggers/CronBuilder/CronBuilder.tsx
@@ -134,7 +134,7 @@ export function CronBuilder({
         <div className="text-sm text-feedback-error">{t('triggers.cron.invalidExpression')}</div>
       )}
 
-      {/* Minimum interval error (< 1 minute) — blocks submit */}
+      {/* Minimum interval error (< 10 minutes) — blocks submit */}
       {isValid && intervalTooShort && (
         <div
           role="alert"

--- a/packages/frontend/src/components/triggers/CronBuilder/__tests__/cronUtils.test.ts
+++ b/packages/frontend/src/components/triggers/CronBuilder/__tests__/cronUtils.test.ts
@@ -2,9 +2,10 @@
  * Tests for schedule interval detection and classification.
  *
  * The behaviour being tested is the primary guard against users scheduling
- * triggers that fire more often than once per minute — a cadence that would
- * quickly exhaust the `GetOpenIdTokenForDeveloperIdentity` 25 TPS hard quota
- * when aggregated across multiple users. The backend enforces the same rule
+ * triggers that fire more often than once per 10 minutes — a cadence that
+ * would quickly exhaust the `GetOpenIdTokenForDeveloperIdentity` 25 TPS hard
+ * quota when aggregated across multiple users, and drive up per-fire
+ * Lambda/Bedrock cost. The backend enforces the same rule
  * in `packages/backend/src/services/scheduler-service.ts`; any change to
  * `getMinimumIntervalMinutes` here must be mirrored there (and vice-versa).
  */
@@ -50,16 +51,22 @@ describe('getMinimumIntervalMinutes', () => {
 });
 
 describe('validateScheduleInterval', () => {
-  it('returns "too-short" for sub-minute schedules', () => {
+  it('returns "too-short" for schedules faster than the 10-minute floor', () => {
     expect(validateScheduleInterval('rate(30 seconds)')).toBe('too-short');
-    // Hypothetical fractional cron (not real AWS syntax but guards the
-    // numeric threshold regardless).
     expect(validateScheduleInterval('rate(0.5 minutes)')).toBe('too-short');
+    expect(validateScheduleInterval('* * * * ? *')).toBe('too-short'); // every minute
+    expect(validateScheduleInterval('*/5 * * * ? *')).toBe('too-short'); // every 5 minutes
+    expect(validateScheduleInterval('rate(9 minutes)')).toBe('too-short'); // just under floor
   });
 
-  it('returns "warning" for sub-hourly schedules', () => {
-    expect(validateScheduleInterval('* * * * ? *')).toBe('warning'); // every minute
-    expect(validateScheduleInterval('*/5 * * * ? *')).toBe('warning'); // every 5 minutes
+  it('treats exactly the 10-minute floor as allowed (with warning)', () => {
+    // Boundary: 10 min is >= MINIMUM_INTERVAL_MINUTES, so it is no longer
+    // blocked, but still < COST_WARNING_THRESHOLD_MINUTES so it warns.
+    expect(validateScheduleInterval('*/10 * * * ? *')).toBe('warning');
+    expect(validateScheduleInterval('rate(10 minutes)')).toBe('warning');
+  });
+
+  it('returns "warning" for sub-hourly schedules at or above the floor', () => {
     expect(validateScheduleInterval('*/30 * * * ? *')).toBe('warning'); // every 30 minutes
     expect(validateScheduleInterval('0,30 * * * ? *')).toBe('warning');
   });
@@ -83,7 +90,7 @@ describe('validateScheduleInterval', () => {
     // These constants are part of the shared contract between the frontend
     // and backend implementations. Changing them requires matching changes
     // in scheduler-service.ts.
-    expect(MINIMUM_INTERVAL_MINUTES).toBe(1);
+    expect(MINIMUM_INTERVAL_MINUTES).toBe(10);
     expect(COST_WARNING_THRESHOLD_MINUTES).toBe(60);
   });
 });

--- a/packages/frontend/src/components/triggers/CronBuilder/cronUtils.ts
+++ b/packages/frontend/src/components/triggers/CronBuilder/cronUtils.ts
@@ -29,11 +29,12 @@ export interface CronPreset {
  */
 export const CRON_PRESETS: CronPreset[] = [
   // NOTE: `everyMinute` preset intentionally removed — cron expressions that
-  // fire more often than once per minute are blocked by both the UI
-  // (`validateScheduleInterval`) and the backend
-  // (`scheduler-service.ts#assertMinimumInterval`). A once-per-minute cadence
-  // risks hitting the `GetOpenIdTokenForDeveloperIdentity` 25 TPS hard quota
-  // when multiple users schedule the same cron. See
+  // fire more often than once per `MINIMUM_INTERVAL_MINUTES` (10 min) are
+  // blocked by both the UI (`validateScheduleInterval`) and the backend
+  // (`scheduler-service.ts#assertMinimumInterval`). High-frequency cadences
+  // risk hitting the `GetOpenIdTokenForDeveloperIdentity` 25 TPS hard quota
+  // when multiple users schedule the same cron, and run up per-fire
+  // Lambda/Bedrock cost. See
   // `docs/adr/event-driven-identity-pool-credentials.md` > Quotas & Rate Limits.
   {
     id: 'everyHour',
@@ -119,9 +120,10 @@ export const COST_WARNING_THRESHOLD_MINUTES = 60;
 /**
  * Hard minimum interval (in minutes). Schedules below this are rejected
  * outright — both in the UI and by the backend — to protect the
- * `GetOpenIdTokenForDeveloperIdentity` 25 TPS hard quota.
+ * `GetOpenIdTokenForDeveloperIdentity` 25 TPS hard quota and to bound the
+ * per-fire cost of high-frequency schedules.
  */
-export const MINIMUM_INTERVAL_MINUTES = 1;
+export const MINIMUM_INTERVAL_MINUTES = 10;
 
 /**
  * Estimate the minimum interval (in minutes) between executions of the
@@ -266,9 +268,11 @@ function deriveHourGap(hour: string): number | null {
 
 /**
  * Classify a schedule expression against the two thresholds:
- *   - `'too-short'` (< 1 min)  → must be blocked, never created
- *   - `'warning'`   (< 60 min) → allow but display a cost warning and
- *                                request explicit confirmation at submit
+ *   - `'too-short'` (< MINIMUM_INTERVAL_MINUTES, i.e. < 10 min) → must be
+ *                                blocked, never created
+ *   - `'warning'`   (< COST_WARNING_THRESHOLD_MINUTES, i.e. < 60 min) → allow
+ *                                but display a cost warning and request
+ *                                explicit confirmation at submit
  *   - `'ok'`        (>= 60 min or indeterminate but daily+) → no warning
  *   - `'unknown'`   parse failure → treat conservatively as warning in
  *                  the UI so the user is at least nudged to double-check

--- a/packages/frontend/src/components/triggers/TriggerFormModal/TriggerFormModal.tsx
+++ b/packages/frontend/src/components/triggers/TriggerFormModal/TriggerFormModal.tsx
@@ -201,9 +201,10 @@ export function TriggerFormModal({ isOpen, onClose, trigger, onSave }: TriggerFo
       return false;
     }
 
-    // Hard block: schedules under MINIMUM_INTERVAL_MINUTES (1 min) must never
+    // Hard block: schedules under MINIMUM_INTERVAL_MINUTES (10 min) must never
     // be created. This protects the `GetOpenIdTokenForDeveloperIdentity`
-    // 25 TPS hard quota when multiple users schedule similar crons. The
+    // 25 TPS hard quota when multiple users schedule similar crons, and bounds
+    // the per-fire Lambda/Bedrock cost of high-frequency schedules. The
     // backend enforces the same rule in `scheduler-service.ts`; the UI check
     // is purely for immediate feedback.
     if (selectedEventType === 'schedule') {

--- a/packages/frontend/src/locales/en.yaml
+++ b/packages/frontend/src/locales/en.yaml
@@ -634,7 +634,7 @@ triggers:
     customExpression: 'Custom Cron Expression'
     customExpressionHint: 'AWS EventBridge format: minute hour day month weekday year (e.g., 0 0 * * ? *)'
     invalidExpression: Invalid cron expression
-    intervalTooShort: Schedule interval must be at least 1 minute
+    intervalTooShort: Schedule interval must be at least 10 minutes
     costWarning:
       title: Short schedule interval
       body: Running this schedule more than once per hour may incur unexpectedly high AWS costs (Lambda invocations, generative AI model calls, and Cognito token issuance). Are you sure you want to create this schedule?

--- a/packages/frontend/src/locales/ja.yaml
+++ b/packages/frontend/src/locales/ja.yaml
@@ -634,7 +634,7 @@ triggers:
     customExpression: 'カスタムCron式'
     customExpressionHint: 'cron形式: 分 時 日 月 曜日 年 (例: 0 0 * * ? *)'
     invalidExpression: 無効なCron式です
-    intervalTooShort: 実行間隔は 1 分以上で指定してください
+    intervalTooShort: 実行間隔は 10 分以上で指定してください
     costWarning:
       title: 短い実行間隔が設定されています
       body: 1 時間未満の実行間隔では、Lambda 起動、生成 AI モデル呼び出し、Cognito トークン発行などの AWS リソース利用料が想定以上に発生する可能性があります。本当にこの設定で作成しますか？


### PR DESCRIPTION
Increase the hard floor for trigger schedule expressions from 1 minute to 10 minutes in both backend validation and frontend cron builder, to bound per-fire Lambda/Bedrock cost and protect the GetOpenIdTokenForDeveloperIdentity 25 TPS quota. Updates error messages, cost-warning copy, and the corresponding unit tests on both sides to reflect the new threshold.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
