### PR TITLE
docs(frontend): fix Tooltip delay default in comment (200 → 0)

### DIFF
--- a/packages/frontend/src/components/ui/Tooltip/Tooltip.tsx
+++ b/packages/frontend/src/components/ui/Tooltip/Tooltip.tsx
@@ -19,7 +19,7 @@ export interface TooltipProps {
   maxWidth?: string;
   /** Disable the tooltip */
   disabled?: boolean;
-  /** Display delay time (milliseconds, default: 200) */
+  /** Display delay time (milliseconds, default: 0) */
   delay?: number;
 }
 


### PR DESCRIPTION
## Summary

The `TooltipProps.delay` JSDoc claimed a default of **200ms**, but the component destructures it with a default of **0**:

```ts
// packages/frontend/src/components/ui/Tooltip/Tooltip.tsx
/** Display delay time (milliseconds, default: 200) */  // ← stated 200
delay?: number;
// ...
export function Tooltip({
  // ...
  delay = 0,   // ← actual default
}) { ... }
```

This PR aligns the comment with the actual default. **Comment-only change; no behavior change.**

## Detection
Found by an automated code-comment alignment audit (comment vs. implementation drift).

## Category
`frontend`