### PR TITLE
fix(frontend): Fixed an issue where horizontal scrolling occurred with long strings of English text.

### DIFF
--- a/packages/frontend/src/components/Message.tsx
+++ b/packages/frontend/src/components/Message.tsx
@@ -164,7 +164,7 @@ export const Message: React.FC<MessageProps> = ({ message }) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       th: ({ children, ...props }: any) => (
         <th
-          className="border border-border-strong px-4 py-2 bg-surface-secondary font-semibold text-left"
+          className="border border-border-strong px-4 py-2 bg-surface-secondary font-semibold text-left break-words"
           {...props}
         >
           {children}
@@ -172,7 +172,7 @@ export const Message: React.FC<MessageProps> = ({ message }) => {
       ),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       td: ({ children, ...props }: any) => (
-        <td className="border border-border-strong px-4 py-2" {...props}>
+        <td className="border border-border-strong px-4 py-2 break-words" {...props}>
           {children}
         </td>
       ),

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -153,6 +153,10 @@
   /* Markdown content styles */
   .markdown-content {
     color: var(--color-fg-default);
+    /* Break long unbreakable strings (e.g. slash-separated paths, long English
+       words) so they wrap instead of overflowing horizontally on narrow screens. */
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
 
   .markdown-content h1,


### PR DESCRIPTION
## Overview
This update fixes an issue where, when English text (especially long, continuous strings without spaces) is included in the chat field, the message area overflows horizontally without line breaks, allowing for horizontal scrolling.

Examples: `Runtime/Memory/Identity/Gateway/Policy/Browser`, `Browser+Playwright`, etc.

## Cause
The `.markdown-content` style lacked a line-wrapping specification (`overflow-wrap` / `word-break`), remaining at the browser's default `overflow-wrap: normal`.

- Japanese text can wrap lines at the character level, so it will wrap.
- Long English words and slash-separated paths are considered "one word" and have no line break points, so they exceed the container width.

## Changes
- `index.css`: Added `overflow-wrap: anywhere;` and `word-break: break-word;` to `.markdown-content`
- `Message.tsx`: Added `break-words` to table cells (`th`/`td`)

## Verification
- Changes only to CSS / Tailwind utilities (no logic changes)