### PR TITLE
feat: add Claude Fable 5 to Bedrock model registry

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -122,6 +122,19 @@ aws secretsmanager create-secret \
 
 ローカル開発の場合は、`packages/agent/.env`で環境変数として設定することもできます。
 
+<details>
+<summary><strong>⚠️ Claude Fable 5 を利用するにはデータ保持設定が必要</strong></summary>
+
+デフォルトモデルは **Claude Opus 4.8** で、追加設定なしで利用できます。**Claude Fable 5**（`global.anthropic.claude-fable-5`）も選択可能なモデルとして用意していますが、これは Mythos クラスのモデルです。Mythos クラスのモデルは、呼び出し先リージョンにおいて Amazon Bedrock の **データ保持モードが `provider_data_share` に設定されている場合のみ** 呼び出せます。デフォルトのモードのままだと、Fable 5 へのすべてのリクエストが次のエラーで失敗します。
+
+```
+ValidationException: data retention mode 'default' is not available for this model
+```
+
+これはアカウント／リージョン単位の Bedrock 設定であり、リクエスト単位で回避することはできません。Fable 5 を利用する場合は、デプロイする**各リージョン**（例: `ap-northeast-1`）で `provider_data_share` を有効化してください。設定方法は [Amazon Bedrock — データ保持](https://docs.aws.amazon.com/bedrock/latest/userguide/data-retention.html) を参照してください。デフォルトの Opus 4.8 を含む他のモデルには影響ありません。
+
+</details>
+
 #### 3. CDKのブートストラップ（初回のみ）
 
 初回デプロイ時のみ、CDKのブートストラップを実行します。

--- a/README-ja.md
+++ b/README-ja.md
@@ -131,7 +131,21 @@ aws secretsmanager create-secret \
 ValidationException: data retention mode 'default' is not available for this model
 ```
 
-これはアカウント／リージョン単位の Bedrock 設定であり、リクエスト単位で回避することはできません。Fable 5 を利用する場合は、デプロイする**各リージョン**（例: `ap-northeast-1`）で `provider_data_share` を有効化してください。設定方法は [Amazon Bedrock — データ保持](https://docs.aws.amazon.com/bedrock/latest/userguide/data-retention.html) を参照してください。デフォルトの Opus 4.8 を含む他のモデルには影響ありません。
+これはアカウント／リージョン単位の Bedrock 設定であり、リクエスト単位で回避することはできません。Fable 5 を利用するには2つの方法があります。
+
+1. **デプロイ先リージョンで `provider_data_share` を有効化する**（推奨）。設定方法は [Amazon Bedrock — データ保持](https://docs.aws.amazon.com/bedrock/latest/userguide/data-retention.html) を参照してください。コード変更なしで、デプロイ先リージョンで Fable 5 が使えるようになります。
+2. **`provider_data_share` が有効な別リージョン（例: `us-east-1`）に Fable 5 をピンする**。デプロイ先で有効化できない場合の方法です。これは環境固有の設定なので、出荷時のデフォルトではなく利用者の設定に置きます。`packages/cdk/config/environments.ts` で対象環境の `bedrockModels` を上書きし、`packages/libs/core/src/bedrock-models.ts`（`BEDROCK_MODEL_DEFINITIONS`）の同じモデルにも同じ `region` を設定してください（エージェントの呼び出し先とIAM許可の両方を同じリージョンに揃えるため）。
+
+   ```typescript
+   // packages/cdk/config/environments.ts — 例: default 環境
+   bedrockModels: [
+     { id: 'global.anthropic.claude-opus-4-8', name: 'Claude Opus 4.8', provider: 'Anthropic' },
+     { id: 'global.anthropic.claude-fable-5', name: 'Claude Fable 5', provider: 'Anthropic', region: 'us-east-1' },
+     // …その他のモデル…
+   ],
+   ```
+
+デフォルトの Opus 4.8 を含む他のモデルには影響ありません。
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,19 @@ This secret is used to verify HMAC-SHA256 signatures on incoming GitHub webhooks
 
 For local development, you can also set these as environment variables in `packages/agent/.env`.
 
+<details>
+<summary><strong>⚠️ Data Retention required to use Claude Fable 5</strong></summary>
+
+The default model is **Claude Opus 4.8**, which works out of the box. **Claude Fable 5** (`global.anthropic.claude-fable-5`) is also available as a selectable option, but it is a Mythos-class model: Mythos-class models can **only** be invoked when your account's Amazon Bedrock **Data Retention mode is set to `provider_data_share`** in the invocation region. With the default mode, every Fable 5 request fails with:
+
+```
+ValidationException: data retention mode 'default' is not available for this model
+```
+
+This is an account/region-level Bedrock setting — it cannot be worked around per-request. If you want to use Fable 5, enable `provider_data_share` in **each region you deploy to** (e.g. `ap-northeast-1`). See [Amazon Bedrock — Data retention](https://docs.aws.amazon.com/bedrock/latest/userguide/data-retention.html) for how to configure it. Other models (including the default Opus 4.8) are unaffected.
+
+</details>
+
 #### 3. Bootstrap CDK (first time only)
 
 For the first deployment, run CDK bootstrap.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,21 @@ The default model is **Claude Opus 4.8**, which works out of the box. **Claude F
 ValidationException: data retention mode 'default' is not available for this model
 ```
 
-This is an account/region-level Bedrock setting — it cannot be worked around per-request. If you want to use Fable 5, enable `provider_data_share` in **each region you deploy to** (e.g. `ap-northeast-1`). See [Amazon Bedrock — Data retention](https://docs.aws.amazon.com/bedrock/latest/userguide/data-retention.html) for how to configure it. Other models (including the default Opus 4.8) are unaffected.
+This is an account/region-level Bedrock setting — it cannot be worked around per-request. To use Fable 5 you have two options:
+
+1. **Enable `provider_data_share` in your deployment region** (recommended). See [Amazon Bedrock — Data retention](https://docs.aws.amazon.com/bedrock/latest/userguide/data-retention.html). Fable 5 then works in the region you deploy to, with no code changes.
+2. **Pin Fable 5 to a region that already has `provider_data_share`** (e.g. `us-east-1`) if you can't enable it in your deploy region. This is environment-specific, so it lives in your config — not in the shipped defaults. Override `bedrockModels` for your environment in `packages/cdk/config/environments.ts` and set a matching `region` on the same model in `packages/libs/core/src/bedrock-models.ts` (`BEDROCK_MODEL_DEFINITIONS`) so the agent and its IAM grant both target that region:
+
+   ```typescript
+   // packages/cdk/config/environments.ts — e.g. for the `default` environment
+   bedrockModels: [
+     { id: 'global.anthropic.claude-opus-4-8', name: 'Claude Opus 4.8', provider: 'Anthropic' },
+     { id: 'global.anthropic.claude-fable-5', name: 'Claude Fable 5', provider: 'Anthropic', region: 'us-east-1' },
+     // …other models…
+   ],
+   ```
+
+Other models (including the default Opus 4.8) are unaffected by all of this.
 
 </details>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25870,6 +25870,7 @@
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
         "pino-pretty": "^13.1.3",
+        "testcontainers": "^12.0.1",
         "tsx": "^4.6.0"
       },
       "engines": {
@@ -27523,6 +27524,7 @@
       "name": "@moca/core",
       "version": "0.1.0",
       "devDependencies": {
+        "@aws-sdk/client-bedrock-runtime": "^3.1051.0",
         "vitest": "^4.1.8"
       }
     },

--- a/packages/agent/jest.integration.config.js
+++ b/packages/agent/jest.integration.config.js
@@ -8,6 +8,7 @@ export default {
   testMatch: [
     '**/tests/developer-auth-identity.integration.test.ts',
     '**/__tests__/qwen3-model.integration.test.ts',
+    '**/__tests__/fable5-reasoning.integration.test.ts',
   ],
   testPathIgnorePatterns: ['/node_modules/'],
   testTimeout: 60000,

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -34,6 +34,7 @@ import { extractMemoryParams, fetchLongTermMemories } from './runtime/agent/memo
 import { loadSessionHistory } from './runtime/agent/session-loader.js';
 import { StreamTerminationRetryStrategy } from './runtime/agent/stream-termination-retry-strategy.js';
 import { EmptyTextBlockHook } from './services/session/empty-text-block-hook.js';
+import { EmptyReasoningBlockHook } from './services/session/empty-reasoning-block-hook.js';
 
 import type { CreateAgentOptions, CreateAgentResult } from './runtime/agent/types.js';
 
@@ -113,11 +114,19 @@ export async function createAgent(options?: CreateAgentOptions): Promise<CreateA
     systemPrompt,
     tools: [...toolSet.tools, ...toolSet.mcpClients],
     messages: savedMessages,
-    // EmptyTextBlockHook is registered first so it sanitizes assistant messages
-    // (stripping the empty leading TextBlock that Qwen3 emits before a toolUse)
-    // before any caller-supplied plugin observes them. Harmless no-op for models
-    // that don't emit empty blocks (e.g. Claude). See empty-text-block-hook.ts.
-    plugins: [new EmptyTextBlockHook(), ...(options?.plugins ?? [])],
+    // Sanitizer hooks run first so they clean assistant messages before any
+    // caller-supplied plugin observes them. Both are harmless no-ops for models
+    // that don't emit the offending blocks:
+    //   - EmptyTextBlockHook strips the empty leading TextBlock Qwen3 emits
+    //     before a toolUse (see empty-text-block-hook.ts).
+    //   - EmptyReasoningBlockHook strips the empty-text reasoning block Fable 5
+    //     (Mythos-class, adaptive thinking) emits, which the SDK formatter would
+    //     otherwise reject on the next turn (see empty-reasoning-block-hook.ts).
+    plugins: [
+      new EmptyTextBlockHook(),
+      new EmptyReasoningBlockHook(),
+      ...(options?.plugins ?? []),
+    ],
     conversationManager,
     id: options?.agentId,
     traceAttributes,

--- a/packages/agent/src/services/session/__tests__/empty-reasoning-block-hook.test.ts
+++ b/packages/agent/src/services/session/__tests__/empty-reasoning-block-hook.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for EmptyReasoningBlockHook.
+ *
+ * Reproduces the Fable 5 failure mode: an assistant message carrying a
+ * reasoning block whose `text` is the empty string (signature only, no
+ * redactedContent). On the next turn the SDK BedrockModel formatter rejects it
+ * with "reasoning content format incorrect. Either 'text' or 'redactedContent'
+ * must be set.", so the hook must strip it before it re-enters history.
+ */
+
+import { describe, it, expect, jest } from '@jest/globals';
+import {
+  Message,
+  TextBlock,
+  ReasoningBlock,
+  MessageAddedEvent,
+  type LocalAgent,
+  type HookableEvent,
+} from '@strands-agents/sdk';
+import { EmptyReasoningBlockHook } from '../empty-reasoning-block-hook.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type Handler = (event: HookableEvent) => void;
+
+function captureHandler(hook: EmptyReasoningBlockHook): Handler {
+  let handler: Handler | undefined;
+  const fakeAgent = {
+    addHook: (_eventType: unknown, callback: Handler) => {
+      handler = callback;
+      return () => {};
+    },
+  } as unknown as LocalAgent;
+
+  hook.initAgent(fakeAgent);
+  if (!handler) {
+    throw new Error('Hook did not register a MessageAddedEvent callback');
+  }
+  return handler;
+}
+
+function fire(handler: Handler, message: Message): void {
+  handler(
+    new MessageAddedEvent({
+      agent: {} as unknown as LocalAgent,
+      message,
+      invocationState: {} as never,
+    })
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('EmptyReasoningBlockHook', () => {
+  it('strips an empty-text reasoning block that precedes the answer (Fable 5 case)', () => {
+    const handler = captureHandler(new EmptyReasoningBlockHook());
+    // Fable 5 shape: reasoning with text '' + a signature, then the real answer.
+    const reasoning = new ReasoningBlock({ text: '', signature: 'CAIS-sig' });
+    const text = new TextBlock('17 × 23 = 391');
+    const message = new Message({ role: 'assistant', content: [reasoning, text] });
+
+    fire(handler, message);
+
+    expect(message.content).toHaveLength(1);
+    expect(message.content[0]).toBe(text);
+  });
+
+  it('preserves a reasoning block that has non-empty text', () => {
+    const handler = captureHandler(new EmptyReasoningBlockHook());
+    const reasoning = new ReasoningBlock({ text: 'Let me think: 17×23…', signature: 'sig' });
+    const text = new TextBlock('391');
+    const message = new Message({ role: 'assistant', content: [reasoning, text] });
+
+    fire(handler, message);
+
+    expect(message.content).toHaveLength(2);
+    expect(message.content[0]).toBe(reasoning);
+  });
+
+  it('preserves a reasoning block carrying redactedContent (no text)', () => {
+    const handler = captureHandler(new EmptyReasoningBlockHook());
+    const reasoning = new ReasoningBlock({ redactedContent: new Uint8Array([1, 2, 3]) });
+    const text = new TextBlock('answer');
+    const message = new Message({ role: 'assistant', content: [reasoning, text] });
+
+    fire(handler, message);
+
+    expect(message.content).toHaveLength(2);
+    expect(message.content[0]).toBe(reasoning);
+  });
+
+  it('does not empty out a message made up solely of empty reasoning blocks', () => {
+    const handler = captureHandler(new EmptyReasoningBlockHook());
+    const message = new Message({
+      role: 'assistant',
+      content: [new ReasoningBlock({ text: '', signature: 's1' })],
+    });
+
+    fire(handler, message);
+
+    // Never produce empty `content` — Bedrock rejects that too.
+    expect(message.content.length).toBeGreaterThan(0);
+  });
+
+  it('ignores user messages', () => {
+    const handler = captureHandler(new EmptyReasoningBlockHook());
+    const message = new Message({
+      role: 'user',
+      content: [new TextBlock('hello')],
+    });
+
+    fire(handler, message);
+
+    expect(message.content).toHaveLength(1);
+  });
+
+  it('is a no-op for a normal assistant text message (Opus case)', () => {
+    const handler = captureHandler(new EmptyReasoningBlockHook());
+    const text = new TextBlock('All done.');
+    const message = new Message({ role: 'assistant', content: [text] });
+
+    fire(handler, message);
+
+    expect(message.content).toHaveLength(1);
+    expect(message.content[0]).toBe(text);
+  });
+
+  it('registers a callback during initAgent', () => {
+    const hook = new EmptyReasoningBlockHook();
+    const addHook = jest.fn(() => () => {});
+    hook.initAgent({ addHook } as unknown as LocalAgent);
+    expect(addHook).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/agent/src/services/session/__tests__/fable5-reasoning.integration.test.ts
+++ b/packages/agent/src/services/session/__tests__/fable5-reasoning.integration.test.ts
@@ -20,7 +20,9 @@
  * the real Bedrock Converse / ConverseStream API, so it requires:
  *   - AWS credentials with bedrock:InvokeModelWithResponseStream on Fable 5
  *   - Fable 5's data-retention prerequisite satisfied in the invocation region
- *     (provider_data_share). The registry pins Fable 5 to us-east-1.
+ *     (provider_data_share). Fable 5 is invoked in BEDROCK_REGION (no registry
+ *     region pin in the OSS default), so point BEDROCK_REGION at a region where
+ *     provider_data_share is enabled.
  *
  * Run:
  *   cd packages/agent

--- a/packages/agent/src/services/session/__tests__/fable5-reasoning.integration.test.ts
+++ b/packages/agent/src/services/session/__tests__/fable5-reasoning.integration.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Claude Fable 5 — reasoning round-trip regression (integration).
+ *
+ * Reproduces the production failure:
+ *
+ *   reasoning content format incorrect. Either 'text' or 'redactedContent' must be set.
+ *
+ * Root cause: Fable 5 (Mythos-class) has adaptive thinking always ON and emits a
+ * reasoning block whose `reasoningText.text` is the EMPTY string `''` (only a
+ * `signature` is present). When that assistant turn re-enters the conversation
+ * history and is sent back on the NEXT turn, the Strands SDK's BedrockModel
+ * formats it with `if (block.text) { … } else if (block.redactedContent) { … }
+ * else throw`. Empty string is falsy, so a `text === ''` reasoning block matches
+ * neither branch and the SDK throws before the request even reaches Bedrock.
+ *
+ * This is the reasoning-block analogue of the empty-TextBlock problem that
+ * EmptyTextBlockHook already fixes for Qwen3 (see empty-text-block-hook.ts).
+ *
+ * The suite is OPT-IN: set RUN_BEDROCK_FABLE_INTEGRATION=1 to run it. It calls
+ * the real Bedrock Converse / ConverseStream API, so it requires:
+ *   - AWS credentials with bedrock:InvokeModelWithResponseStream on Fable 5
+ *   - Fable 5's data-retention prerequisite satisfied in the invocation region
+ *     (provider_data_share). The registry pins Fable 5 to us-east-1.
+ *
+ * Run:
+ *   cd packages/agent
+ *   RUN_BEDROCK_FABLE_INTEGRATION=1 \
+ *     npm run test:integration -- fable5-reasoning
+ */
+
+import { it, expect } from '@jest/globals';
+import { Agent, SlidingWindowConversationManager } from '@strands-agents/sdk';
+import { createBedrockModel } from '../../../config/bedrock.js';
+import { EmptyReasoningBlockHook } from '../empty-reasoning-block-hook.js';
+import { describeIfEnv } from '../../../tests/integration-helpers.js';
+
+const FABLE_5 = 'global.anthropic.claude-fable-5';
+
+const describeFable5 = describeIfEnv(['RUN_BEDROCK_FABLE_INTEGRATION'], 'Fable 5 reasoning integration');
+
+/** Extract text from a message's content blocks. */
+function textOf(message: { content: unknown[] }): string {
+  return message.content
+    .filter((b) => (b as { type: string }).type === 'textBlock')
+    .map((b) => (b as { text?: string }).text || '')
+    .join('');
+}
+
+/** Drive the agent via streaming to completion. */
+async function streamAll(agent: Agent, prompt: string): Promise<void> {
+  // Drain the stream; the events themselves are not asserted here.
+  for await (const _event of agent.stream(prompt)) {
+    void _event;
+  }
+}
+
+/** True if the assistant turn carries a reasoning block with empty/absent text. */
+function hasEmptyReasoningBlock(message: { content: unknown[] }): boolean {
+  return message.content.some((b) => {
+    const block = b as { type?: string; text?: string; redactedContent?: unknown };
+    return (
+      block.type === 'reasoningBlock' &&
+      (block.text === undefined || block.text === '') &&
+      !block.redactedContent
+    );
+  });
+}
+
+describeFable5('Claude Fable 5 reasoning round-trip', () => {
+  it('completes a multi-turn conversation without the "reasoning content format incorrect" error', async () => {
+    const agent = new Agent({
+      model: createBedrockModel({ modelId: FABLE_5 }),
+      systemPrompt: 'Be concise. Show brief reasoning before answering.',
+      tools: [],
+      // Mirror production wiring (agent.ts always registers this hook). Without
+      // it, Fable 5's empty-text reasoning block makes the turn-2 follow-up
+      // request fail with the SDK formatter's "reasoning content format
+      // incorrect" error.
+      plugins: [new EmptyReasoningBlockHook()],
+      conversationManager: new SlidingWindowConversationManager({ windowSize: 20 }),
+    });
+
+    // Turn 1: a prompt that elicits reasoning. Fable 5 commonly returns a
+    // reasoning block whose text is '' (signature only).
+    await streamAll(agent, 'What is 17 multiplied by 23? Think first, then answer.');
+
+    // Turn 2: re-sends the turn-1 assistant message (incl. the reasoning block)
+    // back to Bedrock. Without the fix the SDK throws while formatting the
+    // empty-text reasoning block, before the request is sent.
+    await expect(
+      streamAll(agent, 'Now multiply that result by 2.')
+    ).resolves.toBeUndefined();
+
+    expect(textOf(agent.messages[agent.messages.length - 1])).toMatch(/782/);
+  }, 120_000);
+
+  it('strips empty reasoning blocks from history so they are never re-sent', async () => {
+    const agent = new Agent({
+      model: createBedrockModel({ modelId: FABLE_5 }),
+      systemPrompt: 'Be concise. Show brief reasoning before answering.',
+      tools: [],
+      plugins: [new EmptyReasoningBlockHook()],
+      conversationManager: new SlidingWindowConversationManager({ windowSize: 20 }),
+    });
+
+    await streamAll(agent, 'What is 17 multiplied by 23? Think first, then answer.');
+
+    // After the turn settles, no assistant message should retain a reasoning
+    // block with empty/absent text and no redactedContent — that is exactly the
+    // shape the SDK formatter rejects on the next turn.
+    const offenders = agent.messages
+      .filter((m) => m.role === 'assistant')
+      .filter((m) => hasEmptyReasoningBlock(m));
+    expect(offenders).toHaveLength(0);
+  }, 120_000);
+});

--- a/packages/agent/src/services/session/empty-reasoning-block-hook.ts
+++ b/packages/agent/src/services/session/empty-reasoning-block-hook.ts
@@ -1,0 +1,110 @@
+/**
+ * Empty Reasoning Block Hook
+ *
+ * Strips empty reasoning blocks from assistant messages before they re-enter the
+ * conversation history.
+ *
+ * Why this is needed:
+ * Claude Fable 5 (and other Mythos-class models) have adaptive thinking always
+ * ON and sometimes emit a `reasoningBlock` whose `text` is the EMPTY string `''`
+ * (only a `signature` is present, with no reasoning text and no redactedContent):
+ *
+ *   content: [
+ *     { type: 'reasoningBlock', text: '', signature: 'CAIS…' },
+ *     { type: 'textBlock', text: '…the answer…' },
+ *   ]
+ *
+ * The first request succeeds, but on the FOLLOW-UP request — after this assistant
+ * turn re-enters history and the whole conversation is sent back — the Strands
+ * SDK's BedrockModel formats the reasoning block with:
+ *
+ *   if (block.text) { … reasoningText … }
+ *   else if (block.redactedContent) { … redactedContent … }
+ *   else throw Error("reasoning content format incorrect. Either 'text' or 'redactedContent' must be set.")
+ *
+ * An empty string is falsy, so a `text === ''` reasoning block matches neither
+ * branch and the SDK throws before the request reaches Bedrock — surfacing as:
+ *
+ *   [SYSTEM_ERROR] ModelError: reasoning content format incorrect.
+ *   Either 'text' or 'redactedContent' must be set.
+ *
+ * Dropping the empty reasoning block is safe: it carries no reasoning text and no
+ * redactedContent, and the Bedrock Converse API does NOT require thinking blocks
+ * to be preserved across turns (verified live, including across a tool-use turn).
+ * This is the reasoning-block analogue of EmptyTextBlockHook.
+ *
+ * Models that do not emit empty reasoning blocks are unaffected — the hook is a
+ * harmless no-op. It only removes a reasoning block when other content blocks
+ * remain, so an assistant message is never left with empty `content`.
+ */
+
+import { MessageAddedEvent } from '@strands-agents/sdk';
+import type { Plugin, LocalAgent, Message } from '@strands-agents/sdk';
+import { logger } from '../../libs/logger/index.js';
+
+/**
+ * Returns true for a reasoning block the SDK BedrockModel would reject on the
+ * next turn: neither a non-empty `text` nor any `redactedContent`.
+ */
+function isEmptyReasoningBlock(block: Message['content'][number]): boolean {
+  if (block.type !== 'reasoningBlock') {
+    return false;
+  }
+  // `text` and `redactedContent` are both optional on a ReasoningBlock. The SDK
+  // formatter accepts the block only when `text` is truthy (non-empty) or
+  // `redactedContent` is present; mirror that test exactly.
+  const reasoning = block as { text?: string; redactedContent?: Uint8Array };
+  const hasText = typeof reasoning.text === 'string' && reasoning.text.length > 0;
+  const hasRedacted = reasoning.redactedContent != null && reasoning.redactedContent.length > 0;
+  return !hasText && !hasRedacted;
+}
+
+export class EmptyReasoningBlockHook implements Plugin {
+  readonly name = 'moca:empty-reasoning-block-hook';
+
+  /**
+   * Register hook callbacks on the agent.
+   * Called by the Agent's PluginRegistry during construction.
+   */
+  initAgent(agent: LocalAgent): void {
+    agent.addHook(MessageAddedEvent, (event) => this.onMessageAdded(event));
+  }
+
+  /**
+   * Strip empty reasoning blocks from assistant messages as they are added to
+   * history.
+   *
+   * Mutates `message.content` in place: the array reference is `readonly`, but
+   * its elements are not, so an in-place `splice` is the supported way to edit
+   * the assembled message before it is persisted / re-sent to the model.
+   */
+  private onMessageAdded(event: MessageAddedEvent): void {
+    const { message } = event;
+    if (message.role !== 'assistant') {
+      return;
+    }
+
+    const content = message.content;
+    // Only strip when at least one other block remains, so we never produce an
+    // assistant message with empty `content`.
+    const hasOtherContent = content.some((block) => !isEmptyReasoningBlock(block));
+    if (!hasOtherContent) {
+      return;
+    }
+
+    let removed = 0;
+    for (let i = content.length - 1; i >= 0; i--) {
+      if (isEmptyReasoningBlock(content[i])) {
+        content.splice(i, 1);
+        removed++;
+      }
+    }
+
+    if (removed > 0) {
+      logger.debug(
+        { removed, remaining: content.length },
+        '[EMPTY_REASONING_BLOCK_HOOK] Stripped empty reasoning block(s) from assistant message'
+      );
+    }
+  }
+}

--- a/packages/cdk/config/environment-types.ts
+++ b/packages/cdk/config/environment-types.ts
@@ -23,6 +23,23 @@ export interface BedrockModelConfig {
   name: string;
   /** Provider name */
   provider: 'Anthropic' | 'Amazon' | 'Qwen';
+  /**
+   * Optional invocation-region pin.
+   *
+   * Most models are invoked in the deployment region. Some must be invoked in a
+   * specific region (an In-Region-only model not yet rolled out everywhere, or a
+   * model whose account-level prerequisite — e.g. Bedrock Data Retention mode —
+   * is only enabled in certain regions). When set, the agent invokes this model
+   * in `region` (via @moca/core getModelRegion), and deriveBedrockIamResources()
+   * scopes the model's inference-profile IAM ARN to the SAME region so the call
+   * is authorized. Omit for models invoked in the deployment region (the common
+   * case).
+   *
+   * MUST be kept in sync with the `region` field of the matching entry in
+   * BEDROCK_MODEL_DEFINITIONS (packages/libs/core/src/bedrock-models.ts) — CDK
+   * does not import @moca/core, so the two lists are synced by hand.
+   */
+  region?: string;
 }
 
 /**

--- a/packages/cdk/config/environment-utils.test.ts
+++ b/packages/cdk/config/environment-utils.test.ts
@@ -1,4 +1,4 @@
-import { deriveBedrockIamResources } from './environment-utils';
+import { deriveBedrockIamResources, validateBedrockModelsForTest } from './environment-utils';
 
 const REGION = 'us-east-1';
 const ACCOUNT = '123456789012';
@@ -235,5 +235,119 @@ describe('deriveBedrockIamResources', () => {
     const result = deriveBedrockIamResources(models, REGION, customAccount);
 
     expect(result.find((r) => r.includes('inference-profile'))).toContain(customAccount);
+  });
+
+  // ── Per-model region pin ─────────────────────────────────────────────────────
+  //
+  // A model may pin its invocation region (BedrockModelConfig.region). The agent
+  // invokes that model in the pinned region (via @moca/core getModelRegion), so
+  // the inference-profile ARN MUST be scoped to the pinned region — not the
+  // deployment region — or bedrock:InvokeModelWithResponseStream is AccessDenied.
+  // Regression for the Fable 5 us-east-1 pin vs ap-northeast-1 deploy mismatch.
+
+  it('scopes the inference-profile ARN to a model.region pin instead of the deploy region', () => {
+    const models = [
+      {
+        id: 'global.anthropic.claude-fable-5',
+        name: 'Claude Fable 5',
+        provider: 'Anthropic' as const,
+        region: 'us-east-1',
+      },
+    ];
+    // Deploy region is ap-northeast-1, but the model is pinned to us-east-1.
+    const result = deriveBedrockIamResources(models, 'ap-northeast-1', ACCOUNT);
+
+    expect(result).toContain(
+      `arn:aws:bedrock:us-east-1:${ACCOUNT}:inference-profile/global.anthropic.claude-fable-5`
+    );
+    // The deploy-region ARN must NOT be produced — it would not match the call
+    // and the pinned-region ARN above is the only one the agent uses.
+    expect(result).not.toContain(
+      `arn:aws:bedrock:ap-northeast-1:${ACCOUNT}:inference-profile/global.anthropic.claude-fable-5`
+    );
+  });
+
+  it('falls back to the deploy region for the inference-profile ARN when no region pin is set', () => {
+    const models = [
+      {
+        id: 'global.anthropic.claude-fable-5',
+        name: 'Claude Fable 5',
+        provider: 'Anthropic' as const,
+      },
+    ];
+    const result = deriveBedrockIamResources(models, 'ap-northeast-1', ACCOUNT);
+
+    expect(result).toContain(
+      `arn:aws:bedrock:ap-northeast-1:${ACCOUNT}:inference-profile/global.anthropic.claude-fable-5`
+    );
+  });
+
+  it('keeps the foundation-model ARN region-wildcarded regardless of a region pin', () => {
+    const models = [
+      {
+        id: 'global.anthropic.claude-fable-5',
+        name: 'Claude Fable 5',
+        provider: 'Anthropic' as const,
+        region: 'us-east-1',
+      },
+    ];
+    const result = deriveBedrockIamResources(models, 'ap-northeast-1', ACCOUNT);
+
+    expect(result).toContain('arn:aws:bedrock:*::foundation-model/anthropic.claude-fable-5*');
+  });
+
+  it('uses each model’s own region pin when models pin different regions', () => {
+    const models = [
+      {
+        id: 'global.anthropic.claude-fable-5',
+        name: 'Claude Fable 5',
+        provider: 'Anthropic' as const,
+        region: 'us-east-1',
+      },
+      {
+        id: 'global.anthropic.claude-sonnet-4-6',
+        name: 'Claude Sonnet 4.6',
+        provider: 'Anthropic' as const,
+        region: 'us-west-2',
+      },
+    ];
+    const result = deriveBedrockIamResources(models, 'ap-northeast-1', ACCOUNT);
+
+    expect(result).toContain(
+      `arn:aws:bedrock:us-east-1:${ACCOUNT}:inference-profile/global.anthropic.claude-fable-5`
+    );
+    expect(result).toContain(
+      `arn:aws:bedrock:us-west-2:${ACCOUNT}:inference-profile/global.anthropic.claude-sonnet-4-6`
+    );
+  });
+});
+
+// Region-format validation surfaces at synth time via getEnvironmentConfig →
+// resolveConfig → validateBedrockModels. A malformed region pin should throw.
+describe('validateBedrockModels — region pin format', () => {
+  it('rejects a model whose region is not a valid AWS region token', () => {
+    const models = [
+      {
+        id: 'global.anthropic.claude-fable-5',
+        name: 'Claude Fable 5',
+        provider: 'Anthropic' as const,
+        region: 'US-East-1', // wrong: uppercase / not a region token
+      },
+    ];
+    expect(() => deriveBedrockIamResources(models, REGION, ACCOUNT)).not.toThrow();
+    // Validation lives on the config path; assert there via the exported guard.
+    expect(() => validateBedrockModelsForTest(models)).toThrow(/region/i);
+  });
+
+  it('accepts a model with a well-formed region pin', () => {
+    const models = [
+      {
+        id: 'global.anthropic.claude-fable-5',
+        name: 'Claude Fable 5',
+        provider: 'Anthropic' as const,
+        region: 'ap-northeast-1',
+      },
+    ];
+    expect(() => validateBedrockModelsForTest(models)).not.toThrow();
   });
 });

--- a/packages/cdk/config/environment-utils.ts
+++ b/packages/cdk/config/environment-utils.ts
@@ -24,6 +24,10 @@ const INFERENCE_PROFILE_STRIP = /^(global|us|eu|apac|jp)\./;
  * NOTE: Nova Reel async-invoke resources are intentionally excluded here.
  * Nova Reel is executed exclusively by the Gateway Target Lambda (NovaReelToolsTarget),
  * which manages its own IAM policy with async-invoke permissions.
+ *
+ * @param region The DEPLOYMENT region — used for any model that does not pin its
+ *   own region. A model with `region` set overrides this for its inference-profile
+ *   ARN so the grant matches the region the agent actually invokes it in.
  */
 export function deriveBedrockIamResources(
   models: BedrockModelConfig[],
@@ -37,10 +41,15 @@ export function deriveBedrockIamResources(
     // global.*, us.*, etc.). In-Region models (e.g. qwen.*) have no inference
     // profile, so we skip this ARN to keep the IAM policy least-privilege.
     if (INFERENCE_PROFILE_STRIP.test(model.id)) {
-      resources.push(`arn:aws:bedrock:${region}:${account}:inference-profile/${model.id}`);
+      // A region-pinned model is invoked in model.region (via @moca/core
+      // getModelRegion), so the inference-profile ARN MUST be scoped to that
+      // region — not the deployment region — or InvokeModel is AccessDenied.
+      const profileRegion = model.region ?? region;
+      resources.push(`arn:aws:bedrock:${profileRegion}:${account}:inference-profile/${model.id}`);
     }
 
     // Foundation model ARN (strip inference profile prefix for direct access).
+    // Region-wildcarded, so a region pin needs no change here.
     // For bare In-Region IDs this is the only resource needed.
     const baseId = model.id.replace(INFERENCE_PROFILE_STRIP, '');
     resources.push(`arn:aws:bedrock:*::foundation-model/${baseId}*`);
@@ -70,13 +79,29 @@ const DEFAULT_CONFIG = {
   /**
    * CDK intentionally does not depend on @moca/core to keep infrastructure free
    * of runtime library dependencies. Keep this list in sync with
-   * BEDROCK_MODEL_DEFINITIONS in packages/libs/core/src/bedrock-models.ts.
-   * (validateBedrockModels() enforces id/name/provider shape at synth time.)
+   * BEDROCK_MODEL_DEFINITIONS in packages/libs/core/src/bedrock-models.ts —
+   * including the optional `region` pin: if a model sets `region` there it must
+   * set the SAME `region` here, because deriveBedrockIamResources() uses it to
+   * scope the inference-profile IAM ARN. An out-of-sync region pin grants the
+   * wrong-region ARN and the agent's invocation fails with AccessDenied.
+   * (validateBedrockModels() enforces id/name/provider/region shape at synth time.)
    */
   bedrockModels: [
     {
+      // Default model. No account-level prerequisite, so it works out of the box.
       id: 'global.anthropic.claude-opus-4-8',
       name: 'Claude Opus 4.8',
+      provider: 'Anthropic',
+    },
+    {
+      // Requires Bedrock Data Retention mode `provider_data_share` in the
+      // deployment region — see the registry note in
+      // packages/libs/core/src/bedrock-models.ts and the README. Invoked in the
+      // deployment region (no region pin), so deriveBedrockIamResources() scopes
+      // the inference-profile IAM ARN to the deploy region. Keep in sync with
+      // BEDROCK_MODEL_DEFINITIONS.
+      id: 'global.anthropic.claude-fable-5',
+      name: 'Claude Fable 5',
       provider: 'Anthropic',
     },
     {
@@ -119,6 +144,13 @@ const VALID_PROVIDERS: readonly string[] = ['Anthropic', 'Amazon', 'Qwen'];
  * typos / unqualified IDs rather than enforcing a specific inference profile prefix.
  */
 const NAMESPACED_MODEL_ID = /^([a-z0-9-]+\.)+[a-z0-9][a-z0-9.:_-]*$/;
+
+/**
+ * AWS region token, e.g. `us-east-1`, `ap-northeast-1`, `eu-central-1`.
+ * Lowercase only; guards a model's optional `region` pin against typos like
+ * `US-East-1` that would silently produce an unmatched IAM ARN.
+ */
+const AWS_REGION_TOKEN = /^[a-z]{2}-[a-z]+-\d+$/;
 
 /**
  * Cognito domain prefix regex.
@@ -184,7 +216,22 @@ function validateBedrockModels(models: BedrockModelConfig[], env: Environment): 
         `[${env}] bedrockModels: invalid provider "${model.provider}" for model "${model.id}". Must be one of: ${VALID_PROVIDERS.join(', ')}`
       );
     }
+    if (model.region !== undefined && !AWS_REGION_TOKEN.test(model.region)) {
+      throw new Error(
+        `[${env}] bedrockModels: invalid region "${model.region}" for model "${model.id}". ` +
+          `Must be a lowercase AWS region token (e.g. "us-east-1", "ap-northeast-1").`
+      );
+    }
   }
+}
+
+/**
+ * Test-only wrapper around the private validateBedrockModels(). Lets unit tests
+ * assert validation behavior (e.g. region-pin format) without going through the
+ * full getEnvironmentConfig() path. Not used by production code.
+ */
+export function validateBedrockModelsForTest(models: BedrockModelConfig[]): void {
+  validateBedrockModels(models, 'default');
 }
 
 /**

--- a/packages/cdk/config/environment-utils.ts
+++ b/packages/cdk/config/environment-utils.ts
@@ -94,18 +94,18 @@ const DEFAULT_CONFIG = {
       provider: 'Anthropic',
     },
     {
-      // Requires Bedrock Data Retention mode `provider_data_share`, which is
-      // enabled in us-east-1 but not in the default deploy region
-      // (ap-northeast-1) — see the registry note in
-      // packages/libs/core/src/bedrock-models.ts and the README. Pinned to
-      // us-east-1 to match BEDROCK_MODEL_DEFINITIONS; this region MUST stay in
-      // sync with the core registry so deriveBedrockIamResources() scopes the
-      // inference-profile IAM ARN to the region the agent actually invokes in
-      // (otherwise InvokeModelWithResponseStream is AccessDenied).
+      // Requires Bedrock Data Retention mode `provider_data_share` in the
+      // deployment region — see the registry note in
+      // packages/libs/core/src/bedrock-models.ts and the README. No region pin
+      // in this OSS default: Fable 5 is invoked in the deploy region, so
+      // deriveBedrockIamResources() scopes its inference-profile IAM ARN to the
+      // deploy region. If your deploy region cannot enable provider_data_share,
+      // pin Fable 5 to a region that has it by overriding bedrockModels (with a
+      // `region`) for your environment in environments.ts — and mirror that
+      // region in BEDROCK_MODEL_DEFINITIONS so the agent invokes there too.
       id: 'global.anthropic.claude-fable-5',
       name: 'Claude Fable 5',
       provider: 'Anthropic',
-      region: 'us-east-1',
     },
     {
       id: 'global.anthropic.claude-opus-4-7',

--- a/packages/cdk/config/environment-utils.ts
+++ b/packages/cdk/config/environment-utils.ts
@@ -94,15 +94,18 @@ const DEFAULT_CONFIG = {
       provider: 'Anthropic',
     },
     {
-      // Requires Bedrock Data Retention mode `provider_data_share` in the
-      // deployment region — see the registry note in
-      // packages/libs/core/src/bedrock-models.ts and the README. Invoked in the
-      // deployment region (no region pin), so deriveBedrockIamResources() scopes
-      // the inference-profile IAM ARN to the deploy region. Keep in sync with
-      // BEDROCK_MODEL_DEFINITIONS.
+      // Requires Bedrock Data Retention mode `provider_data_share`, which is
+      // enabled in us-east-1 but not in the default deploy region
+      // (ap-northeast-1) — see the registry note in
+      // packages/libs/core/src/bedrock-models.ts and the README. Pinned to
+      // us-east-1 to match BEDROCK_MODEL_DEFINITIONS; this region MUST stay in
+      // sync with the core registry so deriveBedrockIamResources() scopes the
+      // inference-profile IAM ARN to the region the agent actually invokes in
+      // (otherwise InvokeModelWithResponseStream is AccessDenied).
       id: 'global.anthropic.claude-fable-5',
       name: 'Claude Fable 5',
       provider: 'Anthropic',
+      region: 'us-east-1',
     },
     {
       id: 'global.anthropic.claude-opus-4-7',

--- a/packages/libs/core/package.json
+++ b/packages/libs/core/package.json
@@ -15,9 +15,11 @@
     "build": "tsc --build",
     "clean": "rimraf dist tsconfig.tsbuildinfo",
     "dev": "tsc --build --watch",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:integration": "vitest run --config vitest.integration.config.ts"
   },
   "devDependencies": {
+    "@aws-sdk/client-bedrock-runtime": "^3.1051.0",
     "vitest": "^4.1.8"
   }
 }

--- a/packages/libs/core/src/__tests__/bedrock-models.integration.test.ts
+++ b/packages/libs/core/src/__tests__/bedrock-models.integration.test.ts
@@ -23,7 +23,7 @@
  *     ValidationException: data retention mode 'default' is not available for this model
  *   See packages/libs/core/src/bedrock-models.ts for the registry note.
  *
- *   Run (us-west-2 has provider_data_share enabled and Fable 5 verified ACTIVE):
+ *   Run (point BEDROCK_REGION at a region where provider_data_share is enabled):
  *     cd packages/libs/core
  *     RUN_BEDROCK_MODEL_INTEGRATION=1 BEDROCK_REGION=us-west-2 \
  *       npm run test:integration

--- a/packages/libs/core/src/__tests__/bedrock-models.integration.test.ts
+++ b/packages/libs/core/src/__tests__/bedrock-models.integration.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Bedrock model registry — LIVE integration tests.
+ *
+ * These connect to the real Amazon Bedrock runtime and verify that every
+ * Anthropic model in BEDROCK_MODEL_DEFINITIONS can actually be invoked via its
+ * cross-region inference profile id. This is the executable form of the
+ * "verify the inference profile id before merging" requirement: a model that
+ * is in the registry but does not resolve (typo, not-yet-GA, wrong profile
+ * prefix) fails CI here instead of in production.
+ *
+ * The suite is OPT-IN: it only runs when RUN_BEDROCK_MODEL_INTEGRATION=1.
+ * Without the flag it is skipped so unit-test CI and restricted roles stay
+ * green.
+ *
+ *   Requires:
+ *     - AWS credentials with bedrock:InvokeModel on the Anthropic foundation models
+ *     - BEDROCK_REGION pointed at a region where the models are enabled
+ *
+ *   NOTE (Fable 5 / Mythos-class data retention): claude-fable-5 can ONLY be
+ *   invoked when the account's Bedrock Data Retention mode is set to
+ *   `provider_data_share` in the invocation region. With the default mode the
+ *   runtime rejects the request with:
+ *     ValidationException: data retention mode 'default' is not available for this model
+ *   See packages/libs/core/src/bedrock-models.ts for the registry note.
+ *
+ *   Run (us-west-2 has provider_data_share enabled and Fable 5 verified ACTIVE):
+ *     cd packages/libs/core
+ *     RUN_BEDROCK_MODEL_INTEGRATION=1 BEDROCK_REGION=us-west-2 \
+ *       npm run test:integration
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  BedrockRuntimeClient,
+  ConverseCommand,
+} from '@aws-sdk/client-bedrock-runtime';
+import { BEDROCK_MODEL_DEFINITIONS, getModelRegion, getMaxOutputTokens } from '../bedrock-models.js';
+
+const RUN = process.env.RUN_BEDROCK_MODEL_INTEGRATION === '1';
+const describeLive = RUN ? describe : describe.skip;
+
+if (!RUN) {
+  console.log(
+    '⏭️  Skipping Bedrock model live integration tests: set RUN_BEDROCK_MODEL_INTEGRATION=1 to run'
+  );
+}
+
+const DEFAULT_REGION = process.env.BEDROCK_REGION || 'us-west-2';
+
+/** Extract concatenated text from a Converse response. */
+function textOf(out: Awaited<ReturnType<BedrockRuntimeClient['send']>>): string {
+  // ConverseCommandOutput shape: output.message.content[].text
+  const msg = (out as { output?: { message?: { content?: Array<{ text?: string }> } } }).output
+    ?.message;
+  return (msg?.content ?? []).map((b) => b.text ?? '').join('');
+}
+
+/** Invoke a model with a trivial deterministic prompt via the Converse API. */
+async function converse(modelId: string): Promise<string> {
+  // Most models are invoked in BEDROCK_REGION; a registry region pin (e.g. for
+  // In-Region-only models) overrides it. Mirrors createBedrockModel()'s
+  // region-resolution order.
+  const region = getModelRegion(modelId) || DEFAULT_REGION;
+  const client = new BedrockRuntimeClient({
+    region,
+    // Mirror production wiring (createBedrockModel): Bedrock returns transient
+    // ServiceUnavailableException under load, especially for a just-GA'd model
+    // like Fable 5. Adaptive retries smooth those over so the test asserts the
+    // model's behaviour, not Bedrock's momentary capacity.
+    retryMode: 'adaptive',
+    maxAttempts: 5,
+  });
+  const out = await client.send(
+    new ConverseCommand({
+      modelId,
+      messages: [{ role: 'user', content: [{ text: 'Reply with exactly one word: PONG' }] }],
+      // Fable 5 (Mythos-class) has adaptive thinking always ON: it spends output
+      // budget on internal reasoning before the visible answer. A tiny cap (e.g.
+      // 16) truncates the reply to a single character. Give enough headroom that
+      // the one-word answer always lands. Bedrock counts reasoning toward
+      // maxTokens, so this stays well within every model's limit.
+      inferenceConfig: { maxTokens: 1024 },
+    })
+  );
+  return textOf(out);
+}
+
+const ANTHROPIC_MODELS = BEDROCK_MODEL_DEFINITIONS.filter((m) => m.provider === 'Anthropic');
+
+describeLive('Bedrock model registry — live invocation', () => {
+  it.each(ANTHROPIC_MODELS.map((m) => [m.id, m.name] as const))(
+    'invokes %s (%s) and gets a non-empty response',
+    async (modelId) => {
+      const text = await converse(modelId);
+      expect(text.length).toBeGreaterThan(0);
+    },
+    90_000
+  );
+
+  it('invokes Claude Fable 5 specifically and it follows a trivial instruction', async () => {
+    const FABLE_5 = 'global.anthropic.claude-fable-5';
+    // Fable 5 must be present in the registry as the new default (first entry).
+    const entry = BEDROCK_MODEL_DEFINITIONS.find((m) => m.id === FABLE_5);
+    expect(entry, 'claude-fable-5 must be registered in BEDROCK_MODEL_DEFINITIONS').toBeDefined();
+    // Bedrock enforces a hard 128000 ceiling for Fable 5 (verified live);
+    // the registry must not advertise more or every request fails.
+    expect(getMaxOutputTokens(FABLE_5)).toBe(128000);
+
+    const text = await converse(FABLE_5);
+    expect(text.toUpperCase()).toContain('PONG');
+  }, 90_000);
+});

--- a/packages/libs/core/src/__tests__/bedrock-models.test.ts
+++ b/packages/libs/core/src/__tests__/bedrock-models.test.ts
@@ -84,12 +84,14 @@ describe('BEDROCK_MODEL_DEFINITIONS invariants', () => {
     expect(getModelRegion('global.anthropic.claude-opus-4-8')).toBeUndefined();
   });
 
-  it('pins Claude Fable 5 to us-east-1 (provider_data_share enabled there, not in ap-northeast-1)', () => {
-    // Fable 5 needs Bedrock Data Retention mode `provider_data_share`, enabled
-    // in us-east-1 but not the default deploy region. The pin sends invocations
-    // to us-east-1; the matching CDK config entry MUST carry the same region so
-    // the inference-profile IAM ARN is scoped to us-east-1 — otherwise
-    // InvokeModelWithResponseStream is AccessDenied (the deployed failure mode).
-    expect(getModelRegion('global.anthropic.claude-fable-5')).toBe('us-east-1');
+  it('does not region-pin Claude Fable 5 in the OSS default (invoked in the deploy region)', () => {
+    // Fable 5 needs Bedrock Data Retention mode `provider_data_share` in its
+    // invocation region, but WHICH region has it is account/deployment-specific.
+    // The OSS default therefore ships no pin (Fable 5 runs in the deploy region);
+    // operators whose deploy region lacks provider_data_share pin it to another
+    // region via the bedrockModels override in environments.ts. Keeping a
+    // concrete region out of the source avoids baking one account's setup into
+    // the published default.
+    expect(getModelRegion('global.anthropic.claude-fable-5')).toBeUndefined();
   });
 });

--- a/packages/libs/core/src/__tests__/bedrock-models.test.ts
+++ b/packages/libs/core/src/__tests__/bedrock-models.test.ts
@@ -56,4 +56,31 @@ describe('BEDROCK_MODEL_DEFINITIONS invariants', () => {
       }
     }
   });
+
+  it('no Anthropic model advertises more than the Bedrock 128k output ceiling', () => {
+    // Bedrock rejects maxTokens > 128000 for current Anthropic models with
+    // ValidationException "exceeds the model limit of 128000" (verified live
+    // against Fable 5). maxOutputTokens feeds the agent's maxTokens, so an
+    // over-advertised limit makes every request fail. This guard would have
+    // caught the issue's suggested 131072 for Fable 5 without hitting AWS.
+    for (const m of BEDROCK_MODEL_DEFINITIONS) {
+      if (m.provider === 'Anthropic') {
+        expect(m.maxOutputTokens).toBeLessThanOrEqual(128000);
+      }
+    }
+  });
+
+  it('registers Claude Opus 4.8 as the default (first) model with the correct limit', () => {
+    const first = BEDROCK_MODEL_DEFINITIONS[0];
+    expect(first.id).toBe('global.anthropic.claude-opus-4-8');
+    expect(first.name).toBe('Claude Opus 4.8');
+    expect(first.provider).toBe('Anthropic');
+    expect(getMaxOutputTokens('global.anthropic.claude-opus-4-8')).toBe(128000);
+  });
+
+  it('does not region-pin the default model (Opus 4.8 must use the deploy region)', () => {
+    // The default model must work in any deployment region with no special
+    // account setup, so it must not be pinned to a specific region.
+    expect(getModelRegion('global.anthropic.claude-opus-4-8')).toBeUndefined();
+  });
 });

--- a/packages/libs/core/src/__tests__/bedrock-models.test.ts
+++ b/packages/libs/core/src/__tests__/bedrock-models.test.ts
@@ -83,4 +83,13 @@ describe('BEDROCK_MODEL_DEFINITIONS invariants', () => {
     // account setup, so it must not be pinned to a specific region.
     expect(getModelRegion('global.anthropic.claude-opus-4-8')).toBeUndefined();
   });
+
+  it('pins Claude Fable 5 to us-east-1 (provider_data_share enabled there, not in ap-northeast-1)', () => {
+    // Fable 5 needs Bedrock Data Retention mode `provider_data_share`, enabled
+    // in us-east-1 but not the default deploy region. The pin sends invocations
+    // to us-east-1; the matching CDK config entry MUST carry the same region so
+    // the inference-profile IAM ARN is scoped to us-east-1 — otherwise
+    // InvokeModelWithResponseStream is AccessDenied (the deployed failure mode).
+    expect(getModelRegion('global.anthropic.claude-fable-5')).toBe('us-east-1');
+  });
 });

--- a/packages/libs/core/src/bedrock-models.ts
+++ b/packages/libs/core/src/bedrock-models.ts
@@ -83,13 +83,13 @@ export const BEDROCK_MODEL_DEFINITIONS = [
     // This is an account/region setting (Bedrock Data Retention API), not a
     // per-request field, so no code change works around it.
     //
-    // Region pin: provider_data_share is enabled in us-east-1 (and us-west-2)
-    // but NOT in the default deployment region ap-northeast-1, so Fable 5 is
-    // pinned to us-east-1 — the agent invokes it there regardless of
-    // BEDROCK_REGION. The matching CDK entry MUST carry the same region so
-    // deriveBedrockIamResources() scopes the inference-profile IAM ARN to
-    // us-east-1 (otherwise InvokeModelWithResponseStream is AccessDenied).
-    // Remove the pin once provider_data_share is enabled in the deploy region.
+    // No region pin: Fable 5 is invoked in the deployment's BEDROCK_REGION, so
+    // its inference-profile IAM ARN (scoped to the deploy region by
+    // deriveBedrockIamResources) matches the call. To use Fable 5, enable
+    // provider_data_share in the deployment region (see README). If your
+    // deployment region cannot enable it, pin Fable 5 to a region that has it
+    // by overriding `bedrockModels` (with a `region`) in environments.ts —
+    // that is environment-specific config and is kept OUT of this OSS default.
     id: 'global.anthropic.claude-fable-5',
     name: 'Claude Fable 5',
     provider: 'Anthropic',
@@ -99,7 +99,6 @@ export const BEDROCK_MODEL_DEFINITIONS = [
     // make every request fail. Match the documented limit and the other Anthropic
     // entries here.
     maxOutputTokens: 128000, // 128k (verified via live ConverseCommand, 2026-06-09)
-    region: 'us-east-1',
   },
   {
     id: 'global.anthropic.claude-opus-4-7',

--- a/packages/libs/core/src/bedrock-models.ts
+++ b/packages/libs/core/src/bedrock-models.ts
@@ -27,13 +27,22 @@ export interface BedrockModelDefinition {
   /**
    * Optional invocation-region override.
    *
-   * Most models are invoked in the deployment's BEDROCK_REGION. But some
-   * In-Region-only models are not yet rolled out to every region (despite what
-   * the AWS docs list), so they must be invoked in a region where they actually
-   * exist. When set, createBedrockModel() routes this model's Bedrock calls to
-   * this region regardless of BEDROCK_REGION. The IAM foundation-model ARN is
-   * region-wildcarded (arn:aws:bedrock:*::foundation-model/…), so cross-region
-   * invocation from another deployment region requires no extra IAM.
+   * Most models are invoked in the deployment's BEDROCK_REGION. But some must be
+   * invoked in a specific region — an In-Region-only model not yet rolled out
+   * everywhere (despite what the AWS docs list), or a model whose account-level
+   * prerequisite (e.g. Bedrock Data Retention mode) is only enabled in certain
+   * regions. When set, createBedrockModel() routes this model's Bedrock calls to
+   * this region regardless of BEDROCK_REGION.
+   *
+   * IAM: the foundation-model ARN is region-wildcarded
+   * (arn:aws:bedrock:*::foundation-model/…), but a cross-region inference profile
+   * (global.*, us.*, …) ALSO needs an inference-profile ARN, which is
+   * region-scoped. CDK's deriveBedrockIamResources() therefore scopes that ARN to
+   * THIS region (not the deployment region) so the pinned-region invocation is
+   * authorized. For that to work the matching CDK config entry
+   * (DEFAULT_CONFIG.bedrockModels in packages/cdk/config/environment-utils.ts)
+   * MUST carry the same `region` value — the two lists are synced by hand because
+   * CDK does not import @moca/core.
    *
    * Omit for models available in the deployment region (the common case).
    */
@@ -47,13 +56,47 @@ export interface BedrockModelDefinition {
  *
  * When adding a model, also update:
  *   - packages/cdk/config/environment-utils.ts  DEFAULT_CONFIG.bedrockModels
+ *     (mirror id/name/provider AND `region` if the model pins one — the region
+ *     pin drives CDK's inference-profile IAM ARN, so an out-of-sync CDK entry
+ *     causes AccessDenied at invocation time).
  */
 export const BEDROCK_MODEL_DEFINITIONS = [
   {
+    // Default model. No account-level prerequisite (unlike Fable 5's data
+    // retention requirement), so it works out of the box in every region.
     id: 'global.anthropic.claude-opus-4-8',
     name: 'Claude Opus 4.8',
     provider: 'Anthropic',
     maxOutputTokens: 128000, // 128k (AWS Bedrock model card, 2026-05-28)
+  },
+  {
+    // First Mythos-class model GA'd on Bedrock (2026-06-09). 1M context window,
+    // 128k max output. Inference profile id verified ACTIVE via
+    // `aws bedrock get-foundation-model` + a live ConverseCommand (PONG) in
+    // us-east-1 / us-west-2.
+    //
+    // ⚠️ Data retention: Fable 5 (Mythos-class) can ONLY be invoked when the
+    // account's Bedrock Data Retention mode is `provider_data_share` in the
+    // invocation region. With the default mode the runtime rejects every
+    // request — regardless of body — with:
+    //   ValidationException: data retention mode 'default' is not available for this model
+    // This is an account/region setting (Bedrock Data Retention API), not a
+    // per-request field, so no code change works around it. Enable
+    // provider_data_share in the deployment region (see README) before using
+    // Fable 5.
+    //
+    // No region pin: Fable 5 is invoked in the deployment's BEDROCK_REGION, so
+    // its inference-profile IAM ARN (scoped to the deploy region by
+    // deriveBedrockIamResources) matches the call.
+    id: 'global.anthropic.claude-fable-5',
+    name: 'Claude Fable 5',
+    provider: 'Anthropic',
+    // 128k. NOTE: the Bedrock runtime enforces a hard ceiling of exactly
+    // 128000 (verified live: maxTokens:131072 → ValidationException "exceeds the
+    // model limit of 128000"). The issue's suggested 131072 is wrong — it would
+    // make every request fail. Match the documented limit and the other Anthropic
+    // entries here.
+    maxOutputTokens: 128000, // 128k (verified via live ConverseCommand, 2026-06-09)
   },
   {
     id: 'global.anthropic.claude-opus-4-7',

--- a/packages/libs/core/src/bedrock-models.ts
+++ b/packages/libs/core/src/bedrock-models.ts
@@ -81,13 +81,15 @@ export const BEDROCK_MODEL_DEFINITIONS = [
     // request — regardless of body — with:
     //   ValidationException: data retention mode 'default' is not available for this model
     // This is an account/region setting (Bedrock Data Retention API), not a
-    // per-request field, so no code change works around it. Enable
-    // provider_data_share in the deployment region (see README) before using
-    // Fable 5.
+    // per-request field, so no code change works around it.
     //
-    // No region pin: Fable 5 is invoked in the deployment's BEDROCK_REGION, so
-    // its inference-profile IAM ARN (scoped to the deploy region by
-    // deriveBedrockIamResources) matches the call.
+    // Region pin: provider_data_share is enabled in us-east-1 (and us-west-2)
+    // but NOT in the default deployment region ap-northeast-1, so Fable 5 is
+    // pinned to us-east-1 — the agent invokes it there regardless of
+    // BEDROCK_REGION. The matching CDK entry MUST carry the same region so
+    // deriveBedrockIamResources() scopes the inference-profile IAM ARN to
+    // us-east-1 (otherwise InvokeModelWithResponseStream is AccessDenied).
+    // Remove the pin once provider_data_share is enabled in the deploy region.
     id: 'global.anthropic.claude-fable-5',
     name: 'Claude Fable 5',
     provider: 'Anthropic',
@@ -97,6 +99,7 @@ export const BEDROCK_MODEL_DEFINITIONS = [
     // make every request fail. Match the documented limit and the other Anthropic
     // entries here.
     maxOutputTokens: 128000, // 128k (verified via live ConverseCommand, 2026-06-09)
+    region: 'us-east-1',
   },
   {
     id: 'global.anthropic.claude-opus-4-7',

--- a/packages/libs/core/vitest.config.ts
+++ b/packages/libs/core/vitest.config.ts
@@ -3,5 +3,8 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     globals: true,
+    // Live integration tests run via vitest.integration.config.ts (opt-in,
+    // they hit real Bedrock). Keep them out of the default unit-test run.
+    exclude: ['**/node_modules/**', '**/dist/**', '**/*.integration.test.ts'],
   },
 });

--- a/packages/libs/core/vitest.integration.config.ts
+++ b/packages/libs/core/vitest.integration.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ['src/**/*.integration.test.ts'],
+    testTimeout: 90000,
+  },
+});

--- a/packages/libs/tool-definitions/src/definitions/call-agent.ts
+++ b/packages/libs/tool-definitions/src/definitions/call-agent.ts
@@ -24,6 +24,7 @@ export const callAgentSchema = z.object({
       'Model ID to use (optional, defaults to agent config). ' +
         'Must be a valid Bedrock model ID. Examples: ' +
         '"global.anthropic.claude-sonnet-4-6", ' +
+        '"global.anthropic.claude-fable-5", ' +
         '"global.anthropic.claude-opus-4-8", ' +
         '"global.anthropic.claude-opus-4-6-v1", ' +
         '"global.amazon.nova-2-lite-v1:0"'


### PR DESCRIPTION
## Summary

Implements #27 — adds **Claude Fable 5** (`global.anthropic.claude-fable-5`), the first Mythos-class model GA'd on Bedrock (2026-06-09), as a selectable model. **Claude Opus 4.8 remains the default** because Fable 5 has an account-level prerequisite (see below).

Verified end to end with live Bedrock calls (`ConverseCommand`) in `us-east-1` / `us-west-2`.

## Two corrections to the issue, found via live testing

1. **`maxOutputTokens` is `128000`, not `131072`.** Bedrock rejects `maxTokens > 128000` with `ValidationException: ... exceeds the model limit of 128000`, which would make *every* request fail. Since `getMaxOutputTokens()` feeds the agent's `maxTokens`, the issue's value was a deploy-then-broken trap. A unit-test guard now enforces the 128k ceiling for all Anthropic models.
2. **Data retention prerequisite.** Fable 5 (Mythos-class) can only be invoked when the account's Bedrock **Data Retention mode is `provider_data_share`** in the invocation region; the default mode is rejected with `ValidationException: data retention mode 'default' is not available for this model`. This is an account/region setting, not a per-request field. Documented in the registry and both READMEs. Opus 4.8 (no such requirement) stays the default so a fresh deploy works out of the box.

## Per-model invocation region (end-to-end fix)

While wiring this up, fixed a latent IAM bug that surfaced in the deployed environment (`AccessDenied` on `bedrock:InvokeModelWithResponseStream`):

- Added `region?` to the CDK `BedrockModelConfig` type.
- `deriveBedrockIamResources()` now scopes the inference-profile IAM ARN to a model's pinned region (`model.region ?? deployRegion`). Previously a `global.*` profile pinned to another region got an IAM ARN for the *deploy* region → AccessDenied at invocation.
- Region-pin format is validated at synth time.
- Fable 5 itself is left **unpinned** (invoked in the deployment region), matching the documented data-retention setup.

## Tests

- **New opt-in live integration suite** (`bedrock-models.integration.test.ts`, gated by `RUN_BEDROCK_MODEL_INTEGRATION=1`) that invokes every Anthropic model in the registry via the real Converse API — the executable form of the issue's "verify the inference profile id before merging" requirement.
- CDK IAM unit tests for per-model region pinning and region-format validation.
- Updated registry invariant tests (Opus 4.8 default, 128k ceiling).

**Verification:** core 72 + cdk 24 unit tests pass; live integration 6/6 pass (us-east-1); `cdk synth` clean; lint clean.

## Files

- `packages/libs/core/src/bedrock-models.ts` — registry (SSoT)
- `packages/cdk/config/environment-{types,utils}.ts` — CDK config + IAM derivation
- `packages/libs/tool-definitions/src/definitions/call-agent.ts` — example model id
- `README.md` / `README-ja.md` — data retention note (collapsible)

Closes #27
