### PR TITLE
docs(cdk): fix stale @default model list on EnvironmentConfig.bedrockModels

### DIFF
--- a/packages/cdk/config/environment-types.ts
+++ b/packages/cdk/config/environment-types.ts
@@ -198,7 +198,10 @@ export interface EnvironmentConfig {
    * Available Bedrock models for frontend model selector (optional)
    * Each model ID should include the cross-region inference profile prefix
    * (e.g., 'global.', 'jp.', 'us.', 'eu.', 'apac.')
-   * @default global.* prefixed models (Opus 4.6, Sonnet 4.6, Nova Lite 2)
+   * @default The bedrockModels list in DEFAULT_CONFIG
+   *   (packages/cdk/config/environment-utils.ts); Claude Opus 4.8 is the
+   *   default-selected model. See that list for the authoritative set, which
+   *   grows as new models are added.
    */
   bedrockModels?: BedrockModelConfig[];
 


### PR DESCRIPTION
## Summary
Comment-vs-implementation alignment fix (scheduled audit job, category `cdk`).

The `@default` JSDoc on `EnvironmentConfig.bedrockModels` in
`packages/cdk/config/environment-types.ts` was **stale**:

```
@default global.* prefixed models (Opus 4.6, Sonnet 4.6, Nova Lite 2)
```

But `DEFAULT_CONFIG.bedrockModels` in `packages/cdk/config/environment-utils.ts`
actually ships **seven** models today: Claude Opus 4.8 (default-selected),
Claude Fable 5, Claude Opus 4.7, Claude Opus 4.6, Claude Sonnet 4.6,
Nova Lite 2, Qwen3 Coder Next.

The comment dated from the `init` commit (`c1f9ce0`, 2026-05-18) and was never
updated as models were added (most recently Fable 5 via #29). **Implementation
is correct; only the comment was wrong.**

## Change
Replace the hard-coded (recurrently-stale) enumeration with a pointer to the
authoritative `DEFAULT_CONFIG.bedrockModels` list, noting Opus 4.8 is the
default-selected model. Keeps the doc accurate as the model list grows.

## Verification
- Diffed `@default` text against the live `DEFAULT_CONFIG.bedrockModels` array.
- `git log -L` confirms the line is unchanged since `init` while the list grew.
- Docs-only change; no behavior impact.
