### PR TITLE
fix(agent): import jest globals in workspace-sync integration test

### DIFF
--- a/packages/agent/src/services/__tests__/workspace-sync.integration.test.ts
+++ b/packages/agent/src/services/__tests__/workspace-sync.integration.test.ts
@@ -7,16 +7,7 @@
  * npx jest --testMatch="glob-pattern-for-integration-tests"
  */
 
-import {
-  describe,
-  it,
-  test,
-  expect,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  jest,
-} from '@jest/globals';
+import { describe, test, expect, beforeEach, afterEach, beforeAll } from '@jest/globals';
 import { WorkspaceSync } from '../workspace-sync.js';
 import {
   S3Client,

--- a/packages/agent/src/services/__tests__/workspace-sync.integration.test.ts
+++ b/packages/agent/src/services/__tests__/workspace-sync.integration.test.ts
@@ -7,6 +7,16 @@
  * npx jest --testMatch="glob-pattern-for-integration-tests"
  */
 
+import {
+  describe,
+  it,
+  test,
+  expect,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  jest,
+} from '@jest/globals';
 import { WorkspaceSync } from '../workspace-sync.js';
 import {
   S3Client,


### PR DESCRIPTION
## 概要

`packages/agent/src/services/__tests__/workspace-sync.integration.test.ts` で `beforeEach` 等が「名前が見つかりません」となる型エラーを修正します。

## 原因

- このテストファイルだけ `@jest/globals` からの import がなく、jest のグローバル (`describe`/`it`/`beforeEach`/`expect` など) に暗黙的に依存していました。
- agent の `tsconfig.json` は `**/*.test.ts` を `exclude` しているため、エディタ/`tsc` 上ではこのファイルがどの tsconfig にも include されず、`types: ["jest"]` の設定が効かずグローバル型を解決できませんでした。
- `@types/jest` はルートにインストール済みのため、エラーメッセージの「`@types/jest` を入れろ」という提案は的外れでした。

## 修正

リポジトリ内の他のすべてのテストファイルと同様に、`@jest/globals` から使用するグローバルを明示 import するようにしました (jest 30 + ESM のこのプロジェクトの慣習)。

ts-jest 実行時はグローバルが注入されるため挙動は変わりません。エディタ/型チェック上のエラーのみ解消します。