### PR TITLE
fix(runtime): release microVM after trigger-based invocations (#23)

### DIFF
--- a/packages/agent/src/handlers/invocations.ts
+++ b/packages/agent/src/handlers/invocations.ts
@@ -41,6 +41,7 @@ import { initializeWorkspaceSync } from '../services/workspace-sync-helper.js';
 import { createSessionPersistenceDeps } from '../services/session-persistence-deps-factory.js';
 import { logger } from '../libs/logger/index.js';
 import { streamAgentResponse } from './stream-handler.js';
+import { stopOwnSession } from '../services/session-terminator.js';
 
 /**
  * Agent invocation endpoint (with streaming support).
@@ -126,4 +127,19 @@ export async function handleInvocation(req: Request, res: Response): Promise<voi
     sessionStorage: sessionResult?.storage,
     sessionConfig: sessionResult?.config,
   });
+
+  // Event-driven (trigger) invocations are fire-and-forget: nothing on the
+  // client side will tell the Runtime the session is done, so the microVM
+  // would otherwise linger (billing memory) until the idle timeout. Now that
+  // `streamAgentResponse` has fully written and ended the response, proactively
+  // stop our own session to release the microVM immediately.
+  //
+  // Restricted to `sessionType === 'event'`: interactive (chat) sessions are
+  // intentionally kept warm so follow-up turns reuse the same context, and the
+  // frontend's graceful stream close lets them go Idle on their own. Stopping
+  // also terminates any ongoing stream, so this must run AFTER the response is
+  // sent (which it is — `streamAgentResponse` calls `res.end()` before returning).
+  if (sessionType === 'event' && sessionId) {
+    await stopOwnSession(sessionId);
+  }
 }

--- a/packages/agent/src/services/__tests__/session-terminator.test.ts
+++ b/packages/agent/src/services/__tests__/session-terminator.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for session-terminator
+ *
+ * Covers ARN recovery from the platform-injected AGENTCORE_RUNTIME_URL and the
+ * best-effort StopRuntimeSession call (success + swallowed-failure paths).
+ */
+
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+
+// Mock config so importing the module doesn't pull in real env parsing.
+jest.unstable_mockModule('../../config/index.js', () => ({
+  config: { AWS_REGION: 'ap-northeast-1' },
+}));
+
+// Mock the AWS SDK client; `sendMock` is asserted/overridden per test.
+const sendMock = jest.fn<(...args: unknown[]) => Promise<unknown>>();
+jest.unstable_mockModule('@aws-sdk/client-bedrock-agentcore', () => ({
+  BedrockAgentCoreClient: jest.fn().mockImplementation(() => ({ send: sendMock })),
+  StopRuntimeSessionCommand: jest
+    .fn()
+    .mockImplementation((input: unknown) => ({ __input: input })),
+}));
+
+const { resolveOwnRuntimeArn, stopOwnSession } = await import('../session-terminator.js');
+const { StopRuntimeSessionCommand } = await import('@aws-sdk/client-bedrock-agentcore');
+
+const ARN = 'arn:aws:bedrock-agentcore:ap-northeast-1:123456789012:runtime/moca-3bl7hC71J7';
+const RUNTIME_URL = `https://bedrock-agentcore.ap-northeast-1.amazonaws.com/runtimes/${encodeURIComponent(
+  ARN
+)}/invocations`;
+
+describe('resolveOwnRuntimeArn', () => {
+  it('extracts and decodes the ARN from a percent-encoded runtime URL', () => {
+    expect(resolveOwnRuntimeArn(RUNTIME_URL)).toBe(ARN);
+  });
+
+  it('returns undefined when the env var is absent', () => {
+    expect(resolveOwnRuntimeArn(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when the URL lacks a /runtimes/<arn>/invocations segment', () => {
+    expect(
+      resolveOwnRuntimeArn('https://bedrock-agentcore.ap-northeast-1.amazonaws.com/ping')
+    ).toBeUndefined();
+  });
+
+  it('falls back to process.env.AGENTCORE_RUNTIME_URL when no argument is passed', () => {
+    const prev = process.env.AGENTCORE_RUNTIME_URL;
+    process.env.AGENTCORE_RUNTIME_URL = RUNTIME_URL;
+    try {
+      expect(resolveOwnRuntimeArn()).toBe(ARN);
+    } finally {
+      if (prev === undefined) delete process.env.AGENTCORE_RUNTIME_URL;
+      else process.env.AGENTCORE_RUNTIME_URL = prev;
+    }
+  });
+});
+
+describe('stopOwnSession', () => {
+  beforeEach(() => {
+    sendMock.mockReset();
+    (StopRuntimeSessionCommand as unknown as jest.Mock).mockClear();
+    process.env.AGENTCORE_RUNTIME_URL = RUNTIME_URL;
+  });
+
+  afterEach(() => {
+    delete process.env.AGENTCORE_RUNTIME_URL;
+  });
+
+  it('calls StopRuntimeSession with the resolved ARN and given session id', async () => {
+    sendMock.mockResolvedValue({ statusCode: 200 });
+
+    await stopOwnSession('session-abc-0000000000000000000000000');
+
+    expect(StopRuntimeSessionCommand).toHaveBeenCalledWith({
+      agentRuntimeArn: ARN,
+      runtimeSessionId: 'session-abc-0000000000000000000000000',
+    });
+    expect(sendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call the SDK when the ARN cannot be resolved', async () => {
+    delete process.env.AGENTCORE_RUNTIME_URL;
+
+    await stopOwnSession('session-abc');
+
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it('swallows SDK errors (best-effort)', async () => {
+    sendMock.mockRejectedValue(new Error('AccessDeniedException'));
+
+    await expect(stopOwnSession('session-abc')).resolves.toBeUndefined();
+    expect(sendMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/agent/src/services/session-terminator.ts
+++ b/packages/agent/src/services/session-terminator.ts
@@ -1,0 +1,117 @@
+/**
+ * Event-driven session self-termination
+ *
+ * Event-driven (trigger) invocations are fire-and-forget: the Trigger Lambda
+ * sends the request and returns immediately without consuming the NDJSON
+ * stream. Once the agent finishes processing, nothing on the client side
+ * tells AgentCore Runtime that the session is done, so the microVM is only
+ * reclaimed after the idle timeout (default 900s) elapses — billing memory
+ * the whole time.
+ *
+ * Interactive (chat) invocations don't have this problem: the frontend reads
+ * the stream to completion and the session naturally goes Idle, and we WANT
+ * the microVM to stay warm so follow-up turns reuse the same context.
+ *
+ * For the event path there is no follow-up turn, so as soon as the response
+ * has been fully written we proactively call `StopRuntimeSession` on our own
+ * session. AgentCore's docs state this "instantly terminates the specified
+ * session and stops any ongoing streaming responses" — so it MUST run only
+ * after `res.end()`, otherwise it would cut off the response we just sent.
+ *
+ * ## Obtaining our own Runtime ARN
+ *
+ * `StopRuntimeSession` requires the runtime ARN. We cannot inject it via a
+ * CDK environment variable because `runtime.agentRuntimeArn` is a CloudFormation
+ * `GetAtt` on the same resource — feeding it back into that resource's own
+ * `environmentVariables` creates a circular dependency. Instead we recover it
+ * from `AGENTCORE_RUNTIME_URL`, which the AgentCore platform injects at runtime
+ * (not via the CDK resource definition, so no cycle). Its path segment carries
+ * the URL-encoded ARN:
+ *
+ *   https://bedrock-agentcore.<region>.amazonaws.com/runtimes/<url-encoded-arn>/invocations
+ */
+
+import {
+  BedrockAgentCoreClient,
+  StopRuntimeSessionCommand,
+} from '@aws-sdk/client-bedrock-agentcore';
+import { config } from '../config/index.js';
+import { createLogger } from '../libs/logger/index.js';
+
+const log = createLogger('SessionTerminator');
+
+/**
+ * Extract this container's own Runtime ARN from `AGENTCORE_RUNTIME_URL`.
+ *
+ * @returns the decoded ARN, or `undefined` if the env var is absent or
+ *          does not contain a `/runtimes/<arn>/invocations` segment (e.g.
+ *          in local development where the platform var is not injected).
+ */
+export function resolveOwnRuntimeArn(
+  runtimeUrl: string | undefined = process.env.AGENTCORE_RUNTIME_URL
+): string | undefined {
+  if (!runtimeUrl) {
+    return undefined;
+  }
+
+  // The ARN sits between `/runtimes/` and the trailing `/invocations`. It is
+  // percent-encoded (colons and slashes → %3A / %2F), so decode after capture.
+  const match = runtimeUrl.match(/\/runtimes\/([^/]+)\/invocations/);
+  if (!match) {
+    return undefined;
+  }
+
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    // Malformed percent-encoding — treat as unresolvable rather than throw.
+    return undefined;
+  }
+}
+
+let cachedClient: BedrockAgentCoreClient | undefined;
+
+function getClient(): BedrockAgentCoreClient {
+  if (!cachedClient) {
+    cachedClient = new BedrockAgentCoreClient({ region: config.AWS_REGION });
+  }
+  return cachedClient;
+}
+
+/**
+ * Stop the current event-driven session so its microVM is released promptly
+ * instead of lingering until the idle timeout.
+ *
+ * Best-effort: any failure (missing ARN, missing IAM permission, throttling)
+ * is logged and swallowed. The `idleRuntimeSessionTimeout` configured on the
+ * Runtime is the defense-in-depth backstop that reclaims the container if this
+ * call doesn't land.
+ *
+ * MUST be called only after the response has been fully written (`res.end()`),
+ * because stopping the session also stops any ongoing streaming response.
+ *
+ * @param sessionId the runtime session id to stop (from the request context)
+ */
+export async function stopOwnSession(sessionId: string): Promise<void> {
+  const runtimeArn = resolveOwnRuntimeArn();
+  if (!runtimeArn) {
+    log.warn(
+      'Skipping self-termination: could not resolve own Runtime ARN from AGENTCORE_RUNTIME_URL'
+    );
+    return;
+  }
+
+  try {
+    log.info({ sessionId }, 'Stopping event-driven session to release microVM');
+    await getClient().send(
+      new StopRuntimeSessionCommand({
+        agentRuntimeArn: runtimeArn,
+        runtimeSessionId: sessionId,
+      })
+    );
+    log.info({ sessionId }, 'StopRuntimeSession accepted');
+  } catch (error) {
+    // Non-fatal: the idle timeout will still reclaim the container.
+    log.warn({ err: error, sessionId }, 'StopRuntimeSession failed (non-fatal)');
+  }
+}

--- a/packages/cdk/lib/constructs/agentcore/agentcore-runtime.ts
+++ b/packages/cdk/lib/constructs/agentcore/agentcore-runtime.ts
@@ -138,6 +138,23 @@ export interface AgentCoreRuntimeProps {
    * Nova Reel async-invoke is excluded — handled by Gateway Target Lambda only.
    */
   readonly bedrockModels: BedrockModelConfig[];
+
+  /**
+   * Idle timeout for runtime sessions (defense-in-depth backstop).
+   *
+   * Event-driven (trigger) invocations self-terminate their session after the
+   * response is sent (see packages/agent/src/services/session-terminator.ts),
+   * so the microVM is normally released immediately. This timeout reclaims any
+   * session that, for whatever reason, was left Idle without being stopped —
+   * bounding how long a leaked container can keep billing memory.
+   *
+   * Idle is measured from when the agent stops processing, so a shorter value
+   * never interrupts an in-flight invocation. The timer resets on each new
+   * invocation to the same session.
+   *
+   * @default Duration.seconds(300) — 5 minutes, well under the platform default of 900s
+   */
+  readonly idleRuntimeSessionTimeout?: cdk.Duration;
 }
 
 /**
@@ -297,6 +314,13 @@ export class AgentCoreRuntime extends Construct {
       description: props.description || `Strands Agent Runtime: ${props.runtimeName}`,
       authorizerConfiguration: authorizerConfiguration,
       environmentVariables: environmentVariables,
+      // Defense-in-depth: bound how long an Idle (leaked) session keeps a
+      // microVM alive. Event-driven sessions self-terminate after responding,
+      // but this reclaims any session left dangling. Idle is measured from when
+      // the agent stops processing, so it never cuts off an active invocation.
+      lifecycleConfiguration: {
+        idleRuntimeSessionTimeout: props.idleRuntimeSessionTimeout ?? cdk.Duration.seconds(300),
+      },
       // Enable Authorization header forwarding for JWT authentication
       // and Cognito ID Token forwarding for Identity Pool credential exchange.
       requestHeaderConfiguration: {
@@ -429,6 +453,20 @@ export class AgentCoreRuntime extends Construct {
           `arn:aws:bedrock-agentcore:${region}:${account}:browser/*`,
           `arn:aws:bedrock-agentcore:${region}:aws:browser/*`, // AWS Managed Browser
         ],
+      })
+    );
+
+    // Self-termination: event-driven sessions stop their own microVM after
+    // responding (see packages/agent/src/services/session-terminator.ts) by
+    // calling StopRuntimeSession. Scoped to this account's runtimes; the ARN is
+    // a wildcard because the runtime cannot reference its own ARN at synth time
+    // without creating a CloudFormation circular dependency.
+    this.runtime.addToRolePolicy(
+      new iam.PolicyStatement({
+        sid: 'BedrockAgentCoreStopRuntimeSession',
+        effect: iam.Effect.ALLOW,
+        actions: ['bedrock-agentcore:StopRuntimeSession'],
+        resources: [`arn:aws:bedrock-agentcore:${region}:${account}:runtime/*`],
       })
     );
 

--- a/packages/trigger/src/services/agent-invoker.ts
+++ b/packages/trigger/src/services/agent-invoker.ts
@@ -109,6 +109,10 @@ export class AgentInvoker {
       'Prompt preparation'
     );
 
+    // Session hygiene: reuse the trigger's sessionId only when one was
+    // explicitly configured (e.g. a trigger that intentionally continues a
+    // conversation). Otherwise mint a fresh id per invocation so a new run
+    // never collides with a still-releasing session from a previous run.
     const sessionId = payload.sessionId || generateSessionId();
 
     return {


### PR DESCRIPTION
## Summary

Fixes #23 — AgentCore Runtime containers were not released after trigger-based (async) invocations, causing idle container retention and disproportionate memory-based billing.

Event-driven (scheduled / custom-event) invocations are fire-and-forget: the Trigger Lambda sends the request and returns immediately without consuming the NDJSON stream. Nothing on the client side ever tells AgentCore Runtime that the session is done, so the microVM lingered in an **Idle** state until the default idle timeout (900s / 15 min) elapsed — billing memory the entire time. The interactive chat path is unaffected because the frontend reads the stream to completion and the session is intentionally kept warm for follow-up turns.

## Root cause clarification

The original issue hypothesized that the missing `response.body.cancel()` caused a TCP RST that left the session "dangling." After reviewing the [AgentCore Runtime session lifecycle docs](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-sessions.html), the **Active/Idle state is determined by server-side processing (invocation tracking + `/ping` `HealthyBusy`), not by the client HTTP connection state**. So once processing ends the session goes Idle regardless — and then waits out the full idle timeout before the microVM is reclaimed. The real lever is to stop the session explicitly once event-driven work is done. (Investigation details posted on #23.)

## Changes — three layers of defense

### 1. Self-termination (primary)
`packages/agent/src/services/session-terminator.ts` (new)
- After `streamAgentResponse` has fully written and ended the response, an **`event`-typed** session calls `StopRuntimeSession` on itself to release the microVM immediately.
- Its own Runtime ARN is recovered from the platform-injected `AGENTCORE_RUNTIME_URL` (decoded from the `/runtimes/<url-encoded-arn>/invocations` path). This avoids the CloudFormation **circular dependency** that would arise from feeding `runtime.agentRuntimeArn` (a `GetAtt`) back into the same resource's `environmentVariables`.
- Runs **only after `res.end()`** (stopping a session also stops any ongoing stream), and **only for `sessionType === 'event'`** — chat sessions stay warm so follow-up turns reuse context.
- Best-effort: any failure (missing ARN / IAM / throttling) is logged and swallowed; the idle timeout is the backstop.

### 2. Idle timeout backstop
`packages/cdk/lib/constructs/agentcore/agentcore-runtime.ts`
- Sets `lifecycleConfiguration.idleRuntimeSessionTimeout = 300s` (down from the 900s platform default), overridable via a new optional prop. Idle is measured from when the agent stops processing, so this never interrupts an in-flight invocation.

### 3. IAM
`packages/cdk/lib/constructs/agentcore/agentcore-runtime.ts`
- Grants the execution role `bedrock-agentcore:StopRuntimeSession`, scoped to `arn:aws:bedrock-agentcore:<region>:<account>:runtime/*`.

### Session hygiene
`packages/trigger/src/services/agent-invoker.ts`
- The existing `payload.sessionId || generateSessionId()` already mints a fresh id per invocation unless the trigger explicitly configured one (conversation continuation). Added a comment clarifying the intent.

## Testing

- `packages/agent`: **394 unit tests pass** (incl. 7 new `session-terminator` tests covering ARN extraction, success, missing-ARN skip, and swallowed-failure paths).
- `packages/trigger`: 19 tests pass.
- Type-check (agent / trigger / cdk): clean.
- ESLint on changed files: clean.
- `cdk synth`: succeeds with **no circular dependency**; generated template confirmed to contain `IdleRuntimeSessionTimeout: 300` and the `StopRuntimeSession` IAM statement.

## Expected behavior

After a trigger-based invocation completes, the microVM is released promptly via self-termination (comparable responsiveness to the chat path's natural close), so memory-based billing stops shortly after processing ends and the memory-to-CPU ratio returns to a normal range. If self-termination ever fails, the 300s idle timeout reclaims the container.