### PR TITLE
docs(cdk): fix stale memoryExpirationDays default in comment (90 → 30)

### DIFF
--- a/packages/cdk/lib/agentcore-stack.ts
+++ b/packages/cdk/lib/agentcore-stack.ts
@@ -69,7 +69,7 @@ export interface AgentCoreStackProps extends cdk.StackProps {
 
   /**
    * Memory expiration period in days (optional)
-   * Default: 90 days
+   * Default: 30 days (DEFAULT_CONFIG.memoryExpirationDays in config/environment-utils.ts)
    */
   readonly memoryExpirationDays?: number;
 


### PR DESCRIPTION
## Summary

The JSDoc for `AgentCoreStackProps.memoryExpirationDays` claimed a default of **90 days**, but the implementation uses **30 days**.

```ts
// packages/cdk/lib/agentcore-stack.ts
const expirationDays = props?.memoryExpirationDays || envConfig.memoryExpirationDays;
```

`envConfig.memoryExpirationDays` falls back to `DEFAULT_CONFIG.memoryExpirationDays`, which is **30** in `packages/cdk/config/environment-utils.ts`:

```ts
const DEFAULT_CONFIG = {
  // ...
  memoryExpirationDays: 30,
};
```

This PR aligns the comment with the actual default. **Comment-only change; no behavior change.**

## Detection
Found by an automated code-comment alignment audit (comment vs. implementation drift).

## Category
`cdk`