### PR TITLE
docs(cdk): document GSI2 in TriggersTable structure comment

### DIFF
--- a/packages/cdk/lib/constructs/storage/triggers-table.ts
+++ b/packages/cdk/lib/constructs/storage/triggers-table.ts
@@ -26,9 +26,13 @@ export interface TriggersTableProps {
  * - PK: TRIGGER#{userId} or TRIGGER#{triggerId}
  * - SK: TRIGGER#{triggerId} or EXECUTION#{executionId}
  *
- * GSI1:
+ * GSI1 (query triggers by type):
  * - GSI1PK: TYPE#{type}
  * - GSI1SK: USER#{userId}#{triggerId}
+ *
+ * GSI2 (query triggers by eventSourceId — event subscription model):
+ * - GSI2PK: EVENTSOURCE#{eventSourceId}
+ * - GSI2SK: USER#{userId}#TRIGGER#{triggerId}
  *
  * TTL: enabled on 'ttl' attribute for automatic cleanup of execution history
  */


### PR DESCRIPTION
## What

The `TriggersTable` CDK construct's header doc comment describes the table structure (PK/SK, **GSI1**, TTL) but **omits GSI2**, even though the construct actually creates GSI2 a few lines below (with an inline comment: *"Add GSI2 for querying triggers by eventSourceId (event subscription model)"*).

This is a comment-vs-implementation drift: the *implementation is correct*; the *structure documentation is stale/incomplete*. Per policy, the comment is fixed to match the implementation.

## Change

Add GSI2 to the structure block comment, documenting its keys to match what the backend repository actually writes:

```
GSI2 (query triggers by eventSourceId — event subscription model):
- GSI2PK: EVENTSOURCE#{eventSourceId}
- GSI2SK: USER#{userId}#TRIGGER#{triggerId}
```

## Verification

Key formats verified against `packages/backend/src/repositories/triggers/dynamodb/item.ts`:
- `keys.GSI2PK = \`EVENTSOURCE#\${trigger.eventConfig.eventSourceId}\``
- `keys.GSI2SK = \`USER#\${trigger.userId}#TRIGGER#\${trigger.id}\``

Comment-only change; no behavioral impact.

---
🤖 Filed by the scheduled code-comment alignment job (category: `cdk`).