### PR TITLE
feat(frontend): multi-select, marquee & bulk ops for storage modal; r…

### DIFF
--- a/packages/frontend/src/api/__tests__/storage.download.test.ts
+++ b/packages/frontend/src/api/__tests__/storage.download.test.ts
@@ -1,0 +1,94 @@
+/**
+ * storage download — partial/total failure handling for ZIP downloads.
+ *
+ * fetchFilesIntoZip (via downloadFolder/downloadItems) must:
+ *  - throw when NO file could be fetched (never present an empty ZIP as success)
+ *  - report accurate succeeded/failed counts when some files fail
+ *  - only count successfully-fetched files as `succeeded`
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import * as storageApi from '../storage';
+import type { DownloadFileInfo } from '../storage';
+import { backendClient } from '../client/backend-client';
+
+// Mock the backend metadata calls; the file fetches go through global fetch.
+// downloadFolder -> getFolderDownloadInfo -> backendClient.get('/storage/download-folder')
+vi.mock('../client/backend-client', () => ({
+  backendClient: { get: vi.fn(), post: vi.fn(), request: vi.fn() },
+}));
+
+const file = (relativePath: string): DownloadFileInfo => ({
+  relativePath,
+  downloadUrl: `https://s3.example/${relativePath}`,
+  size: 10,
+});
+
+const mockFolderInfo = (files: DownloadFileInfo[]) => {
+  vi.mocked(backendClient.get).mockResolvedValue({
+    files,
+    totalSize: files.reduce((s, f) => s + f.size, 0),
+    fileCount: files.length,
+  });
+};
+
+const okResponse = () =>
+  ({ ok: true, arrayBuffer: async () => new ArrayBuffer(4) }) as unknown as Response;
+const notOkResponse = () => ({ ok: false, statusText: 'Forbidden' }) as unknown as Response;
+
+describe('downloadFolder partial/total failure', () => {
+  beforeEach(() => {
+    // jsdom is not the env (node), so stub the DOM bits fetchFilesIntoZip touches
+    // on success. URL + anchor are only reached when at least one file succeeds.
+    vi.stubGlobal('URL', {
+      createObjectURL: vi.fn(() => 'blob:x'),
+      revokeObjectURL: vi.fn(),
+    });
+    vi.stubGlobal('Blob', class {});
+    const anchor = { href: '', download: '', click: vi.fn() };
+    vi.stubGlobal('document', { createElement: vi.fn(() => anchor) });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('throws when every file fails (no empty ZIP presented as success)', async () => {
+    mockFolderInfo([file('a.txt'), file('b.txt')]);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => notOkResponse())
+    );
+
+    await expect(storageApi.downloadFolder('/dir', 'dir')).rejects.toThrow(
+      'Failed to download any files'
+    );
+  });
+
+  it('reports accurate failed count on partial success', async () => {
+    mockFolderInfo([file('ok.txt'), file('bad.txt'), file('boom.txt')]);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        if (url.endsWith('ok.txt')) return okResponse();
+        if (url.endsWith('bad.txt')) return notOkResponse();
+        throw new Error('network down'); // boom.txt
+      })
+    );
+
+    const result = await storageApi.downloadFolder('/dir', 'dir');
+    expect(result).toEqual({ total: 3, succeeded: 1, failed: 2 });
+  });
+
+  it('reports zero failures when all succeed', async () => {
+    mockFolderInfo([file('a.txt'), file('b.txt')]);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => okResponse())
+    );
+
+    const result = await storageApi.downloadFolder('/dir', 'dir');
+    expect(result).toEqual({ total: 2, succeeded: 2, failed: 0 });
+  });
+});

--- a/packages/frontend/src/api/storage.ts
+++ b/packages/frontend/src/api/storage.ts
@@ -80,6 +80,17 @@ export interface DownloadProgress {
   currentFile: string;
 }
 
+/**
+ * Result of a ZIP download: how many files were requested vs. actually
+ * included. `failed > 0` means the ZIP is incomplete (some files could not be
+ * fetched, e.g. expired presigned URLs) and the caller should warn the user.
+ */
+export interface DownloadResult {
+  total: number;
+  succeeded: number;
+  failed: number;
+}
+
 export interface DirectorySizeResponse {
   totalSize: number;
   fileCount: number;
@@ -207,40 +218,42 @@ export async function getFolderDownloadInfo(path: string): Promise<FolderDownloa
 }
 
 /**
- * Download folder as ZIP
- * Note: Uses fflate (MIT license) for ZIP creation and Web standard API for download.
+ * Download a set of files into a single ZIP, reporting progress.
+ * Each entry maps a ZIP-internal path to a presigned S3 download URL.
+ *
+ * Files that fail to download (network error or non-OK response) are skipped
+ * and counted as failures; only successfully fetched files are added to the
+ * ZIP. Throws if NO file could be downloaded (so the caller never presents an
+ * empty ZIP as success). Returns per-file stats so the caller can warn when
+ * the ZIP is incomplete.
  */
-export async function downloadFolder(
-  folderPath: string,
-  folderName: string,
+async function fetchFilesIntoZip(
+  entries: DownloadFileInfo[],
+  zipName: string,
   onProgress?: (progress: DownloadProgress) => void,
   signal?: AbortSignal
-): Promise<void> {
+): Promise<DownloadResult> {
   const { zipSync } = await import('fflate');
 
-  // Get file info for the folder
-  const downloadInfo = await getFolderDownloadInfo(folderPath);
-
-  if (downloadInfo.fileCount === 0) {
-    throw new Error('Folder is empty');
-  }
-
   const fileMap: Record<string, Uint8Array> = {};
-  let downloadedCount = 0;
+  const total = entries.length;
+  // Files actually added to the ZIP. Kept separate from `processed` so the
+  // progress bar advances per-file while `succeeded` reflects real content.
+  let succeeded = 0;
+  let processed = 0;
 
-  // Download each file and add to ZIP
-  for (const file of downloadInfo.files) {
+  for (const file of entries) {
     // Check for cancellation
     if (signal?.aborted) {
       throw new Error('Download cancelled');
     }
 
-    // Notify progress
+    // Notify progress (processed = attempted so far, success or fail)
     if (onProgress) {
       onProgress({
-        current: downloadedCount,
-        total: downloadInfo.fileCount,
-        percentage: Math.round((downloadedCount / downloadInfo.fileCount) * 100),
+        current: processed,
+        total,
+        percentage: total > 0 ? Math.round((processed / total) * 100) : 0,
         currentFile: file.relativePath,
       });
     }
@@ -257,22 +270,28 @@ export async function downloadFolder(
       const arrayBuffer = await response.arrayBuffer();
       fileMap[file.relativePath] = new Uint8Array(arrayBuffer);
 
-      downloadedCount++;
+      succeeded++;
     } catch (error) {
       if (signal?.aborted) {
         throw new Error('Download cancelled', { cause: error });
       }
       logger.error('Error downloading file %s:', file.relativePath, error);
-      // Skip and continue on error
-      downloadedCount++;
+      // Skip and continue on error (counted as a failure, not added to ZIP)
+    } finally {
+      processed++;
     }
+  }
+
+  // If nothing could be downloaded, do not present an empty ZIP as success.
+  if (succeeded === 0) {
+    throw new Error('Failed to download any files');
   }
 
   // Notify final progress
   if (onProgress) {
     onProgress({
-      current: downloadedCount,
-      total: downloadInfo.fileCount,
+      current: total,
+      total,
       percentage: 100,
       currentFile: 'Creating ZIP file...',
     });
@@ -286,7 +305,75 @@ export async function downloadFolder(
   const url = URL.createObjectURL(zipBlob);
   const anchor = document.createElement('a');
   anchor.href = url;
-  anchor.download = `${folderName}.zip`;
+  anchor.download = `${zipName}.zip`;
   anchor.click();
   URL.revokeObjectURL(url);
+
+  return { total, succeeded, failed: total - succeeded };
+}
+
+/**
+ * Download folder as ZIP
+ * Note: Uses fflate (MIT license) for ZIP creation and Web standard API for download.
+ */
+export async function downloadFolder(
+  folderPath: string,
+  folderName: string,
+  onProgress?: (progress: DownloadProgress) => void,
+  signal?: AbortSignal
+): Promise<DownloadResult> {
+  // Get file info for the folder
+  const downloadInfo = await getFolderDownloadInfo(folderPath);
+
+  if (downloadInfo.fileCount === 0) {
+    throw new Error('Folder is empty');
+  }
+
+  return fetchFilesIntoZip(downloadInfo.files, folderName, onProgress, signal);
+}
+
+/**
+ * Download multiple selected items (files and/or folders) as a single ZIP.
+ * Folder contents are nested under the folder name to preserve structure.
+ * @param items Selected items to bundle
+ * @param zipName Base name for the resulting ZIP file (without extension)
+ */
+export async function downloadItems(
+  items: StorageItem[],
+  zipName: string,
+  onProgress?: (progress: DownloadProgress) => void,
+  signal?: AbortSignal
+): Promise<DownloadResult> {
+  if (items.length === 0) {
+    throw new Error('No items selected');
+  }
+
+  // Collect ZIP entries from all selected items
+  const entries: DownloadFileInfo[] = [];
+
+  for (const item of items) {
+    if (signal?.aborted) {
+      throw new Error('Download cancelled');
+    }
+
+    if (item.type === 'file') {
+      const downloadUrl = await generateDownloadUrl(item.path);
+      entries.push({ relativePath: item.name, downloadUrl, size: item.size ?? 0 });
+    } else {
+      // Folder: fetch its file list and nest under the folder name
+      const downloadInfo = await getFolderDownloadInfo(item.path);
+      for (const file of downloadInfo.files) {
+        entries.push({
+          ...file,
+          relativePath: `${item.name}/${file.relativePath}`,
+        });
+      }
+    }
+  }
+
+  if (entries.length === 0) {
+    throw new Error('Folder is empty');
+  }
+
+  return fetchFilesIntoZip(entries, zipName, onProgress, signal);
 }

--- a/packages/frontend/src/components/MessageInput.tsx
+++ b/packages/frontend/src/components/MessageInput.tsx
@@ -1,11 +1,13 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Send, Loader2, Paperclip } from 'lucide-react';
+import { Send, Loader2, Paperclip, CheckCircle2 } from 'lucide-react';
 import { randomId } from '../utils/randomId';
 import { useChatStore } from '../stores/chatStore';
 import { useAgentStore } from '../stores/agentStore';
 import { useSettingsStore } from '../stores/settingsStore';
 import { useUIStore } from '../stores/uiStore';
+import { useStorageStore } from '../stores/storageStore';
+import * as storageApi from '../api/storage';
 import { StoragePathDisplay } from './StoragePathDisplay';
 import { StorageManagementModal } from './StorageManagementModal';
 import { ModelReasoningSelector } from './ui/ModelReasoningSelector';
@@ -34,13 +36,28 @@ export const MessageInput: React.FC<MessageInputProps> = ({
   const isLoading = sessionState?.isLoading || false;
   const isAgentStoreLoading = useAgentStore((state) => state.isLoading);
   const isWideView = useUIStore((state) => state.isWideView);
+  const agentWorkingDirectory = useStorageStore((state) => state.agentWorkingDirectory);
   const [input, setInput] = useState('');
   const [attachedImages, setAttachedImages] = useState<ImageAttachment[]>([]);
   const [isStorageModalOpen, setIsStorageModalOpen] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
+  const [uploadingFileName, setUploadingFileName] = useState<string | null>(null);
+  // Brief "upload complete" message shown in the same spot as the uploading
+  // overlay, right after it disappears. null when nothing to show.
+  const [uploadDoneMessage, setUploadDoneMessage] = useState<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const prevLoadingRef = useRef(isLoading);
+  const doneTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clear the completion-message timer on unmount
+  useEffect(() => {
+    return () => {
+      if (doneTimerRef.current) {
+        clearTimeout(doneTimerRef.current);
+      }
+    };
+  }, []);
 
   // Auto-resize textarea
   useEffect(() => {
@@ -171,6 +188,96 @@ export const MessageInput: React.FC<MessageInputProps> = ({
     [processAndAttachImages]
   );
 
+  // Insert text at the textarea cursor (falls back to appending). Keeps the
+  // caret right after the inserted text so the user can keep typing.
+  const insertTextAtCursor = useCallback((text: string) => {
+    setInput((prev) => {
+      const textarea = textareaRef.current;
+      const start = textarea?.selectionStart ?? prev.length;
+      const end = textarea?.selectionEnd ?? prev.length;
+      const next = prev.slice(0, start) + text + prev.slice(end);
+      // Restore the caret after React commits the new value
+      requestAnimationFrame(() => {
+        const el = textareaRef.current;
+        if (el) {
+          const pos = start + text.length;
+          el.focus();
+          el.setSelectionRange(pos, pos);
+        }
+      });
+      return next;
+    });
+  }, []);
+
+  // Join a directory and file name into a normalized absolute path
+  const joinWorkingPath = useCallback((dir: string, fileName: string): string => {
+    if (!dir || dir === '/') {
+      return `/${fileName}`;
+    }
+    const trimmed = dir.endsWith('/') ? dir.slice(0, -1) : dir;
+    return `${trimmed}/${fileName}`;
+  }, []);
+
+  // Upload non-image files to the current agent working directory and insert
+  // their resulting paths into the message input. Uploads sequentially so the
+  // inserted paths keep the drop order.
+  const uploadFilesToWorkingDirectory = useCallback(
+    async (files: File[]) => {
+      if (files.length === 0) return;
+
+      const maxSize = 500 * 1024 * 1024; // 500MB (matches storage store limit)
+      let uploadedCount = 0;
+      try {
+        for (const file of files) {
+          if (file.size > maxSize) {
+            alert(t('chat.fileDrop.tooLarge', { name: file.name }));
+            continue;
+          }
+          try {
+            setUploadingFileName(file.name);
+            const { uploadUrl } = await storageApi.generateUploadUrl(
+              file.name,
+              agentWorkingDirectory,
+              file.type
+            );
+            await storageApi.uploadFileToS3(uploadUrl, file);
+
+            const uploadedPath = joinWorkingPath(agentWorkingDirectory, file.name);
+            insertTextAtCursor(`${uploadedPath} `);
+            uploadedCount++;
+          } catch (error) {
+            logger.error('Failed to upload dropped file %s:', file.name, error);
+            alert(
+              t('chat.fileDrop.failed', {
+                name: file.name,
+                error: error instanceof Error ? error.message : String(error),
+              })
+            );
+          }
+        }
+        // Refresh the storage modal view/tree so the new files show up
+        await useStorageStore.getState().loadFolderTree();
+        if (useStorageStore.getState().currentPath === agentWorkingDirectory) {
+          await useStorageStore.getState().loadItems(agentWorkingDirectory);
+        }
+      } finally {
+        setUploadingFileName(null);
+        // Briefly show a completion message in the same spot, then hide it.
+        if (uploadedCount > 0) {
+          setUploadDoneMessage(t('chat.fileDrop.uploaded', { count: uploadedCount }));
+          if (doneTimerRef.current) {
+            clearTimeout(doneTimerRef.current);
+          }
+          doneTimerRef.current = setTimeout(() => {
+            setUploadDoneMessage(null);
+            doneTimerRef.current = null;
+          }, 1000);
+        }
+      }
+    },
+    [agentWorkingDirectory, insertTextAtCursor, joinWorkingPath, t]
+  );
+
   // Drag and drop handlers
   const handleDragOver = useCallback((e: React.DragEvent) => {
     e.preventDefault();
@@ -190,17 +297,26 @@ export const MessageInput: React.FC<MessageInputProps> = ({
       e.stopPropagation();
       setIsDragging(false);
 
-      const files = e.dataTransfer.files;
-      if (files.length > 0) {
-        const imageFiles = Array.from(files).filter((file) =>
-          IMAGE_ATTACHMENT_CONFIG.ACCEPTED_TYPES.includes(file.type as never)
-        );
-        if (imageFiles.length > 0) {
-          processAndAttachImages(imageFiles);
-        }
+      const files = Array.from(e.dataTransfer.files);
+      if (files.length === 0) return;
+
+      // Images keep the existing "attach to message" behavior; every other file
+      // is uploaded to the working directory and its path inserted into the input.
+      const imageFiles = files.filter((file) =>
+        IMAGE_ATTACHMENT_CONFIG.ACCEPTED_TYPES.includes(file.type as never)
+      );
+      const otherFiles = files.filter(
+        (file) => !IMAGE_ATTACHMENT_CONFIG.ACCEPTED_TYPES.includes(file.type as never)
+      );
+
+      if (imageFiles.length > 0) {
+        processAndAttachImages(imageFiles);
+      }
+      if (otherFiles.length > 0) {
+        void uploadFilesToWorkingDirectory(otherFiles);
       }
     },
-    [processAndAttachImages]
+    [processAndAttachImages, uploadFilesToWorkingDirectory]
   );
 
   // Handle paste from clipboard (screenshots)
@@ -350,6 +466,22 @@ export const MessageInput: React.FC<MessageInputProps> = ({
           onDragLeave={handleDragLeave}
           onDrop={handleDrop}
         >
+          {/* Upload status overlay for dropped files: shows progress while
+              uploading, then a brief completion message in the same spot. */}
+          {uploadingFileName ? (
+            <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-start gap-2 rounded-2xl bg-surface-primary/80 px-4 text-sm text-fg-secondary">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              <span>{t('chat.fileDrop.uploading', { name: uploadingFileName })}</span>
+            </div>
+          ) : (
+            uploadDoneMessage && (
+              <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-start gap-2 rounded-2xl bg-surface-primary/80 px-4 text-sm text-fg-secondary">
+                <CheckCircle2 className="w-4 h-4 text-emerald-500" />
+                <span>{uploadDoneMessage}</span>
+              </div>
+            )
+          )}
+
           {/* Image preview */}
           <ImagePreview images={attachedImages} onRemove={handleRemoveImage} disabled={isLoading} />
 

--- a/packages/frontend/src/components/StorageManagementModal.tsx
+++ b/packages/frontend/src/components/StorageManagementModal.tsx
@@ -5,191 +5,35 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  X,
-  Folder,
-  File,
-  Upload,
-  FolderPlus,
-  Trash2,
-  Loader2,
-  AlertCircle,
-  AlertTriangle,
-  ChevronRight,
-  Home,
-  Download,
-  Copy,
-  Check,
-  HelpCircle,
-  FolderCog,
-} from 'lucide-react';
+import { X, Folder, Upload, Loader2, AlertCircle, Check, HelpCircle } from 'lucide-react';
 import { useStorageStore } from '../stores/storageStore';
 import type { StorageItem, FolderNode } from '../api/storage';
 import { Modal } from './ui/Modal/Modal';
+import { ConfirmModal } from './ui/Modal/ConfirmModal';
 import {
-  generateDownloadUrl,
-  downloadFolder,
-  getDirectorySize,
-  type DownloadProgress,
-} from '../api/storage';
+  StorageContentContextMenu,
+  StorageFolderContextMenu,
+} from './storage/StorageContextMenu';
+import { StorageItemRow } from './storage/StorageItemRow';
+import { StorageBreadcrumb } from './storage/StorageBreadcrumb';
+import { StorageToolbar } from './storage/StorageToolbar';
+import { getDirectorySize } from '../api/storage';
 import { Tooltip } from './ui/Tooltip/Tooltip';
 import { FolderTree } from './FolderTree';
-import { getFileIcon } from '../utils/fileIcons';
-import { downloadWithAsyncUrl } from '../utils/download';
+import {
+  collectDropEntries,
+  readDroppedEntries,
+  resolveDirectoryCreation,
+} from '../utils/fileSystemEntry';
+import { useStorageSelection } from '../hooks/useStorageSelection';
+import { useFolderDownload } from '../hooks/useFolderDownload';
+import { useStorageHashSync } from '../hooks/useStorageHashSync';
 import { DownloadProgressModal } from './ui/DownloadProgressModal';
 import { logger } from '../utils/logger';
 
 interface StorageManagementModalProps {
   isOpen: boolean;
   onClose: () => void;
-}
-
-/**
- * File/directory item display component
- */
-interface StorageItemComponentProps {
-  item: StorageItem;
-  onDelete: (item: StorageItem) => void;
-  onNavigate: (path: string) => void;
-  onDownload: (item: StorageItem) => void;
-  onContextMenu: (e: React.MouseEvent, item: StorageItem) => void;
-  onSetWorkingDirectory?: (path: string) => void;
-}
-
-function StorageItemComponent({
-  item,
-  onDelete,
-  onNavigate,
-  onDownload,
-  onContextMenu,
-  onSetWorkingDirectory,
-}: StorageItemComponentProps) {
-  const { t } = useTranslation();
-
-  const handleDelete = (e: React.MouseEvent) => {
-    e.stopPropagation(); // Stop card click event
-
-    const confirmMessage =
-      item.type === 'directory'
-        ? t('storage.deleteDirectoryConfirm', { name: item.name })
-        : t('storage.deleteFileConfirm', { name: item.name });
-
-    if (window.confirm(confirmMessage)) {
-      onDelete(item);
-    }
-  };
-
-  const handleDownloadClick = (e: React.MouseEvent) => {
-    e.stopPropagation(); // Stop card click event
-    onDownload(item);
-  };
-
-  const handleCardClick = () => {
-    if (item.type === 'directory') {
-      onNavigate(item.path);
-    } else {
-      // Download if file
-      onDownload(item);
-    }
-  };
-
-  const formatSize = (bytes?: number) => {
-    if (!bytes) return '—';
-    if (bytes < 1024) return `${bytes} B`;
-    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  };
-
-  const formatDate = (dateString?: string) => {
-    if (!dateString) return '—';
-    return new Date(dateString).toLocaleDateString('ja-JP', {
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
-  };
-
-  const handleContextMenuClick = (e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    onContextMenu(e, item);
-  };
-
-  // Get file icon
-  const fileIconConfig = item.type === 'file' ? getFileIcon(item.name) : null;
-  const FileIcon = fileIconConfig?.icon;
-
-  return (
-    <div
-      onClick={handleCardClick}
-      onContextMenu={handleContextMenuClick}
-      className="border border-border rounded-lg p-3 hover:bg-surface-secondary transition-colors cursor-pointer"
-      role="button"
-      tabIndex={0}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          handleCardClick();
-        }
-      }}
-    >
-      <div className="flex items-center gap-3">
-        {/* Icon */}
-        <div className="flex-shrink-0">
-          {item.type === 'directory' ? (
-            <Folder className="w-5 h-5 text-amber-500" />
-          ) : FileIcon ? (
-            <FileIcon className={`w-5 h-5 ${fileIconConfig.color}`} />
-          ) : (
-            <File className="w-5 h-5 text-action-primary" />
-          )}
-        </div>
-
-        {/* Information */}
-        <div className="flex-1 min-w-0">
-          <div className="text-sm font-medium text-fg-default truncate">{item.name}</div>
-          <div className="flex items-center gap-4 text-xs text-fg-muted mt-1">
-            {item.type === 'file' && <span>{formatSize(item.size)}</span>}
-            <span className="hidden sm:inline">{formatDate(item.lastModified)}</span>
-          </div>
-        </div>
-
-        {/* Actions */}
-        <div className="flex items-center gap-1 sm:gap-2">
-          {item.type === 'directory' && onSetWorkingDirectory && (
-            <Tooltip content={t('storage.setAsWorkingDirectory')}>
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onSetWorkingDirectory(item.path);
-                }}
-                className="p-2 text-fg-disabled hover:text-fg-secondary hover:bg-surface-secondary rounded-lg transition-colors"
-                title={t('storage.setAsWorkingDirectory')}
-              >
-                <FolderCog className="w-4 h-4" />
-              </button>
-            </Tooltip>
-          )}
-          <button
-            onClick={handleDownloadClick}
-            className="p-2 text-fg-disabled hover:text-action-primary hover:bg-feedback-info-bg rounded-lg transition-colors"
-            title={item.type === 'directory' ? t('storage.downloadFolder') : t('storage.download')}
-          >
-            <Download className="w-4 h-4" />
-          </button>
-          <button
-            onClick={handleDelete}
-            className="p-2 text-fg-disabled hover:text-feedback-error hover:bg-feedback-error-bg rounded-lg transition-colors"
-            title={t('common.delete')}
-          >
-            <Trash2 className="w-4 h-4" />
-          </button>
-        </div>
-      </div>
-    </div>
-  );
 }
 
 /**
@@ -214,11 +58,32 @@ export function StorageManagementModal({ isOpen, onClose }: StorageManagementMod
     uploadFiles,
     createDirectory,
     deleteItem,
+    deleteItems,
     clearError,
     loadFolderTree,
     toggleFolderExpand,
     setAgentWorkingDirectory,
   } = useStorageStore();
+
+  // Multi-select + marquee drag-selection (checkbox/range/select-all/rubber-band).
+  const listContainerRef = useRef<HTMLDivElement>(null);
+  const {
+    selectedPaths,
+    selectedItems,
+    allSelected,
+    someSelected,
+    marqueeRect,
+    toggle: handleToggleSelect,
+    toggleAll: handleToggleSelectAll,
+    clear: clearSelection,
+    deselect: deselectPaths,
+    onListMouseDown: handleListMouseDown,
+  } = useStorageSelection(items, listContainerRef, isOpen);
+
+  // Items pending deletion via the confirm modal. Drives both the bulk-bar
+  // delete and per-item delete (when the item belongs to a multi-selection).
+  const [pendingDeleteItems, setPendingDeleteItems] = useState<StorageItem[]>([]);
+  const [isBulkDeleteConfirmOpen, setIsBulkDeleteConfirmOpen] = useState(false);
 
   const [newDirectoryName, setNewDirectoryName] = useState('');
   const [showNewDirectoryInput, setShowNewDirectoryInput] = useState(false);
@@ -237,22 +102,19 @@ export function StorageManagementModal({ isOpen, onClose }: StorageManagementMod
   } | null>(null);
   const [copiedPath, setCopiedPath] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const contextMenuRef = useRef<HTMLDivElement>(null);
-  const folderContextMenuRef = useRef<HTMLDivElement>(null);
 
-  // Folder download related state
-  const [isDownloadModalOpen, setIsDownloadModalOpen] = useState(false);
-  const [downloadProgress, setDownloadProgress] = useState<DownloadProgress>({
-    current: 0,
-    total: 0,
-    percentage: 0,
-    currentFile: '',
+  // Download orchestration (single-file, folder/bulk ZIP, progress, cancel).
+  const { modalProps: downloadModalProps, downloadItem, downloadFolderAsZip, downloadSelection } =
+    useFolderDownload(t);
+
+  // URL-hash <-> current-path sync (deep links, Back/Forward, close-on-back).
+  const { setPathToHash } = useStorageHashSync({
+    isOpen,
+    onClose,
+    agentWorkingDirectory,
+    loadItems,
+    loadFolderTree,
   });
-  const [downloadStatus, setDownloadStatus] = useState<
-    'downloading' | 'success' | 'error' | 'cancelled'
-  >('downloading');
-  const [downloadError, setDownloadError] = useState<string>('');
-  const abortControllerRef = useRef<AbortController | null>(null);
 
   // Directory size warning state
   const SIZE_WARNING_THRESHOLD = 100 * 1024 * 1024; // 100MB
@@ -261,54 +123,6 @@ export function StorageManagementModal({ isOpen, onClose }: StorageManagementMod
     totalSize: number;
     fileCount: number;
   } | null>(null);
-
-  // Format size for display
-  const formatSizeForWarning = (bytes: number): string => {
-    if (bytes < 1024) return `${bytes} B`;
-    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-    if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-    return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
-  };
-
-  // Get path from URL hash
-  const getPathFromHash = (): string => {
-    const hash = window.location.hash;
-    const match = hash.match(/#storage=(.+)/);
-    return match ? decodeURIComponent(match[1]) : '/';
-  };
-
-  // Set path to URL hash
-  const setPathToHash = (path: string) => {
-    const newHash = `#storage=${encodeURIComponent(path)}`;
-    window.history.pushState(null, '', newHash);
-  };
-
-  // Clear URL hash
-  const clearHash = () => {
-    if (window.location.hash.startsWith('#storage=')) {
-      window.history.pushState(null, '', window.location.pathname + window.location.search);
-    }
-  };
-
-  // Load data when modal opens
-  useEffect(() => {
-    if (isOpen) {
-      // Use URL hash if explicitly set,
-      // otherwise use currently selected path (currentPath)
-      const hasExplicitHash = window.location.hash.startsWith('#storage=');
-      const initialPath = hasExplicitHash ? getPathFromHash() : agentWorkingDirectory || '/';
-
-      // Set URL hash on initial display (add to history)
-      setPathToHash(initialPath);
-      loadItems(initialPath);
-      // Also load folder tree
-      loadFolderTree();
-    } else {
-      // Clear URL hash when closing modal
-      clearHash();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen]);
 
   // Check directory size when path changes
   useEffect(() => {
@@ -336,64 +150,18 @@ export function StorageManagementModal({ isOpen, onClose }: StorageManagementMod
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, currentPath]);
 
-  // Detect browser back/forward
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const handleHashChange = () => {
-      if (window.location.hash.startsWith('#storage=')) {
-        const pathFromHash = getPathFromHash();
-        // Call store method directly
-        useStorageStore.getState().loadItems(pathFromHash);
-      } else {
-        // Close modal if no hash
-        onClose();
-      }
-    };
-
-    window.addEventListener('popstate', handleHashChange);
-    window.addEventListener('hashchange', handleHashChange);
-    return () => {
-      window.removeEventListener('popstate', handleHashChange);
-      window.removeEventListener('hashchange', handleHashChange);
-    };
-  }, [isOpen, onClose]);
-
-  // Detect outside click of context menu
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (contextMenuRef.current && !contextMenuRef.current.contains(event.target as Node)) {
-        setContextMenu(null);
-      }
-      if (
-        folderContextMenuRef.current &&
-        !folderContextMenuRef.current.contains(event.target as Node)
-      ) {
-        setFolderContextMenu(null);
-      }
-    };
-
-    if (contextMenu || folderContextMenu) {
-      document.addEventListener('mousedown', handleClickOutside);
-      return () => {
-        document.removeEventListener('mousedown', handleClickOutside);
-      };
-    }
-  }, [contextMenu, folderContextMenu]);
-
-  // Path navigation
+  // Path navigation (clears selection — the new directory has its own items)
   const handleNavigate = (path: string) => {
+    clearSelection();
     setPathToHash(path);
     loadItems(path);
   };
 
   const handleNavigateToRoot = () => {
+    clearSelection();
     setPathToHash('/');
     loadItems('/');
   };
-
-  // Create breadcrumb list
-  const pathSegments = currentPath.split('/').filter(Boolean);
 
   // File upload (batch processing)
   const handleFileSelect = async (files: FileList | null) => {
@@ -408,54 +176,6 @@ export function StorageManagementModal({ isOpen, onClose }: StorageManagementMod
     }
 
     await uploadFiles(fileArray);
-  };
-
-  // Recursively get files and directories from directory entry
-  const readDirectoryEntry = async (
-    directoryEntry: FileSystemDirectoryEntry,
-    path: string = ''
-  ): Promise<{
-    files: Array<{ file: File; relativePath: string }>;
-    directories: string[];
-  }> => {
-    const files: Array<{ file: File; relativePath: string }> = [];
-    const directories: string[] = [];
-    const reader = directoryEntry.createReader();
-
-    const readEntries = (): Promise<FileSystemEntry[]> => {
-      return new Promise((resolve, reject) => {
-        reader.readEntries(resolve, reject);
-      });
-    };
-
-    const entries = await readEntries();
-
-    // Empty directory if no entry
-    if (entries.length === 0) {
-      directories.push(path);
-      return { files, directories };
-    }
-
-    for (const entry of entries) {
-      if (entry.isFile) {
-        const fileEntry = entry as FileSystemFileEntry;
-        const file = await new Promise<File>((resolve, reject) => {
-          fileEntry.file(resolve, reject);
-        });
-        files.push({
-          file,
-          relativePath: path ? `${path}/${entry.name}` : entry.name,
-        });
-      } else if (entry.isDirectory) {
-        const dirEntry = entry as FileSystemDirectoryEntry;
-        const subPath = path ? `${path}/${entry.name}` : entry.name;
-        const result = await readDirectoryEntry(dirEntry, subPath);
-        files.push(...result.files);
-        directories.push(...result.directories);
-      }
-    }
-
-    return { files, directories };
   };
 
   const handleFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -490,59 +210,20 @@ export function StorageManagementModal({ isOpen, onClose }: StorageManagementMod
       return;
     }
 
-    // Process folder using DataTransferItem
-    const allFiles: Array<{ file: File; relativePath: string }> = [];
-    const allDirectories: string[] = [];
+    // [IMPORTANT] DataTransferItemList is only valid synchronously, so collect
+    // the top-level entries before any await, then walk them asynchronously.
+    const entries = collectDropEntries(items);
+    const { files, directories } = await readDroppedEntries(entries);
 
-    // [IMPORTANT] DataTransferItemList can only be accessed synchronously,
-    // so get all entries synchronously first
-    const entries: FileSystemEntry[] = [];
-    for (let i = 0; i < items.length; i++) {
-      const item = items[i];
-      if (item.kind === 'file') {
-        const entry = item.webkitGetAsEntry();
-        if (entry) {
-          entries.push(entry);
-        }
-      }
-    }
-
-    // Execute async processing after getting entries
-    for (const entry of entries) {
-      if (entry.isFile) {
-        // If file
-        const fileEntry = entry as FileSystemFileEntry;
-        const file = await new Promise<File>((resolve, reject) => {
-          fileEntry.file(resolve, reject);
-        });
-        allFiles.push({ file, relativePath: file.name });
-      } else if (entry.isDirectory) {
-        // If directory, read recursively
-        const dirEntry = entry as FileSystemDirectoryEntry;
-        const result = await readDirectoryEntry(dirEntry, entry.name);
-        allFiles.push(...result.files);
-        allDirectories.push(...result.directories);
-      }
-    }
-
-    // Create empty directory first
-    for (const dirPath of allDirectories) {
-      // Calculate parent path using last segment of dirPath as directory name
-      const pathParts = dirPath.split('/');
-      const dirName = pathParts[pathParts.length - 1];
-      const parentPath =
-        pathParts.length > 1
-          ? currentPath === '/'
-            ? `/${pathParts.slice(0, -1).join('/')}`
-            : `${currentPath}/${pathParts.slice(0, -1).join('/')}`
-          : currentPath;
-
+    // Create empty directories first (files carry their own nested paths).
+    for (const dirPath of directories) {
+      const { dirName, parentPath } = resolveDirectoryCreation(dirPath, currentPath);
       await createDirectory(dirName, parentPath);
     }
 
     // Batch upload all files
-    if (allFiles.length > 0) {
-      await uploadFiles(allFiles);
+    if (files.length > 0) {
+      await uploadFiles(files);
     }
   };
 
@@ -561,22 +242,6 @@ export function StorageManagementModal({ isOpen, onClose }: StorageManagementMod
     setShowNewDirectoryInput(false);
   };
 
-  // Download
-  const handleDownload = async (item: StorageItem) => {
-    if (item.type === 'directory') {
-      // ZIP download for folders
-      await handleFolderDownload(item.path, item.name);
-    } else {
-      // Open window synchronously within user gesture context (before await)
-      // This preserves transient activation on mobile browsers
-      await downloadWithAsyncUrl(
-        () => generateDownloadUrl(item.path),
-        (error) => {
-          logger.error('Download error:', error);
-        }
-      );
-    }
-  };
 
   // Show context menu of content panel
   const handleContextMenu = (e: React.MouseEvent, item: StorageItem) => {
@@ -622,28 +287,19 @@ export function StorageManagementModal({ isOpen, onClose }: StorageManagementMod
     if (!contextMenu) return;
     const item = items.find((i) => i.path === contextMenu.path);
     if (item && item.type === 'file') {
-      await handleDownload(item);
+      await downloadItem(item);
     }
     setContextMenu(null);
   };
 
-  // Delete from content panel context menu
-  const handleContextDelete = async () => {
+  // Delete from content panel context menu. Like the card button, this deletes
+  // the whole selection when the right-clicked item is part of a multi-selection.
+  const handleContextDelete = () => {
     if (!contextMenu) return;
     const item = items.find((i) => i.path === contextMenu.path);
-    if (item) {
-      const confirmMessage =
-        item.type === 'directory'
-          ? t('storage.deleteDirectoryConfirm', { name: item.name })
-          : t('storage.deleteFileConfirm', { name: item.name });
-
-      if (window.confirm(confirmMessage)) {
-        setContextMenu(null);
-        await deleteItem(item);
-      } else {
-        setContextMenu(null);
-      }
-    }
+    setContextMenu(null);
+    if (!item) return;
+    handleItemDelete(item);
   };
 
   // Delete from folder tree context menu
@@ -665,58 +321,34 @@ export function StorageManagementModal({ isOpen, onClose }: StorageManagementMod
     }
   };
 
-  // Folder download
-  const handleFolderDownload = async (folderPath: string, folderName: string) => {
-    // Open modal and start showing progress
-    setDownloadStatus('downloading');
-    setDownloadError('');
-    setDownloadProgress({ current: 0, total: 0, percentage: 0, currentFile: '' });
-    setIsDownloadModalOpen(true);
+  // Bulk download selected items as a single ZIP (clears selection on success).
+  const handleBulkDownload = () => downloadSelection(selectedItems, clearSelection);
 
-    // Create AbortController
-    abortControllerRef.current = new AbortController();
-
-    try {
-      await downloadFolder(
-        folderPath,
-        folderName,
-        (progress) => {
-          setDownloadProgress(progress);
-        },
-        abortControllerRef.current.signal
-      );
-
-      // Success
-      setDownloadStatus('success');
-    } catch (error) {
-      if (error instanceof Error) {
-        if (error.message === 'Download cancelled') {
-          setDownloadStatus('cancelled');
-        } else {
-          setDownloadStatus('error');
-          setDownloadError(error.message);
-        }
-      } else {
-        setDownloadStatus('error');
-        setDownloadError('Unknown error occurred');
-      }
-    } finally {
-      abortControllerRef.current = null;
-    }
+  // Open the confirm modal for the bulk-bar "delete selected" action.
+  const handleBulkDeleteRequest = () => {
+    if (selectedItems.length === 0) return;
+    setPendingDeleteItems(selectedItems);
+    setIsBulkDeleteConfirmOpen(true);
   };
 
-  // Cancel download
-  const handleCancelDownload = () => {
-    if (abortControllerRef.current) {
-      abortControllerRef.current.abort();
+  // Per-item delete (card button). When the item is part of a multi-selection,
+  // delete the whole selection at once; otherwise delete just that item.
+  const handleItemDelete = (item: StorageItem) => {
+    if (selectedPaths.has(item.path) && selectedItems.length > 1) {
+      setPendingDeleteItems(selectedItems);
+    } else {
+      setPendingDeleteItems([item]);
     }
+    setIsBulkDeleteConfirmOpen(true);
   };
 
-  // Close download modal
-  const handleCloseDownloadModal = () => {
-    setIsDownloadModalOpen(false);
-    setDownloadProgress({ current: 0, total: 0, percentage: 0, currentFile: '' });
-    setDownloadError('');
+  // Confirmed deletion of whatever is pending (single or bulk).
+  const handleDeleteConfirmed = async () => {
+    const targets = [...pendingDeleteItems];
+    // Drop deleted items from the current selection.
+    deselectPaths(targets.map((i) => i.path));
+    setPendingDeleteItems([]);
+    await deleteItems(targets);
   };
 
   // Folder download from context menu
@@ -725,7 +357,7 @@ export function StorageManagementModal({ isOpen, onClose }: StorageManagementMod
     const item = items.find((i) => i.path === contextMenu.path);
     if (item && item.type === 'directory') {
       setContextMenu(null);
-      await handleFolderDownload(item.path, item.name);
+      await downloadFolderAsZip(item.path, item.name);
     }
   };
 
@@ -733,7 +365,7 @@ export function StorageManagementModal({ isOpen, onClose }: StorageManagementMod
   const handleTreeFolderDownload = async () => {
     if (!folderContextMenu) return;
     setFolderContextMenu(null);
-    await handleFolderDownload(folderContextMenu.path, folderContextMenu.name);
+    await downloadFolderAsZip(folderContextMenu.path, folderContextMenu.name);
   };
 
   return (
@@ -775,67 +407,26 @@ export function StorageManagementModal({ isOpen, onClose }: StorageManagementMod
         </div>
       </div>
 
-      {/* Toolbar */}
-      <div className="px-4 md:px-6 py-2.5 border-b border-border bg-surface-secondary">
-        <div className="flex flex-wrap items-center gap-1.5">
-          <button
-            onClick={() => fileInputRef.current?.click()}
-            disabled={isUploading}
-            className="flex items-center gap-1.5 px-2 py-1.5 text-xs text-fg-secondary hover:text-fg-default hover:bg-surface-secondary rounded disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-          >
-            <Upload className="w-3.5 h-3.5" />
-            <span>{t('storage.upload')}</span>
-          </button>
-
-          <button
-            onClick={() => setShowNewDirectoryInput(true)}
-            className="flex items-center gap-1.5 px-2 py-1.5 text-xs text-fg-secondary hover:text-fg-default hover:bg-surface-secondary rounded transition-colors"
-          >
-            <FolderPlus className="w-3.5 h-3.5" />
-            <span>{t('storage.newFolder')}</span>
-          </button>
-
-          <button
-            onClick={() => setAgentWorkingDirectory(currentPath)}
-            disabled={agentWorkingDirectory === currentPath}
-            className="flex items-center gap-1.5 px-2 py-1.5 text-xs text-fg-secondary hover:text-fg-default hover:bg-surface-secondary rounded disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-          >
-            <FolderCog className="w-3.5 h-3.5" />
-            <span>{t('storage.setAsWorkingDirectory')}</span>
-          </button>
-
-          <input
-            ref={fileInputRef}
-            type="file"
-            multiple
-            onChange={handleFileInputChange}
-            className="hidden"
-          />
-        </div>
-
-        {/* Upload progress */}
-        {isUploading && (
-          <div className="mt-3">
-            <div className="flex items-center justify-between text-xs sm:text-sm text-fg-secondary mb-1">
-              <span className="truncate">
-                {uploadTotal > 0
-                  ? t('storage.uploadingProgress', {
-                      completed: uploadCompleted,
-                      total: uploadTotal,
-                    })
-                  : t('storage.uploading')}
-              </span>
-              <span className="ml-2">{uploadProgress}%</span>
-            </div>
-            <div className="w-full bg-border rounded-full h-2">
-              <div
-                className="bg-action-primary h-2 rounded-full transition-all duration-300"
-                style={{ width: `${uploadProgress}%` }}
-              />
-            </div>
-          </div>
-        )}
-      </div>
+      {/* Toolbar (default actions or bulk action bar) */}
+      <StorageToolbar
+        selectedCount={selectedPaths.size}
+        onBulkDownload={handleBulkDownload}
+        onBulkDelete={handleBulkDeleteRequest}
+        onClearSelection={clearSelection}
+        canSetWorkingDirectory={agentWorkingDirectory !== currentPath}
+        onUploadClick={() => fileInputRef.current?.click()}
+        onNewFolder={() => setShowNewDirectoryInput(true)}
+        onSetWorkingDirectory={() => setAgentWorkingDirectory(currentPath)}
+        upload={{ isUploading, uploadProgress, uploadTotal, uploadCompleted }}
+      />
+      {/* Hidden file input (owned by the modal; triggered from the toolbar) */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        onChange={handleFileInputChange}
+        className="hidden"
+      />
 
       {/* Content area: responsive layout */}
       <div className="flex divide-x divide-gray-200 flex-1 min-h-0">
@@ -861,68 +452,36 @@ export function StorageManagementModal({ isOpen, onClose }: StorageManagementMod
         {/* Right column: file list */}
         <div className="flex-1 flex flex-col min-w-0">
           {/* Breadcrumb navigation */}
-          <div className="px-4 md:px-6 py-3 border-b border-border bg-surface-primary">
-            <div className="flex items-center gap-2">
-              {/* Breadcrumb section (scrollable) */}
-              <div className="flex items-center gap-1 text-sm overflow-x-auto flex-1 min-w-0">
-                <button
-                  onClick={handleNavigateToRoot}
-                  className="flex items-center gap-1 px-2 py-1 text-fg-secondary hover:text-fg-default hover:bg-surface-secondary rounded transition-colors whitespace-nowrap"
-                >
-                  <Home className="w-4 h-4 flex-shrink-0" />
-                  <span>{t('storage.root')}</span>
-                </button>
-
-                {pathSegments.map((segment, index) => {
-                  const segmentPath = '/' + pathSegments.slice(0, index + 1).join('/');
-                  return (
-                    <div key={segmentPath} className="flex items-center gap-1">
-                      <ChevronRight className="w-4 h-4 text-fg-disabled flex-shrink-0" />
-                      <button
-                        onClick={() => handleNavigate(segmentPath)}
-                        className="px-2 py-1 text-fg-secondary hover:text-fg-default hover:bg-surface-secondary rounded transition-colors truncate max-w-[120px] sm:max-w-none"
-                      >
-                        {segment}
-                      </button>
-                    </div>
-                  );
-                })}
-              </div>
-
-              {/* Directory size warning icon (outside overflow container) */}
-              {sizeWarning?.show && (
-                <Tooltip
-                  content={
-                    <div className="text-xs leading-relaxed">
-                      <p className="font-medium">{t('storage.largeSizeWarningTitle')}</p>
-                      <p className="mt-1">
-                        {t('storage.largeSizeWarningMessage', {
-                          size: formatSizeForWarning(sizeWarning.totalSize),
-                          count: sizeWarning.fileCount,
-                        })}
-                      </p>
-                    </div>
-                  }
-                  position="left"
-                  width="320px"
-                >
-                  <div className="flex-shrink-0 p-1 cursor-help">
-                    <AlertTriangle className="w-4 h-4 text-amber-500" />
-                  </div>
-                </Tooltip>
-              )}
-            </div>
-          </div>
+          <StorageBreadcrumb
+            currentPath={currentPath}
+            onNavigate={handleNavigate}
+            onNavigateToRoot={handleNavigateToRoot}
+            sizeWarning={sizeWarning}
+          />
 
           {/* File list */}
           <div
-            className={`flex-1 overflow-y-auto px-4 md:px-6 py-4 relative ${
+            ref={listContainerRef}
+            className={`flex-1 overflow-y-auto px-4 md:px-6 py-4 relative select-none ${
               isDragOver ? 'bg-feedback-info-bg' : ''
-            }`}
+            } ${marqueeRect ? 'cursor-crosshair' : ''}`}
             onDragOver={handleDragOver}
             onDragLeave={handleDragLeave}
             onDrop={handleDrop}
+            onMouseDown={handleListMouseDown}
           >
+            {/* Marquee selection rectangle */}
+            {marqueeRect && (
+              <div
+                className="absolute z-10 border border-action-primary bg-action-primary/10 pointer-events-none rounded-sm"
+                style={{
+                  left: `${marqueeRect.left}px`,
+                  top: `${marqueeRect.top}px`,
+                  width: `${marqueeRect.width}px`,
+                  height: `${marqueeRect.height}px`,
+                }}
+              />
+            )}
             {/* Error display */}
             {error && (
               <div className="mb-4 p-3 bg-feedback-error-bg border border-feedback-error-border rounded-lg flex items-start gap-2">
@@ -958,15 +517,34 @@ export function StorageManagementModal({ isOpen, onClose }: StorageManagementMod
                   </div>
                 ) : (
                   <div className="space-y-2">
+                    {/* Select-all header */}
+                    {items.length > 0 && (
+                      <div className="flex items-center gap-3 px-3 pb-1">
+                        <input
+                          type="checkbox"
+                          checked={allSelected}
+                          ref={(el) => {
+                            if (el) el.indeterminate = someSelected;
+                          }}
+                          onChange={handleToggleSelectAll}
+                          aria-label={t('storage.selectAll')}
+                          className="block w-4 h-4 rounded border-border-strong text-action-primary focus:ring-border-focus cursor-pointer"
+                        />
+                        <span className="text-xs text-fg-muted">{t('storage.selectAll')}</span>
+                      </div>
+                    )}
                     {items.map((item) => (
-                      <StorageItemComponent
+                      <StorageItemRow
                         key={item.path}
                         item={item}
-                        onDelete={deleteItem}
+                        onDelete={handleItemDelete}
                         onNavigate={handleNavigate}
-                        onDownload={handleDownload}
+                        onDownload={downloadItem}
                         onContextMenu={handleContextMenu}
                         onSetWorkingDirectory={setAgentWorkingDirectory}
+                        selected={selectedPaths.has(item.path)}
+                        selectionActive={selectedPaths.size > 0}
+                        onToggleSelect={handleToggleSelect}
                       />
                     ))}
 
@@ -1032,124 +610,29 @@ export function StorageManagementModal({ isOpen, onClose }: StorageManagementMod
 
         {/* Content panel context menu */}
         {contextMenu && (
-          <div
-            ref={contextMenuRef}
-            className="fixed bg-surface-primary rounded-lg shadow-lg border border-border py-1 z-50 min-w-[160px]"
-            style={{
-              left: `${Math.min(contextMenu.x, window.innerWidth - 180)}px`,
-              top: `${Math.min(contextMenu.y, window.innerHeight - 200)}px`,
-            }}
-          >
-            {contextMenu.type === 'file' ? (
-              <button
-                onClick={handleContextDownload}
-                className="w-full px-4 py-2 text-sm text-left hover:bg-surface-secondary flex items-center gap-2 transition-colors"
-              >
-                <Download className="w-4 h-4 text-fg-secondary" />
-                <span className="text-fg-default">{t('storage.download')}</span>
-              </button>
-            ) : (
-              <>
-                <button
-                  onClick={() => {
-                    setAgentWorkingDirectory(contextMenu.path);
-                    setContextMenu(null);
-                  }}
-                  className="w-full px-4 py-2 text-sm text-left hover:bg-surface-secondary flex items-center gap-2 transition-colors"
-                >
-                  <FolderCog className="w-4 h-4 text-fg-secondary" />
-                  <span className="text-fg-default">{t('storage.setAsWorkingDirectory')}</span>
-                </button>
-                <button
-                  onClick={handleContextFolderDownload}
-                  className="w-full px-4 py-2 text-sm text-left hover:bg-surface-secondary flex items-center gap-2 transition-colors"
-                >
-                  <Download className="w-4 h-4 text-fg-secondary" />
-                  <span className="text-fg-default">{t('storage.downloadFolder')}</span>
-                </button>
-              </>
-            )}
-            <button
-              onClick={handleContextDelete}
-              className="w-full px-4 py-2 text-sm text-left hover:bg-surface-secondary flex items-center gap-2 transition-colors"
-            >
-              <Trash2 className="w-4 h-4 text-fg-secondary" />
-              <span className="text-fg-default">{t('common.delete')}</span>
-            </button>
-            <div className="border-t border-border my-1" />
-            <button
-              onClick={() => handleCopyPath(contextMenu.path, () => setContextMenu(null))}
-              className="w-full px-4 py-2 text-sm text-left hover:bg-surface-secondary flex items-center gap-2 transition-colors"
-            >
-              {copiedPath === contextMenu.path ? (
-                <>
-                  <Check className="w-4 h-4 text-green-600" />
-                  <span className="text-green-600">{t('storage.copied')}</span>
-                </>
-              ) : (
-                <>
-                  <Copy className="w-4 h-4 text-fg-secondary" />
-                  <span className="text-fg-default">{t('storage.copyPath')}</span>
-                </>
-              )}
-            </button>
-          </div>
+          <StorageContentContextMenu
+            menu={contextMenu}
+            copiedPath={copiedPath}
+            onClose={() => setContextMenu(null)}
+            onDownloadFile={handleContextDownload}
+            onDownloadFolder={handleContextFolderDownload}
+            onSetWorkingDirectory={setAgentWorkingDirectory}
+            onDelete={handleContextDelete}
+            onCopyPath={handleCopyPath}
+          />
         )}
 
         {/* Folder tree context menu */}
         {folderContextMenu && (
-          <div
-            ref={folderContextMenuRef}
-            className="fixed bg-surface-primary rounded-lg shadow-lg border border-border py-1 z-50 min-w-[160px]"
-            style={{
-              left: `${Math.min(folderContextMenu.x, window.innerWidth - 180)}px`,
-              top: `${Math.min(folderContextMenu.y, window.innerHeight - 200)}px`,
-            }}
-          >
-            <button
-              onClick={() => {
-                setAgentWorkingDirectory(folderContextMenu.path);
-                setFolderContextMenu(null);
-              }}
-              className="w-full px-4 py-2 text-sm text-left hover:bg-surface-secondary flex items-center gap-2 transition-colors"
-            >
-              <FolderCog className="w-4 h-4 text-fg-secondary" />
-              <span className="text-fg-default">{t('storage.setAsWorkingDirectory')}</span>
-            </button>
-            <button
-              onClick={handleTreeFolderDownload}
-              className="w-full px-4 py-2 text-sm text-left hover:bg-surface-secondary flex items-center gap-2 transition-colors"
-            >
-              <Download className="w-4 h-4 text-fg-secondary" />
-              <span className="text-fg-default">{t('storage.downloadFolder')}</span>
-            </button>
-            <button
-              onClick={handleFolderDelete}
-              className="w-full px-4 py-2 text-sm text-left hover:bg-surface-secondary flex items-center gap-2 transition-colors"
-            >
-              <Trash2 className="w-4 h-4 text-fg-secondary" />
-              <span className="text-fg-default">{t('common.delete')}</span>
-            </button>
-            <div className="border-t border-border my-1" />
-            <button
-              onClick={() =>
-                handleCopyPath(folderContextMenu.path, () => setFolderContextMenu(null))
-              }
-              className="w-full px-4 py-2 text-sm text-left hover:bg-surface-secondary flex items-center gap-2 transition-colors"
-            >
-              {copiedPath === folderContextMenu.path ? (
-                <>
-                  <Check className="w-4 h-4 text-green-600" />
-                  <span className="text-green-600">{t('storage.copied')}</span>
-                </>
-              ) : (
-                <>
-                  <Copy className="w-4 h-4 text-fg-secondary" />
-                  <span className="text-fg-default">{t('storage.copyPath')}</span>
-                </>
-              )}
-            </button>
-          </div>
+          <StorageFolderContextMenu
+            menu={folderContextMenu}
+            copiedPath={copiedPath}
+            onClose={() => setFolderContextMenu(null)}
+            onDownloadFolder={handleTreeFolderDownload}
+            onSetWorkingDirectory={setAgentWorkingDirectory}
+            onDelete={handleFolderDelete}
+            onCopyPath={handleCopyPath}
+          />
         )}
       </div>
 
@@ -1167,13 +650,31 @@ export function StorageManagementModal({ isOpen, onClose }: StorageManagementMod
       </div>
 
       {/* Download progress modal */}
-      <DownloadProgressModal
-        isOpen={isDownloadModalOpen}
-        onClose={handleCloseDownloadModal}
-        progress={downloadProgress}
-        status={downloadStatus}
-        errorMessage={downloadError}
-        onCancel={downloadStatus === 'downloading' ? handleCancelDownload : undefined}
+      <DownloadProgressModal {...downloadModalProps} />
+
+      {/* Delete confirmation modal (single or bulk) */}
+      <ConfirmModal
+        isOpen={isBulkDeleteConfirmOpen}
+        onClose={() => {
+          setIsBulkDeleteConfirmOpen(false);
+          setPendingDeleteItems([]);
+        }}
+        onConfirm={handleDeleteConfirmed}
+        title={t('storage.bulkDeleteConfirmTitle')}
+        message={
+          pendingDeleteItems.length === 1
+            ? pendingDeleteItems[0].type === 'directory'
+              ? t('storage.deleteDirectoryConfirm', { name: pendingDeleteItems[0].name })
+              : t('storage.deleteFileConfirm', { name: pendingDeleteItems[0].name })
+            : t('storage.bulkDeleteConfirm', {
+                count: pendingDeleteItems.length,
+                folders: pendingDeleteItems.filter((i) => i.type === 'directory').length,
+                files: pendingDeleteItems.filter((i) => i.type === 'file').length,
+              })
+        }
+        confirmText={t('common.delete')}
+        cancelText={t('common.cancel')}
+        variant="danger"
       />
     </Modal>
   );

--- a/packages/frontend/src/components/storage/StorageBreadcrumb.tsx
+++ b/packages/frontend/src/components/storage/StorageBreadcrumb.tsx
@@ -1,0 +1,83 @@
+/**
+ * Breadcrumb path navigation for the storage modal, with a large-directory
+ * size-warning tooltip on the right. Presentational leaf — derives its path
+ * segments from `currentPath` and emits navigation callbacks.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { Home, ChevronRight, AlertTriangle } from 'lucide-react';
+import { Tooltip } from '../ui/Tooltip/Tooltip';
+import { formatBytes } from '../../utils/formatBytes';
+
+export interface StorageBreadcrumbProps {
+  currentPath: string;
+  onNavigate: (path: string) => void;
+  onNavigateToRoot: () => void;
+  /** Set when the current directory exceeds the size threshold; null otherwise. */
+  sizeWarning: { show: boolean; totalSize: number; fileCount: number } | null;
+}
+
+export function StorageBreadcrumb({
+  currentPath,
+  onNavigate,
+  onNavigateToRoot,
+  sizeWarning,
+}: StorageBreadcrumbProps) {
+  const { t } = useTranslation();
+  const pathSegments = currentPath.split('/').filter(Boolean);
+
+  return (
+    <div className="px-4 md:px-6 py-3 border-b border-border bg-surface-primary">
+      <div className="flex items-center gap-2">
+        {/* Breadcrumb section (scrollable) */}
+        <div className="flex items-center gap-1 text-sm overflow-x-auto flex-1 min-w-0">
+          <button
+            onClick={onNavigateToRoot}
+            className="flex items-center gap-1 px-2 py-1 text-fg-secondary hover:text-fg-default hover:bg-surface-secondary rounded transition-colors whitespace-nowrap"
+          >
+            <Home className="w-4 h-4 flex-shrink-0" />
+            <span>{t('storage.root')}</span>
+          </button>
+
+          {pathSegments.map((segment, index) => {
+            const segmentPath = '/' + pathSegments.slice(0, index + 1).join('/');
+            return (
+              <div key={segmentPath} className="flex items-center gap-1">
+                <ChevronRight className="w-4 h-4 text-fg-disabled flex-shrink-0" />
+                <button
+                  onClick={() => onNavigate(segmentPath)}
+                  className="px-2 py-1 text-fg-secondary hover:text-fg-default hover:bg-surface-secondary rounded transition-colors truncate max-w-[120px] sm:max-w-none"
+                >
+                  {segment}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Directory size warning icon (outside overflow container) */}
+        {sizeWarning?.show && (
+          <Tooltip
+            content={
+              <div className="text-xs leading-relaxed">
+                <p className="font-medium">{t('storage.largeSizeWarningTitle')}</p>
+                <p className="mt-1">
+                  {t('storage.largeSizeWarningMessage', {
+                    size: formatBytes(sizeWarning.totalSize, { maxUnit: 'GB' }),
+                    count: sizeWarning.fileCount,
+                  })}
+                </p>
+              </div>
+            }
+            position="left"
+            width="320px"
+          >
+            <div className="flex-shrink-0 p-1 cursor-help">
+              <AlertTriangle className="w-4 h-4 text-amber-500" />
+            </div>
+          </Tooltip>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/storage/StorageContextMenu.tsx
+++ b/packages/frontend/src/components/storage/StorageContextMenu.tsx
@@ -1,0 +1,205 @@
+/**
+ * Right-click context menus for the storage modal.
+ *
+ * The content-panel menu and the folder-tree menu were ~90% duplicated JSX.
+ * This collapses them into one presentational primitive ({@link StorageContextMenu})
+ * driven by an `items[]` array, plus two thin wrappers that build the right
+ * items for each surface. The menus are pure leaves: they receive data +
+ * callbacks and never touch the store. Each menu self-dismisses on an outside
+ * mousedown (matching the modal's previous behavior); the parent owns the
+ * open/position state and `copiedPath`.
+ */
+
+import { useEffect, useRef, Fragment } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Download, Trash2, Copy, Check, FolderCog, type LucideIcon } from 'lucide-react';
+
+export interface StorageContextMenuItem {
+  key: string;
+  icon: LucideIcon;
+  label: string;
+  onClick: () => void;
+  /** Render a divider above this item. */
+  dividerBefore?: boolean;
+  /** Green "confirmation" styling (used by the Copy-path → Copied swap). */
+  confirmActive?: boolean;
+}
+
+export interface StorageContextMenuProps {
+  /** Viewport coordinates from the originating contextmenu event. */
+  x: number;
+  y: number;
+  items: StorageContextMenuItem[];
+  /** Outside-click dismissal; the parent clears its menu-position state. */
+  onClose: () => void;
+}
+
+/** Generic positioned popover menu. Clamps to the viewport like the original. */
+export function StorageContextMenu({ x, y, items, onClose }: StorageContextMenuProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleMouseDown = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => document.removeEventListener('mousedown', handleMouseDown);
+  }, [onClose]);
+
+  return (
+    <div
+      ref={ref}
+      className="fixed bg-surface-primary rounded-lg shadow-lg border border-border py-1 z-50 min-w-[160px]"
+      style={{
+        left: `${Math.min(x, window.innerWidth - 180)}px`,
+        top: `${Math.min(y, window.innerHeight - 200)}px`,
+      }}
+    >
+      {items.map((item) => {
+        const Icon = item.icon;
+        return (
+          <Fragment key={item.key}>
+            {item.dividerBefore && <div className="border-t border-border my-1" />}
+            <button
+              onClick={item.onClick}
+              className="w-full px-4 py-2 text-sm text-left hover:bg-surface-secondary flex items-center gap-2 transition-colors"
+            >
+              <Icon className={`w-4 h-4 ${item.confirmActive ? 'text-green-600' : 'text-fg-secondary'}`} />
+              <span className={item.confirmActive ? 'text-green-600' : 'text-fg-default'}>
+                {item.label}
+              </span>
+            </button>
+          </Fragment>
+        );
+      })}
+    </div>
+  );
+}
+
+export interface ContentMenuState {
+  x: number;
+  y: number;
+  path: string;
+  type: 'file' | 'directory';
+}
+
+export interface StorageContentContextMenuProps {
+  menu: ContentMenuState;
+  copiedPath: string | null;
+  onClose: () => void;
+  onDownloadFile: () => void;
+  onDownloadFolder: () => void;
+  onSetWorkingDirectory: (path: string) => void;
+  onDelete: () => void;
+  onCopyPath: (path: string, closeMenu: () => void) => void;
+}
+
+/** Context menu for an item in the file list (file or directory). */
+export function StorageContentContextMenu({
+  menu,
+  copiedPath,
+  onClose,
+  onDownloadFile,
+  onDownloadFolder,
+  onSetWorkingDirectory,
+  onDelete,
+  onCopyPath,
+}: StorageContentContextMenuProps) {
+  const { t } = useTranslation();
+  const copied = copiedPath === menu.path;
+
+  const items: StorageContextMenuItem[] =
+    menu.type === 'file'
+      ? [{ key: 'download', icon: Download, label: t('storage.download'), onClick: onDownloadFile }]
+      : [
+          {
+            key: 'set-wd',
+            icon: FolderCog,
+            label: t('storage.setAsWorkingDirectory'),
+            onClick: () => {
+              onSetWorkingDirectory(menu.path);
+              onClose();
+            },
+          },
+          {
+            key: 'download-folder',
+            icon: Download,
+            label: t('storage.downloadFolder'),
+            onClick: onDownloadFolder,
+          },
+        ];
+
+  items.push({ key: 'delete', icon: Trash2, label: t('common.delete'), onClick: onDelete });
+  items.push({
+    key: 'copy',
+    icon: copied ? Check : Copy,
+    label: copied ? t('storage.copied') : t('storage.copyPath'),
+    confirmActive: copied,
+    dividerBefore: true,
+    onClick: () => onCopyPath(menu.path, onClose),
+  });
+
+  return <StorageContextMenu x={menu.x} y={menu.y} items={items} onClose={onClose} />;
+}
+
+export interface FolderMenuState {
+  x: number;
+  y: number;
+  path: string;
+  name: string;
+}
+
+export interface StorageFolderContextMenuProps {
+  menu: FolderMenuState;
+  copiedPath: string | null;
+  onClose: () => void;
+  onDownloadFolder: () => void;
+  onSetWorkingDirectory: (path: string) => void;
+  onDelete: () => void;
+  onCopyPath: (path: string, closeMenu: () => void) => void;
+}
+
+/** Context menu for a folder in the left-hand tree. */
+export function StorageFolderContextMenu({
+  menu,
+  copiedPath,
+  onClose,
+  onDownloadFolder,
+  onSetWorkingDirectory,
+  onDelete,
+  onCopyPath,
+}: StorageFolderContextMenuProps) {
+  const { t } = useTranslation();
+  const copied = copiedPath === menu.path;
+
+  const items: StorageContextMenuItem[] = [
+    {
+      key: 'set-wd',
+      icon: FolderCog,
+      label: t('storage.setAsWorkingDirectory'),
+      onClick: () => {
+        onSetWorkingDirectory(menu.path);
+        onClose();
+      },
+    },
+    {
+      key: 'download-folder',
+      icon: Download,
+      label: t('storage.downloadFolder'),
+      onClick: onDownloadFolder,
+    },
+    { key: 'delete', icon: Trash2, label: t('common.delete'), onClick: onDelete },
+    {
+      key: 'copy',
+      icon: copied ? Check : Copy,
+      label: copied ? t('storage.copied') : t('storage.copyPath'),
+      confirmActive: copied,
+      dividerBefore: true,
+      onClick: () => onCopyPath(menu.path, onClose),
+    },
+  ];
+
+  return <StorageContextMenu x={menu.x} y={menu.y} items={items} onClose={onClose} />;
+}

--- a/packages/frontend/src/components/storage/StorageItemRow.tsx
+++ b/packages/frontend/src/components/storage/StorageItemRow.tsx
@@ -1,0 +1,182 @@
+/**
+ * A single row in the storage file list (file or directory).
+ *
+ * Presentational leaf: it receives the item plus selection state and callbacks,
+ * and never touches the store. The `data-storage-path` attribute is REQUIRED —
+ * the marquee selection hook locates rows by it.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { Folder, File, Download, Trash2, FolderCog } from 'lucide-react';
+import type { StorageItem } from '../../api/storage';
+import { Tooltip } from '../ui/Tooltip/Tooltip';
+import { getFileIcon } from '../../utils/fileIcons';
+import { formatBytes } from '../../utils/formatBytes';
+
+export interface StorageItemRowProps {
+  item: StorageItem;
+  onDelete: (item: StorageItem) => void;
+  onNavigate: (path: string) => void;
+  onDownload: (item: StorageItem) => void;
+  onContextMenu: (e: React.MouseEvent, item: StorageItem) => void;
+  onSetWorkingDirectory?: (path: string) => void;
+  selected: boolean;
+  selectionActive: boolean;
+  onToggleSelect: (item: StorageItem, e: React.MouseEvent) => void;
+}
+
+export function StorageItemRow({
+  item,
+  onDelete,
+  onNavigate,
+  onDownload,
+  onContextMenu,
+  onSetWorkingDirectory,
+  selected,
+  selectionActive,
+  onToggleSelect,
+}: StorageItemRowProps) {
+  const { t } = useTranslation();
+
+  const handleDelete = (e: React.MouseEvent) => {
+    e.stopPropagation(); // Stop card click event
+    // Parent decides whether this is a single delete (with confirm) or a bulk
+    // delete of the whole selection when this item is part of a multi-selection.
+    onDelete(item);
+  };
+
+  const handleDownloadClick = (e: React.MouseEvent) => {
+    e.stopPropagation(); // Stop card click event
+    onDownload(item);
+  };
+
+  const handleCardClick = (e: React.MouseEvent) => {
+    // While a selection exists, or with a modifier key, clicks toggle selection
+    // instead of navigating/downloading (prevents accidental actions).
+    if (selectionActive || e.metaKey || e.ctrlKey || e.shiftKey) {
+      onToggleSelect(item, e);
+      return;
+    }
+    if (item.type === 'directory') {
+      onNavigate(item.path);
+    } else {
+      // Download if file
+      onDownload(item);
+    }
+  };
+
+  const handleCheckboxClick = (e: React.MouseEvent) => {
+    e.stopPropagation(); // Don't trigger card navigation/download
+    onToggleSelect(item, e);
+  };
+
+  const formatDate = (dateString?: string) => {
+    if (!dateString) return '—';
+    return new Date(dateString).toLocaleDateString('ja-JP', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  const handleContextMenuClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    onContextMenu(e, item);
+  };
+
+  // Get file icon
+  const fileIconConfig = item.type === 'file' ? getFileIcon(item.name) : null;
+  const FileIcon = fileIconConfig?.icon;
+
+  return (
+    <div
+      onClick={handleCardClick}
+      onContextMenu={handleContextMenuClick}
+      data-storage-path={item.path}
+      className={`border rounded-lg p-3 transition-colors cursor-pointer ${
+        selected
+          ? 'border-action-primary bg-feedback-info-bg'
+          : 'border-border hover:bg-surface-secondary'
+      }`}
+      role="button"
+      tabIndex={0}
+      aria-selected={selected}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          handleCardClick(e as unknown as React.MouseEvent);
+        }
+      }}
+    >
+      <div className="flex items-center gap-3">
+        {/* Selection checkbox */}
+        <div className="flex-shrink-0 pr-1" onClick={handleCheckboxClick}>
+          <input
+            type="checkbox"
+            checked={selected}
+            readOnly
+            aria-label={t('storage.selectItem', { name: item.name })}
+            className="block w-4 h-4 rounded border-border-strong text-action-primary focus:ring-border-focus cursor-pointer"
+          />
+        </div>
+
+        {/* Icon */}
+        <div className="flex-shrink-0">
+          {item.type === 'directory' ? (
+            <Folder className="w-5 h-5 text-amber-500" />
+          ) : FileIcon ? (
+            <FileIcon className={`w-5 h-5 ${fileIconConfig.color}`} />
+          ) : (
+            <File className="w-5 h-5 text-action-primary" />
+          )}
+        </div>
+
+        {/* Information */}
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-medium text-fg-default truncate">{item.name}</div>
+          <div className="flex items-center gap-4 text-xs text-fg-muted mt-1">
+            {item.type === 'file' && (
+              <span>{formatBytes(item.size, { emptyPlaceholder: '—' })}</span>
+            )}
+            <span className="hidden sm:inline">{formatDate(item.lastModified)}</span>
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center gap-1 sm:gap-2">
+          {item.type === 'directory' && onSetWorkingDirectory && (
+            <Tooltip content={t('storage.setAsWorkingDirectory')}>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onSetWorkingDirectory(item.path);
+                }}
+                className="p-2 text-fg-disabled hover:text-fg-secondary hover:bg-surface-secondary rounded-lg transition-colors"
+                title={t('storage.setAsWorkingDirectory')}
+              >
+                <FolderCog className="w-4 h-4" />
+              </button>
+            </Tooltip>
+          )}
+          <button
+            onClick={handleDownloadClick}
+            className="p-2 text-fg-disabled hover:text-action-primary hover:bg-feedback-info-bg rounded-lg transition-colors"
+            title={item.type === 'directory' ? t('storage.downloadFolder') : t('storage.download')}
+          >
+            <Download className="w-4 h-4" />
+          </button>
+          <button
+            onClick={handleDelete}
+            className="p-2 text-fg-disabled hover:text-feedback-error hover:bg-feedback-error-bg rounded-lg transition-colors"
+            title={t('common.delete')}
+          >
+            <Trash2 className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/storage/StorageToolbar.tsx
+++ b/packages/frontend/src/components/storage/StorageToolbar.tsx
@@ -1,0 +1,138 @@
+/**
+ * The storage modal's toolbar. Shows the default action row (upload / new
+ * folder / set working dir) or, when items are selected, a bulk action bar
+ * (download / delete / clear). The upload-progress bar renders below either.
+ *
+ * Presentational leaf: the hidden file <input> and all state stay in the modal;
+ * this component only emits callbacks. Upload fields are bundled into one
+ * `upload` object to keep the prop surface narrow.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { X, Upload, FolderPlus, Trash2, Download, FolderCog } from 'lucide-react';
+
+export interface UploadState {
+  isUploading: boolean;
+  uploadProgress: number;
+  uploadTotal: number;
+  uploadCompleted: number;
+}
+
+export interface StorageToolbarProps {
+  selectedCount: number;
+  // Bulk actions (shown when selectedCount > 0)
+  onBulkDownload: () => void;
+  onBulkDelete: () => void;
+  onClearSelection: () => void;
+  // Default actions (shown when nothing is selected)
+  canSetWorkingDirectory: boolean;
+  onUploadClick: () => void;
+  onNewFolder: () => void;
+  onSetWorkingDirectory: () => void;
+  upload: UploadState;
+}
+
+export function StorageToolbar({
+  selectedCount,
+  onBulkDownload,
+  onBulkDelete,
+  onClearSelection,
+  canSetWorkingDirectory,
+  onUploadClick,
+  onNewFolder,
+  onSetWorkingDirectory,
+  upload,
+}: StorageToolbarProps) {
+  const { t } = useTranslation();
+  const { isUploading, uploadProgress, uploadTotal, uploadCompleted } = upload;
+
+  return (
+    <div className="px-4 md:px-6 py-2.5 border-b border-border bg-surface-secondary">
+      {selectedCount > 0 ? (
+        /* Bulk action bar (shown when one or more items are selected) */
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2 min-w-0">
+            <span className="text-xs font-medium text-fg-default whitespace-nowrap">
+              {t('storage.selectedCount', { count: selectedCount })}
+            </span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <button
+              onClick={onBulkDownload}
+              className="flex items-center gap-1.5 px-2 py-1.5 text-xs text-fg-secondary hover:text-fg-default hover:bg-surface-secondary rounded transition-colors"
+            >
+              <Download className="w-3.5 h-3.5" />
+              <span>{t('storage.bulkDownload')}</span>
+            </button>
+            <button
+              onClick={onBulkDelete}
+              className="flex items-center gap-1.5 px-2 py-1.5 text-xs text-feedback-error hover:bg-feedback-error-bg rounded transition-colors"
+            >
+              <Trash2 className="w-3.5 h-3.5" />
+              <span>{t('storage.bulkDelete')}</span>
+            </button>
+            <button
+              onClick={onClearSelection}
+              className="flex items-center gap-1.5 px-2 py-1.5 text-xs text-fg-secondary hover:text-fg-default hover:bg-surface-secondary rounded transition-colors"
+              title={t('storage.clearSelection')}
+            >
+              <X className="w-3.5 h-3.5" />
+              <span className="hidden sm:inline">{t('storage.clearSelection')}</span>
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex flex-wrap items-center gap-1.5">
+          <button
+            onClick={onUploadClick}
+            disabled={isUploading}
+            className="flex items-center gap-1.5 px-2 py-1.5 text-xs text-fg-secondary hover:text-fg-default hover:bg-surface-secondary rounded disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            <Upload className="w-3.5 h-3.5" />
+            <span>{t('storage.upload')}</span>
+          </button>
+
+          <button
+            onClick={onNewFolder}
+            className="flex items-center gap-1.5 px-2 py-1.5 text-xs text-fg-secondary hover:text-fg-default hover:bg-surface-secondary rounded transition-colors"
+          >
+            <FolderPlus className="w-3.5 h-3.5" />
+            <span>{t('storage.newFolder')}</span>
+          </button>
+
+          <button
+            onClick={onSetWorkingDirectory}
+            disabled={!canSetWorkingDirectory}
+            className="flex items-center gap-1.5 px-2 py-1.5 text-xs text-fg-secondary hover:text-fg-default hover:bg-surface-secondary rounded disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            <FolderCog className="w-3.5 h-3.5" />
+            <span>{t('storage.setAsWorkingDirectory')}</span>
+          </button>
+        </div>
+      )}
+
+      {/* Upload progress */}
+      {isUploading && (
+        <div className="mt-3">
+          <div className="flex items-center justify-between text-xs sm:text-sm text-fg-secondary mb-1">
+            <span className="truncate">
+              {uploadTotal > 0
+                ? t('storage.uploadingProgress', {
+                    completed: uploadCompleted,
+                    total: uploadTotal,
+                  })
+                : t('storage.uploading')}
+            </span>
+            <span className="ml-2">{uploadProgress}%</span>
+          </div>
+          <div className="w-full bg-border rounded-full h-2">
+            <div
+              className="bg-action-primary h-2 rounded-full transition-all duration-300"
+              style={{ width: `${uploadProgress}%` }}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/ui/DownloadProgressModal.tsx
+++ b/packages/frontend/src/components/ui/DownloadProgressModal.tsx
@@ -21,6 +21,8 @@ interface DownloadProgressModalProps {
   };
   status: 'downloading' | 'success' | 'error' | 'cancelled';
   errorMessage?: string;
+  /** Optional warning shown on success (e.g. some files could not be included). */
+  warningMessage?: string;
   onCancel?: () => void;
 }
 
@@ -30,6 +32,7 @@ export const DownloadProgressModal: React.FC<DownloadProgressModalProps> = ({
   progress,
   status,
   errorMessage,
+  warningMessage,
   onCancel,
 }) => {
   const { t } = useTranslation();
@@ -106,6 +109,11 @@ export const DownloadProgressModal: React.FC<DownloadProgressModalProps> = ({
             <div className="text-sm text-fg-secondary">
               <p>{t('storage.downloadProgress.successMessage')}</p>
             </div>
+          )}
+
+          {/* Partial-success warning (some files could not be included) */}
+          {status === 'success' && warningMessage && (
+            <Alert variant="warning">{warningMessage}</Alert>
           )}
 
           {/* Error Message */}

--- a/packages/frontend/src/hooks/useFolderDownload.ts
+++ b/packages/frontend/src/hooks/useFolderDownload.ts
@@ -1,0 +1,178 @@
+/**
+ * Download orchestration for the storage modal: single-file downloads, folder
+ * and bulk ZIP downloads, progress/cancel, and the partial-failure warning —
+ * all behind one narrow surface.
+ *
+ * The hook owns its own state cluster (progress modal, status, error/warning,
+ * abort controller) and returns `modalProps` that spread straight onto
+ * <DownloadProgressModal/>, plus three action callbacks. It takes `t` as an
+ * argument (the modal already holds it) rather than calling useTranslation, so
+ * the only i18n keys it touches are explicit.
+ */
+
+import { useCallback, useRef, useState } from 'react';
+import type { TFunction } from 'i18next';
+import {
+  generateDownloadUrl,
+  downloadFolder,
+  downloadItems,
+  type DownloadProgress,
+  type StorageItem,
+} from '../api/storage';
+import { downloadWithAsyncUrl } from '../utils/download';
+import { logger } from '../utils/logger';
+
+type DownloadStatus = 'downloading' | 'success' | 'error' | 'cancelled';
+
+const ZERO_PROGRESS: DownloadProgress = { current: 0, total: 0, percentage: 0, currentFile: '' };
+
+export interface UseFolderDownload {
+  /** Spread directly onto <DownloadProgressModal {...modalProps} />. */
+  modalProps: {
+    isOpen: boolean;
+    onClose: () => void;
+    progress: DownloadProgress;
+    status: DownloadStatus;
+    errorMessage: string;
+    warningMessage: string;
+    onCancel: (() => void) | undefined;
+  };
+  /** Download a single item: file → presigned URL popup; directory → ZIP. */
+  downloadItem: (item: StorageItem) => Promise<void>;
+  /** Download a folder path as a ZIP, showing the progress modal. */
+  downloadFolderAsZip: (folderPath: string, folderName: string) => Promise<void>;
+  /**
+   * Bulk-download a selection as one ZIP. A lone file bypasses ZIP wrapping.
+   * `onComplete` runs only on success (the modal passes clearSelection).
+   */
+  downloadSelection: (items: StorageItem[], onComplete?: () => void) => Promise<void>;
+}
+
+export function useFolderDownload(t: TFunction): UseFolderDownload {
+  const [isDownloadModalOpen, setIsDownloadModalOpen] = useState(false);
+  const [progress, setProgress] = useState<DownloadProgress>(ZERO_PROGRESS);
+  const [status, setStatus] = useState<DownloadStatus>('downloading');
+  const [errorMessage, setErrorMessage] = useState('');
+  const [warningMessage, setWarningMessage] = useState('');
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  // Map a thrown value to a terminal status. The 'Download cancelled' sentinel
+  // is thrown by the API layer on abort and must be matched verbatim.
+  const applyError = useCallback((error: unknown) => {
+    if (error instanceof Error && error.message === 'Download cancelled') {
+      setStatus('cancelled');
+      return;
+    }
+    setStatus('error');
+    setErrorMessage(error instanceof Error ? error.message : 'Unknown error occurred');
+  }, []);
+
+  // Open the modal and reset all transient state for a fresh ZIP download.
+  const beginZipDownload = useCallback(() => {
+    setStatus('downloading');
+    setErrorMessage('');
+    setWarningMessage('');
+    setProgress(ZERO_PROGRESS);
+    setIsDownloadModalOpen(true);
+    abortControllerRef.current = new AbortController();
+    return abortControllerRef.current.signal;
+  }, []);
+
+  const warnIfPartial = useCallback(
+    (result: { failed: number; total: number }) => {
+      if (result.failed > 0) {
+        setWarningMessage(
+          t('storage.downloadProgress.partialWarning', {
+            failed: result.failed,
+            total: result.total,
+          })
+        );
+      }
+    },
+    [t]
+  );
+
+  const downloadFolderAsZip = useCallback(
+    async (folderPath: string, folderName: string) => {
+      const signal = beginZipDownload();
+      try {
+        const result = await downloadFolder(folderPath, folderName, setProgress, signal);
+        warnIfPartial(result);
+        setStatus('success');
+      } catch (error) {
+        applyError(error);
+      } finally {
+        abortControllerRef.current = null;
+      }
+    },
+    [applyError, beginZipDownload, warnIfPartial]
+  );
+
+  const downloadItem = useCallback(
+    async (item: StorageItem) => {
+      if (item.type === 'directory') {
+        await downloadFolderAsZip(item.path, item.name);
+        return;
+      }
+      // File: open the download synchronously within the user gesture (before
+      // any await) so mobile browsers keep transient activation.
+      await downloadWithAsyncUrl(
+        () => generateDownloadUrl(item.path),
+        (error) => logger.error('Download error:', error)
+      );
+    },
+    [downloadFolderAsZip]
+  );
+
+  const downloadSelection = useCallback(
+    async (items: StorageItem[], onComplete?: () => void) => {
+      if (items.length === 0) return;
+
+      // A single selected file downloads directly (no ZIP), still completing.
+      if (items.length === 1 && items[0].type === 'file') {
+        await downloadItem(items[0]);
+        onComplete?.();
+        return;
+      }
+
+      const signal = beginZipDownload();
+      try {
+        const result = await downloadItems(items, t('storage.bulkDownloadName'), setProgress, signal);
+        warnIfPartial(result);
+        setStatus('success');
+        onComplete?.();
+      } catch (error) {
+        applyError(error);
+      } finally {
+        abortControllerRef.current = null;
+      }
+    },
+    [applyError, beginZipDownload, downloadItem, t, warnIfPartial]
+  );
+
+  const onCancel = useCallback(() => {
+    abortControllerRef.current?.abort();
+  }, []);
+
+  const onClose = useCallback(() => {
+    setIsDownloadModalOpen(false);
+    setProgress(ZERO_PROGRESS);
+    setErrorMessage('');
+    setWarningMessage('');
+  }, []);
+
+  return {
+    modalProps: {
+      isOpen: isDownloadModalOpen,
+      onClose,
+      progress,
+      status,
+      errorMessage,
+      warningMessage,
+      onCancel: status === 'downloading' ? onCancel : undefined,
+    },
+    downloadItem,
+    downloadFolderAsZip,
+    downloadSelection,
+  };
+}

--- a/packages/frontend/src/hooks/useStorageHashSync.ts
+++ b/packages/frontend/src/hooks/useStorageHashSync.ts
@@ -1,0 +1,95 @@
+/**
+ * Keeps the storage modal's current path in sync with the URL hash
+ * (`#storage=<path>`), so deep links, browser Back/Forward, and closing the
+ * modal all behave. Encapsulates three window/history side effects that were
+ * inline in StorageManagementModal.
+ *
+ * The pure hash helpers are module-level (they capture nothing); the hook wires
+ * the open-time load and the popstate/hashchange listeners.
+ */
+
+import { useEffect } from 'react';
+import { useStorageStore } from '../stores/storageStore';
+
+/** Read the `#storage=<path>` hash, or '/' when absent. */
+export function getPathFromHash(): string {
+  const match = window.location.hash.match(/#storage=(.+)/);
+  return match ? decodeURIComponent(match[1]) : '/';
+}
+
+/** Push a `#storage=<path>` hash entry (adds history so Back works). */
+export function setPathToHash(path: string): void {
+  window.history.pushState(null, '', `#storage=${encodeURIComponent(path)}`);
+}
+
+/** Drop the storage hash (leaving any unrelated hash untouched). */
+export function clearHash(): void {
+  if (window.location.hash.startsWith('#storage=')) {
+    window.history.pushState(null, '', window.location.pathname + window.location.search);
+  }
+}
+
+export interface UseStorageHashSyncParams {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Default initial path when the URL has no explicit storage hash. */
+  agentWorkingDirectory: string;
+  loadItems: (path?: string) => Promise<void>;
+  loadFolderTree: () => Promise<void>;
+}
+
+export interface UseStorageHashSyncResult {
+  /** Push a hash entry; used by the modal's navigation handlers. */
+  setPathToHash: (path: string) => void;
+}
+
+export function useStorageHashSync({
+  isOpen,
+  onClose,
+  agentWorkingDirectory,
+  loadItems,
+  loadFolderTree,
+}: UseStorageHashSyncParams): UseStorageHashSyncResult {
+  // Load data when the modal opens; clear the hash when it closes.
+  useEffect(() => {
+    if (isOpen) {
+      // Use the URL hash if explicitly set, otherwise the agent working dir.
+      const hasExplicitHash = window.location.hash.startsWith('#storage=');
+      const initialPath = hasExplicitHash ? getPathFromHash() : agentWorkingDirectory || '/';
+
+      setPathToHash(initialPath);
+      loadItems(initialPath);
+      loadFolderTree();
+    } else {
+      clearHash();
+    }
+    // Must run once per open only; re-running when agentWorkingDirectory /
+    // loadItems / loadFolderTree identities change would reset the path or
+    // re-fetch mid-session.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
+
+  // Sync on browser back/forward and manual hash edits.
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleHashChange = () => {
+      if (window.location.hash.startsWith('#storage=')) {
+        // Read fresh store state directly to keep this effect's deps minimal.
+        useStorageStore.getState().loadItems(getPathFromHash());
+      } else {
+        // Hash cleared (e.g. Back past the modal entry) → close the modal.
+        onClose();
+      }
+    };
+
+    window.addEventListener('popstate', handleHashChange);
+    window.addEventListener('hashchange', handleHashChange);
+    return () => {
+      window.removeEventListener('popstate', handleHashChange);
+      window.removeEventListener('hashchange', handleHashChange);
+    };
+  }, [isOpen, onClose]);
+
+  return { setPathToHash };
+}

--- a/packages/frontend/src/hooks/useStorageSelection.ts
+++ b/packages/frontend/src/hooks/useStorageSelection.ts
@@ -1,0 +1,207 @@
+/**
+ * Selection state for the storage file list: checkbox/range selection plus
+ * rubber-band (marquee) drag-selection, behind one narrow surface.
+ *
+ * The caller wires the returned values to the list container and rows; all
+ * selection policy (toggle, range, select-all, marquee hit-testing, clearing
+ * on navigation) lives here. Geometry math is delegated to the pure
+ * {@link ./../utils/marqueeSelection} helpers, so this hook only owns the React
+ * state and the DOM measurement needed to feed them.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { StorageItem } from '../api/storage';
+import { pathsInRect, rectFromPoints, type ItemRect, type Rect } from '../utils/marqueeSelection';
+import { rangeSelect, removePaths, togglePath } from '../utils/selectionSet';
+
+// Distance (px) the pointer must travel before a press becomes a marquee drag
+// rather than a click — avoids hijacking simple clicks on empty space.
+const MARQUEE_THRESHOLD = 6;
+
+export interface StorageSelection {
+  /** Currently selected item paths. */
+  selectedPaths: Set<string>;
+  /** Selected items resolved against the current `items` (current view only). */
+  selectedItems: StorageItem[];
+  /** True when every item in the current view is selected. */
+  allSelected: boolean;
+  /** True when some — but not all — items are selected (checkbox indeterminate). */
+  someSelected: boolean;
+  /** The active marquee rectangle in container coordinates, or null when idle. */
+  marqueeRect: Rect | null;
+  /** Toggle one item; Shift+click range-selects from the last anchor. */
+  toggle: (item: StorageItem, e: { shiftKey: boolean }) => void;
+  /** Select all when not all selected; otherwise clear. */
+  toggleAll: () => void;
+  /** Clear the entire selection. */
+  clear: () => void;
+  /** Remove specific paths from the selection (e.g. after deletion). */
+  deselect: (paths: Iterable<string>) => void;
+  /** Begin a marquee drag from empty space in the list container. */
+  onListMouseDown: (e: React.MouseEvent) => void;
+}
+
+/**
+ * @param items  Items currently rendered, in display order.
+ * @param listContainerRef  The scrollable list container (marquee coordinate origin).
+ * @param enabled  Whether marquee listeners should be active (e.g. modal open).
+ */
+export function useStorageSelection(
+  items: StorageItem[],
+  listContainerRef: React.RefObject<HTMLDivElement | null>,
+  enabled: boolean
+): StorageSelection {
+  const [selectedPaths, setSelectedPaths] = useState<Set<string>>(new Set());
+  const [selectionAnchor, setSelectionAnchor] = useState<string | null>(null);
+  const [marqueeRect, setMarqueeRect] = useState<Rect | null>(null);
+
+  // Drag state held in refs so the window listeners stay subscribed once
+  // (no per-frame re-subscription) and never close over stale state.
+  const dragRef = useRef<{
+    startX: number;
+    startY: number;
+    baseSelection: Set<string>;
+    // Card geometry measured once at mousedown; the list does not reflow
+    // during a drag, so pure math can run each frame with no layout reads.
+    itemRects: ItemRect[];
+    active: boolean;
+  } | null>(null);
+
+  const clear = useCallback(() => {
+    setSelectedPaths(new Set());
+    setSelectionAnchor(null);
+  }, []);
+
+  const deselect = useCallback((paths: Iterable<string>) => {
+    setSelectedPaths((prev) => removePaths(prev, paths));
+  }, []);
+
+  const toggle = useCallback(
+    (item: StorageItem, e: { shiftKey: boolean }) => {
+      setSelectedPaths((prev) =>
+        e.shiftKey && selectionAnchor
+          ? rangeSelect(
+              prev,
+              items.map((i) => i.path),
+              selectionAnchor,
+              item.path
+            )
+          : togglePath(prev, item.path)
+      );
+      setSelectionAnchor(item.path);
+    },
+    [items, selectionAnchor]
+  );
+
+  const allSelected = items.length > 0 && selectedPaths.size === items.length;
+  const someSelected = selectedPaths.size > 0 && !allSelected;
+
+  const toggleAll = useCallback(() => {
+    if (allSelected) clear();
+    else setSelectedPaths(new Set(items.map((i) => i.path)));
+  }, [allSelected, clear, items]);
+
+  const selectedItems = useMemo(
+    () => items.filter((i) => selectedPaths.has(i.path)),
+    [items, selectedPaths]
+  );
+
+  // Measure card geometry once into the scroll-content coordinate space.
+  const measureItemRects = useCallback((container: HTMLElement): ItemRect[] => {
+    const containerBox = container.getBoundingClientRect();
+    const cards = container.querySelectorAll<HTMLElement>('[data-storage-path]');
+    const rects: ItemRect[] = [];
+    cards.forEach((card) => {
+      const path = card.getAttribute('data-storage-path');
+      if (!path) return;
+      const box = card.getBoundingClientRect();
+      rects.push({
+        path,
+        left: box.left - containerBox.left + container.scrollLeft,
+        top: box.top - containerBox.top + container.scrollTop,
+        width: box.width,
+        height: box.height,
+      });
+    });
+    return rects;
+  }, []);
+
+  const onListMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      // Only react to primary button on empty area (not a card/control).
+      if (e.button !== 0) return;
+      const target = e.target as HTMLElement;
+      if (target.closest('[data-storage-path], button, input, a')) return;
+
+      const container = listContainerRef.current;
+      if (!container) return;
+
+      const containerBox = container.getBoundingClientRect();
+      dragRef.current = {
+        startX: e.clientX - containerBox.left + container.scrollLeft,
+        startY: e.clientY - containerBox.top + container.scrollTop,
+        // Additive when a modifier is held; otherwise replaces the selection.
+        baseSelection: e.shiftKey || e.metaKey || e.ctrlKey ? new Set(selectedPaths) : new Set(),
+        itemRects: measureItemRects(container),
+        active: false,
+      };
+    },
+    [listContainerRef, measureItemRects, selectedPaths]
+  );
+
+  // Window-level drag listeners: subscribed once while enabled (no churn).
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      const drag = dragRef.current;
+      const container = listContainerRef.current;
+      if (!drag || !container) return;
+
+      const containerBox = container.getBoundingClientRect();
+      const currentX = e.clientX - containerBox.left + container.scrollLeft;
+      const currentY = e.clientY - containerBox.top + container.scrollTop;
+
+      // Ignore sub-threshold movement until the drag truly begins.
+      if (!drag.active && Math.hypot(currentX - drag.startX, currentY - drag.startY) < MARQUEE_THRESHOLD) {
+        return;
+      }
+      drag.active = true;
+
+      const rect = rectFromPoints(drag.startX, drag.startY, currentX, currentY);
+      setMarqueeRect(rect);
+
+      const inRect = pathsInRect(rect, drag.itemRects);
+      const next = new Set(drag.baseSelection);
+      inRect.forEach((p) => next.add(p));
+      setSelectedPaths(next);
+    };
+
+    const handleMouseUp = () => {
+      if (dragRef.current) {
+        dragRef.current = null;
+        setMarqueeRect(null);
+      }
+    };
+
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseup', handleMouseUp);
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [enabled, listContainerRef]);
+
+  return {
+    selectedPaths,
+    selectedItems,
+    allSelected,
+    someSelected,
+    marqueeRect,
+    toggle,
+    toggleAll,
+    clear,
+    deselect,
+    onListMouseDown,
+  };
+}

--- a/packages/frontend/src/locales/en.yaml
+++ b/packages/frontend/src/locales/en.yaml
@@ -459,6 +459,17 @@ storage:
   currentWorkingDirectory: Current working directory
   workingDirectory: Working directory
 
+  # Multi-select / bulk operations
+  selectedCount: '{{count}} selected'
+  selectAll: Select all
+  selectItem: 'Select {{name}}'
+  clearSelection: Clear selection
+  bulkDownload: Download
+  bulkDelete: Delete
+  bulkDeleteConfirmTitle: Delete selected items
+  bulkDeleteConfirm: 'Delete {{count}} selected item(s) ({{folders}} folder(s), {{files}} file(s))? All files and subfolders within the folders will also be deleted.'
+  bulkDownloadName: selected-items
+
   # Large directory size warning
   largeSizeWarningTitle: Large Storage Directory
   largeSizeWarningMessage: 'This directory contains {{size}} of data ({{count}} files). Sync may take some time when starting a session.'
@@ -473,6 +484,7 @@ storage:
     currentFile: Current file
     successMessage: Folder download completed. The ZIP file has been saved.
     cancelledMessage: Download was cancelled.
+    partialWarning: '{{failed}} of {{total}} files could not be retrieved. The ZIP contains only the files that were downloaded successfully.'
 
 # Memory
 memory:

--- a/packages/frontend/src/locales/en.yaml
+++ b/packages/frontend/src/locales/en.yaml
@@ -208,6 +208,11 @@ chat:
     tooLarge: File is too large. Maximum size is 5MB.
     maxReached: Maximum of 4 images can be attached.
     totalSizeExceeded: Total size of attached images exceeds 7MB. Please remove some images or select smaller ones.
+  fileDrop:
+    uploading: 'Uploading {{name}}...'
+    uploaded: 'Uploaded {{count}} file(s)'
+    failed: 'Failed to upload {{name}}: {{error}}'
+    tooLarge: '{{name}} exceeds the 500MB limit.'
   searchPlaceholder: 'Search sessions...'
   searchDateRange: 'Date range'
   searchDateStart: 'Start date'

--- a/packages/frontend/src/locales/ja.yaml
+++ b/packages/frontend/src/locales/ja.yaml
@@ -458,6 +458,17 @@ storage:
   currentWorkingDirectory: 現在の作業ディレクトリ
   workingDirectory: 作業ディレクトリ
 
+  # 複数選択・一括操作
+  selectedCount: '{{count}} 件選択中'
+  selectAll: すべて選択
+  selectItem: '{{name}} を選択'
+  clearSelection: 選択を解除
+  bulkDownload: 一括ダウンロード
+  bulkDelete: 一括削除
+  bulkDeleteConfirmTitle: 選択したアイテムを削除
+  bulkDeleteConfirm: '選択した {{count}} 件（フォルダ {{folders}} 件・ファイル {{files}} 件）を削除しますか？フォルダ内のすべてのファイルとサブフォルダも削除されます。'
+  bulkDownloadName: 選択アイテム
+
   # 大容量ディレクトリの警告
   largeSizeWarningTitle: 大容量のストレージディレクトリ
   largeSizeWarningMessage: 'このディレクトリには {{size}} のデータ（{{count}} ファイル）が含まれています。セッション開始時の同期に時間がかかる場合があります。'
@@ -472,6 +483,7 @@ storage:
     currentFile: 現在のファイル
     successMessage: フォルダのダウンロードが完了しました。ZIPファイルが保存されています。
     cancelledMessage: ダウンロードがキャンセルされました。
+    partialWarning: '{{total}} 件中 {{failed}} 件のファイルを取得できませんでした。ZIPには取得できたファイルのみ含まれています。'
 
 # メモリ
 memory:

--- a/packages/frontend/src/locales/ja.yaml
+++ b/packages/frontend/src/locales/ja.yaml
@@ -207,6 +207,11 @@ chat:
     tooLarge: ファイルサイズが大きすぎます。最大5MBまでです。
     maxReached: 添付できる画像は最大4枚までです。
     totalSizeExceeded: 添付画像の合計サイズが7MBを超えています。画像を減らすか、小さいサイズの画像を選択してください。
+  fileDrop:
+    uploading: '{{name}} をアップロード中...'
+    uploaded: '{{count}}件のファイルをアップロードしました'
+    failed: '{{name}} のアップロードに失敗しました: {{error}}'
+    tooLarge: '{{name}} は500MBの上限を超えています。'
   searchPlaceholder: 'セッションを検索...'
   searchDateRange: '期間'
   searchDateStart: '開始日'

--- a/packages/frontend/src/stores/__tests__/storageStore.deleteItems.test.ts
+++ b/packages/frontend/src/stores/__tests__/storageStore.deleteItems.test.ts
@@ -1,0 +1,87 @@
+/**
+ * storageStore — batch delete (deleteItems).
+ *
+ * deleteItems removes all targeted items optimistically, deletes them in
+ * parallel, then restores ONLY the items whose API call failed. A single
+ * deleteItem delegates to deleteItems([item]).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useStorageStore } from '../storageStore';
+import * as storageApi from '../../api/storage';
+import type { StorageItem } from '../../api/storage';
+
+vi.mock('../../api/storage');
+
+const fileA: StorageItem = { name: 'a.txt', path: '/a.txt', type: 'file' };
+const fileB: StorageItem = { name: 'b.txt', path: '/b.txt', type: 'file' };
+const dirC: StorageItem = { name: 'c', path: '/c', type: 'directory' };
+
+describe('storageStore deleteItems', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useStorageStore.setState({
+      currentPath: '/',
+      items: [dirC, fileA, fileB],
+      error: null,
+    });
+    // Silent sync re-reads the listing; return the current items unchanged.
+    vi.mocked(storageApi.listStorageItems).mockResolvedValue({
+      items: useStorageStore.getState().items,
+      path: '/',
+    });
+    vi.mocked(storageApi.fetchFolderTree).mockResolvedValue({ tree: [] });
+  });
+
+  it('removes all targeted items when every deletion succeeds', async () => {
+    vi.mocked(storageApi.deleteFile).mockResolvedValue(undefined);
+    vi.mocked(storageApi.deleteDirectory).mockResolvedValue(undefined);
+    // listing after deletion reflects only the survivor
+    vi.mocked(storageApi.listStorageItems).mockResolvedValue({ items: [fileB], path: '/' });
+
+    await useStorageStore.getState().deleteItems([fileA, dirC]);
+
+    const state = useStorageStore.getState();
+    expect(storageApi.deleteFile).toHaveBeenCalledWith('/a.txt');
+    expect(storageApi.deleteDirectory).toHaveBeenCalledWith('/c', true);
+    expect(state.items.map((i) => i.path)).toEqual(['/b.txt']);
+    expect(state.error).toBeNull();
+  });
+
+  it('restores only the failed item and surfaces its error', async () => {
+    vi.mocked(storageApi.deleteFile).mockImplementation((path: string) =>
+      path === '/a.txt' ? Promise.reject(new Error('boom')) : Promise.resolve(undefined)
+    );
+    // Silent sync should not resurrect deleted items; return what the server "has".
+    vi.mocked(storageApi.listStorageItems).mockResolvedValue({
+      items: [dirC, fileA],
+      path: '/',
+    });
+
+    await useStorageStore.getState().deleteItems([fileA, fileB]);
+
+    const state = useStorageStore.getState();
+    // fileA failed → restored; fileB succeeded → gone; dirC untouched.
+    expect(state.items.map((i) => i.path).sort()).toEqual(['/a.txt', '/c']);
+    expect(state.error).toContain('a.txt');
+  });
+
+  it('is a no-op for an empty selection', async () => {
+    await useStorageStore.getState().deleteItems([]);
+    expect(storageApi.deleteFile).not.toHaveBeenCalled();
+    expect(storageApi.deleteDirectory).not.toHaveBeenCalled();
+  });
+
+  it('deleteItem delegates to the batch path', async () => {
+    vi.mocked(storageApi.deleteFile).mockResolvedValue(undefined);
+    vi.mocked(storageApi.listStorageItems).mockResolvedValue({
+      items: [dirC, fileB],
+      path: '/',
+    });
+
+    await useStorageStore.getState().deleteItem(fileA);
+
+    expect(storageApi.deleteFile).toHaveBeenCalledWith('/a.txt');
+    expect(storageApi.deleteFile).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/frontend/src/stores/storageStore.ts
+++ b/packages/frontend/src/stores/storageStore.ts
@@ -35,6 +35,7 @@ interface StorageState {
   uploadFiles: (files: Array<{ file: File; relativePath: string }>) => Promise<void>;
   createDirectory: (directoryName: string, path?: string) => Promise<void>;
   deleteItem: (item: StorageItem) => Promise<void>;
+  deleteItems: (items: StorageItem[]) => Promise<void>;
   refresh: () => Promise<void>;
   clearError: () => void;
 
@@ -266,38 +267,63 @@ export const useStorageStore = create<StorageState>()(
             }
           },
 
-          // Delete item (optimistic UI)
+          // Delete a single item (delegates to batch delete)
           deleteItem: async (item: StorageItem) => {
-            const previousItems = get().items;
+            await get().deleteItems([item]);
+          },
 
-            // Optimistic update: remove the item immediately
+          // Delete multiple items in one batch (optimistic UI)
+          deleteItems: async (items: StorageItem[]) => {
+            if (items.length === 0) return;
+
+            const previousItems = get().items;
+            const targetPaths = new Set(items.map((i) => i.path));
+
+            // Optimistic update: remove all targeted items immediately
             set({
-              items: previousItems.filter((i) => i.path !== item.path),
+              items: previousItems.filter((i) => !targetPaths.has(i.path)),
               error: null,
             });
 
-            try {
-              if (item.type === 'file') {
-                await storageApi.deleteFile(item.path);
-              } else {
-                // Force delete directory (including contents)
-                await storageApi.deleteDirectory(item.path, true);
-              }
+            // Delete each item in parallel; collect per-item outcomes
+            const results = await Promise.allSettled(
+              items.map((item) =>
+                item.type === 'file'
+                  ? storageApi.deleteFile(item.path)
+                  : // Force delete directory (including contents)
+                    storageApi.deleteDirectory(item.path, true)
+              )
+            );
 
-              // Silent sync: reload without showing loading spinner
-              await silentSyncItems(get().currentPath);
-
-              // Silent tree sync if directory was deleted
-              if (item.type === 'directory') {
-                await silentSyncFolderTree();
+            // Identify failures and re-add only the items that failed to delete
+            const failedItems: StorageItem[] = [];
+            const errors: string[] = [];
+            results.forEach((result, index) => {
+              if (result.status === 'rejected') {
+                const item = items[index];
+                failedItems.push(item);
+                logger.error('Failed to delete item %s:', item.path, result.reason);
+                errors.push(`${item.name}: ${extractErrorMessage(result.reason, 'Unknown error')}`);
               }
-            } catch (error) {
-              logger.error('Failed to delete item:', error);
-              // Rollback on failure
+            });
+
+            if (failedItems.length > 0) {
+              // Partial rollback: restore failed items in their original order
+              const failedPaths = new Set(failedItems.map((i) => i.path));
               set({
-                items: previousItems,
-                error: extractErrorMessage(error, 'Failed to delete item'),
+                items: previousItems.filter(
+                  (i) => failedPaths.has(i.path) || !targetPaths.has(i.path)
+                ),
+                error: errors.join('\n'),
               });
+            }
+
+            // Silent sync once after all deletions
+            await silentSyncItems(get().currentPath);
+
+            // Silent tree sync if any directory was deleted
+            if (items.some((i) => i.type === 'directory')) {
+              await silentSyncFolderTree();
             }
           },
 

--- a/packages/frontend/src/utils/__tests__/fileSystemEntry.test.ts
+++ b/packages/frontend/src/utils/__tests__/fileSystemEntry.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest';
+import {
+  readDroppedEntries,
+  collectDropEntries,
+  resolveDirectoryCreation,
+  type DroppedEntry,
+} from '../fileSystemEntry';
+
+/**
+ * The drag-and-drop traversal: collectDropEntries reads the DataTransferItemList
+ * synchronously (it is invalidated after the drop tick); readDroppedEntries then
+ * walks those entries into uploadable files + empty-directory paths;
+ * resolveDirectoryCreation computes where each empty dir is created. All three
+ * are unit-tested here against hand-built fakes (no real DOM).
+ */
+
+type Fake = FileSystemEntry;
+
+function fileEntry(name: string, contents = 'x'): Fake {
+  return {
+    isFile: true,
+    isDirectory: false,
+    name,
+    file: (resolve: (f: File) => void) => resolve(new File([contents], name)),
+  } as unknown as Fake;
+}
+
+/** A directory whose children are produced by readEntries in a single batch. */
+function dirEntry(name: string, children: Fake[]): Fake {
+  return {
+    isFile: false,
+    isDirectory: true,
+    name,
+    createReader: () => ({
+      readEntries: (resolve: (entries: Fake[]) => void) => resolve(children),
+    }),
+  } as unknown as Fake;
+}
+
+const rels = (entries: DroppedEntry[]) => entries.map((e) => e.relativePath).sort();
+
+describe('readDroppedEntries', () => {
+  it('returns a single top-level file with its name as relative path', async () => {
+    const { files, directories } = await readDroppedEntries([fileEntry('a.txt')]);
+    expect(rels(files)).toEqual(['a.txt']);
+    expect(files[0].file).toBeInstanceOf(File);
+    expect(directories).toEqual([]);
+  });
+
+  it('uses the resolved File.name for top-level files (not entry.name)', async () => {
+    // entry.name is 'entry-name' but the resolved File is named 'real.txt';
+    // the top-level branch must use file.name.
+    const entry = {
+      isFile: true,
+      isDirectory: false,
+      name: 'entry-name',
+      file: (resolve: (f: File) => void) => resolve(new File(['x'], 'real.txt')),
+    } as unknown as Fake;
+    const { files } = await readDroppedEntries([entry]);
+    expect(files[0].relativePath).toBe('real.txt');
+  });
+
+  it('nests files under their directory path (using entry.name inside dirs)', async () => {
+    const tree = [dirEntry('docs', [fileEntry('readme.md'), fileEntry('guide.md')])];
+    const { files, directories } = await readDroppedEntries(tree);
+    expect(rels(files)).toEqual(['docs/guide.md', 'docs/readme.md']);
+    expect(directories).toEqual([]);
+  });
+
+  it('records an empty directory as a directory path with no files', async () => {
+    const { files, directories } = await readDroppedEntries([dirEntry('empty', [])]);
+    expect(files).toEqual([]);
+    expect(directories).toEqual(['empty']);
+  });
+
+  it('recurses through nested directories, building full relative paths', async () => {
+    const tree = [
+      dirEntry('a', [
+        fileEntry('top.txt'),
+        dirEntry('b', [fileEntry('deep.txt'), dirEntry('c', [])]),
+      ]),
+    ];
+    const { files, directories } = await readDroppedEntries(tree);
+    expect(rels(files)).toEqual(['a/b/deep.txt', 'a/top.txt']);
+    // Only the truly-empty leaf 'a/b/c' is recorded as an empty directory.
+    expect(directories).toEqual(['a/b/c']);
+  });
+
+  it('handles a mix of top-level files and directories', async () => {
+    const tree = [
+      fileEntry('root.txt'),
+      dirEntry('dir', [fileEntry('inner.txt')]),
+      dirEntry('blank', []),
+    ];
+    const { files, directories } = await readDroppedEntries(tree);
+    expect(rels(files)).toEqual(['dir/inner.txt', 'root.txt']);
+    expect(directories).toEqual(['blank']);
+  });
+
+  it('returns empty results for an empty entry list', async () => {
+    const { files, directories } = await readDroppedEntries([]);
+    expect(files).toEqual([]);
+    expect(directories).toEqual([]);
+  });
+});
+
+describe('collectDropEntries', () => {
+  // Minimal DataTransferItemList fake: indexable + length, items have kind +
+  // webkitGetAsEntry().
+  const list = (items: Array<{ kind: string; entry: Fake | null }>): DataTransferItemList => {
+    const arr = items.map((i) => ({
+      kind: i.kind,
+      webkitGetAsEntry: () => i.entry,
+    }));
+    return Object.assign(arr, { length: arr.length }) as unknown as DataTransferItemList;
+  };
+
+  it('returns entries for kind "file", skipping other kinds', () => {
+    const e1 = fileEntry('a.txt');
+    const e2 = dirEntry('d', []);
+    const result = collectDropEntries(
+      list([
+        { kind: 'file', entry: e1 },
+        { kind: 'string', entry: fileEntry('ignored') },
+        { kind: 'file', entry: e2 },
+      ])
+    );
+    expect(result).toEqual([e1, e2]);
+  });
+
+  it('skips items whose webkitGetAsEntry returns null', () => {
+    const e1 = fileEntry('a.txt');
+    const result = collectDropEntries(
+      list([
+        { kind: 'file', entry: null },
+        { kind: 'file', entry: e1 },
+      ])
+    );
+    expect(result).toEqual([e1]);
+  });
+
+  it('returns an empty array for an empty list', () => {
+    expect(collectDropEntries(list([]))).toEqual([]);
+  });
+});
+
+describe('resolveDirectoryCreation', () => {
+  it('keeps a single-segment dir under currentPath (root)', () => {
+    expect(resolveDirectoryCreation('photos', '/')).toEqual({
+      dirName: 'photos',
+      parentPath: '/',
+    });
+  });
+
+  it('keeps a single-segment dir under a nested currentPath', () => {
+    expect(resolveDirectoryCreation('photos', '/docs')).toEqual({
+      dirName: 'photos',
+      parentPath: '/docs',
+    });
+  });
+
+  it('builds a single-leading-slash parent for nested dirs at root', () => {
+    expect(resolveDirectoryCreation('a/b/c', '/')).toEqual({
+      dirName: 'c',
+      parentPath: '/a/b',
+    });
+  });
+
+  it('joins nested dirs under a nested currentPath', () => {
+    expect(resolveDirectoryCreation('a/b/c', '/docs')).toEqual({
+      dirName: 'c',
+      parentPath: '/docs/a/b',
+    });
+  });
+
+  it('handles a two-segment dir at root', () => {
+    expect(resolveDirectoryCreation('a/b', '/')).toEqual({ dirName: 'b', parentPath: '/a' });
+  });
+});

--- a/packages/frontend/src/utils/__tests__/formatBytes.test.ts
+++ b/packages/frontend/src/utils/__tests__/formatBytes.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { formatBytes } from '../formatBytes';
+
+/**
+ * formatBytes unifies the two byte-formatting variants that previously lived
+ * inside StorageManagementModal (the per-item `formatSize` and the
+ * directory-warning `formatSizeForWarning`). The behavioural differences
+ * between them are expressed here as options.
+ */
+describe('formatBytes', () => {
+  it('formats bytes below 1 KiB with the B unit', () => {
+    expect(formatBytes(0)).toBe('0 B');
+    expect(formatBytes(1)).toBe('1 B');
+    expect(formatBytes(1023)).toBe('1023 B');
+  });
+
+  it('formats KiB and MiB with one decimal', () => {
+    expect(formatBytes(1024)).toBe('1.0 KB');
+    expect(formatBytes(1536)).toBe('1.5 KB');
+    expect(formatBytes(1024 * 1024)).toBe('1.0 MB');
+    expect(formatBytes(5 * 1024 * 1024)).toBe('5.0 MB');
+  });
+
+  it('caps at MB by default (no GB tier)', () => {
+    // 2 GiB rendered in MB by default.
+    expect(formatBytes(2 * 1024 * 1024 * 1024)).toBe('2048.0 MB');
+  });
+
+  it('renders GB when maxUnit is "GB"', () => {
+    expect(formatBytes(2 * 1024 * 1024 * 1024, { maxUnit: 'GB' })).toBe('2.0 GB');
+    // Below the GB threshold still shows MB even with maxUnit GB.
+    expect(formatBytes(5 * 1024 * 1024, { maxUnit: 'GB' })).toBe('5.0 MB');
+  });
+
+  it('treats 0 as a real size, not "missing" (regression: 0-byte file showed em dash)', () => {
+    // Default has no placeholder, so 0 must render as "0 B", never an em dash.
+    expect(formatBytes(0)).toBe('0 B');
+  });
+
+  it('returns the placeholder only for null/undefined when one is provided', () => {
+    expect(formatBytes(undefined, { emptyPlaceholder: '—' })).toBe('—');
+    expect(formatBytes(null as unknown as undefined, { emptyPlaceholder: '—' })).toBe('—');
+    // 0 is a real value and must NOT use the placeholder.
+    expect(formatBytes(0, { emptyPlaceholder: '—' })).toBe('0 B');
+  });
+
+  it('returns "0 B" for missing input when no placeholder is configured', () => {
+    expect(formatBytes(undefined)).toBe('0 B');
+  });
+});

--- a/packages/frontend/src/utils/__tests__/marqueeSelection.test.ts
+++ b/packages/frontend/src/utils/__tests__/marqueeSelection.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { rectFromPoints, pathsInRect, type ItemRect } from '../marqueeSelection';
+
+/**
+ * Pure geometry for rubber-band (marquee) selection. No DOM: rectangles are
+ * plain numbers in the scroll-content coordinate space, so the math is fully
+ * unit-testable and reusable across any list.
+ */
+describe('rectFromPoints', () => {
+  it('builds a normalized rect when dragging down-right', () => {
+    expect(rectFromPoints(10, 20, 110, 220)).toEqual({
+      left: 10,
+      top: 20,
+      width: 100,
+      height: 200,
+    });
+  });
+
+  it('normalizes a rect dragged up-left (anchor below/right of cursor)', () => {
+    expect(rectFromPoints(110, 220, 10, 20)).toEqual({
+      left: 10,
+      top: 20,
+      width: 100,
+      height: 200,
+    });
+  });
+
+  it('produces a zero-size rect when start === current', () => {
+    expect(rectFromPoints(50, 50, 50, 50)).toEqual({
+      left: 50,
+      top: 50,
+      width: 0,
+      height: 0,
+    });
+  });
+});
+
+describe('pathsInRect', () => {
+  // Three stacked 100x60 rows with a 10px gap.
+  const items: ItemRect[] = [
+    { path: '/a', left: 0, top: 0, width: 100, height: 60 },
+    { path: '/b', left: 0, top: 70, width: 100, height: 60 },
+    { path: '/c', left: 0, top: 140, width: 100, height: 60 },
+  ];
+
+  it('returns paths whose rects intersect the selection rect', () => {
+    // Rect covering rows a and b (top 0..100).
+    expect(pathsInRect({ left: 0, top: 0, width: 50, height: 100 }, items)).toEqual(['/a', '/b']);
+  });
+
+  it('includes a row touched even partially', () => {
+    // Rect spanning 125..145: overlaps row b (70..130) by 5px and row c (140..200) by 5px.
+    expect(pathsInRect({ left: 0, top: 125, width: 50, height: 20 }, items)).toEqual(['/b', '/c']);
+  });
+
+  it('returns empty when the rect lands in a gap', () => {
+    // Gap between a (0..60) and b (70..130): 61..69.
+    expect(pathsInRect({ left: 0, top: 62, width: 50, height: 5 }, items)).toEqual([]);
+  });
+
+  it('excludes rows that only share an edge (no overlap)', () => {
+    // Rect bottom exactly at row a's top edge (touching, not overlapping).
+    expect(pathsInRect({ left: 0, top: -10, width: 50, height: 10 }, items)).toEqual([]);
+  });
+
+  it('returns all rows for a rect that spans the whole list', () => {
+    expect(pathsInRect({ left: 0, top: 0, width: 100, height: 200 }, items)).toEqual([
+      '/a',
+      '/b',
+      '/c',
+    ]);
+  });
+
+  it('preserves item order in the result', () => {
+    const reversed = [...items].reverse();
+    expect(pathsInRect({ left: 0, top: 0, width: 100, height: 200 }, reversed)).toEqual([
+      '/c',
+      '/b',
+      '/a',
+    ]);
+  });
+});

--- a/packages/frontend/src/utils/__tests__/selectionSet.test.ts
+++ b/packages/frontend/src/utils/__tests__/selectionSet.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { togglePath, rangeSelect, removePaths } from '../selectionSet';
+
+/**
+ * Pure set algebra for list selection — no React, no DOM. The hook layers
+ * state/anchors on top; this module owns the membership rules.
+ */
+describe('togglePath', () => {
+  it('adds a path that is not selected', () => {
+    expect([...togglePath(new Set(['/a']), '/b')]).toEqual(['/a', '/b']);
+  });
+
+  it('removes a path that is selected', () => {
+    expect([...togglePath(new Set(['/a', '/b']), '/a')]).toEqual(['/b']);
+  });
+
+  it('does not mutate the input set', () => {
+    const input = new Set(['/a']);
+    togglePath(input, '/b');
+    expect([...input]).toEqual(['/a']);
+  });
+});
+
+describe('rangeSelect', () => {
+  const order = ['/a', '/b', '/c', '/d', '/e'];
+
+  it('adds the inclusive range from anchor to target (forward)', () => {
+    expect([...rangeSelect(new Set(), order, '/b', '/d')]).toEqual(['/b', '/c', '/d']);
+  });
+
+  it('adds the inclusive range when target is before anchor (backward)', () => {
+    expect([...rangeSelect(new Set(), order, '/d', '/b')]).toEqual(['/b', '/c', '/d']);
+  });
+
+  it('merges the range into an existing selection', () => {
+    expect([...rangeSelect(new Set(['/e']), order, '/a', '/b')].sort()).toEqual([
+      '/a',
+      '/b',
+      '/e',
+    ]);
+  });
+
+  it('returns the existing selection unchanged when anchor is not found', () => {
+    expect([...rangeSelect(new Set(['/a']), order, '/missing', '/c')]).toEqual(['/a']);
+  });
+
+  it('selects a single item when anchor === target', () => {
+    expect([...rangeSelect(new Set(), order, '/c', '/c')]).toEqual(['/c']);
+  });
+});
+
+describe('removePaths', () => {
+  it('removes the given paths', () => {
+    expect([...removePaths(new Set(['/a', '/b', '/c']), ['/b'])].sort()).toEqual(['/a', '/c']);
+  });
+
+  it('ignores paths that are not present', () => {
+    expect([...removePaths(new Set(['/a']), ['/x'])]).toEqual(['/a']);
+  });
+
+  it('does not mutate the input set', () => {
+    const input = new Set(['/a', '/b']);
+    removePaths(input, ['/a']);
+    expect([...input]).toEqual(['/a', '/b']);
+  });
+});

--- a/packages/frontend/src/utils/fileSystemEntry.ts
+++ b/packages/frontend/src/utils/fileSystemEntry.ts
@@ -1,0 +1,133 @@
+/**
+ * Drag-and-drop file/folder ingestion for the storage modal.
+ *
+ * A drop's `DataTransferItemList` must be read synchronously (it is cleared
+ * after the event tick), so the work is split into three pieces the caller
+ * sequences:
+ *   1. {@link collectDropEntries} — SYNCHRONOUS; pull the top-level
+ *      `FileSystemEntry[]` out of the list before any `await`.
+ *   2. {@link readDroppedEntries} — async walk into uploadable files +
+ *      recursively-empty directory paths.
+ *   3. {@link resolveDirectoryCreation} — pure path math for where each empty
+ *      directory is created.
+ *
+ * Everything here is framework-agnostic and unit-tested; the modal keeps the
+ * store calls (createDirectory / uploadFiles) and the drag-over UI state.
+ */
+
+/** A file paired with its path relative to the drop root (e.g. "dir/sub/a.txt"). */
+export interface DroppedEntry {
+  file: File;
+  relativePath: string;
+}
+
+export interface CollectedEntries {
+  files: DroppedEntry[];
+  /** Relative paths of directories that contain no files (recursively empty). */
+  directories: string[];
+}
+
+const readFile = (entry: FileSystemFileEntry): Promise<File> =>
+  new Promise((resolve, reject) => entry.file(resolve, reject));
+
+const readChildren = (entry: FileSystemDirectoryEntry): Promise<FileSystemEntry[]> =>
+  new Promise((resolve, reject) => entry.createReader().readEntries(resolve, reject));
+
+/**
+ * Synchronously collect the top-level entries from a drop's item list.
+ *
+ * MUST be called before any `await` in the drop handler: `DataTransferItemList`
+ * is invalidated once the handler yields. Skips non-file items (e.g. dragged
+ * text) and items whose `webkitGetAsEntry()` returns null.
+ */
+export function collectDropEntries(items: DataTransferItemList): FileSystemEntry[] {
+  const entries: FileSystemEntry[] = [];
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    if (item.kind === 'file') {
+      const entry = item.webkitGetAsEntry();
+      if (entry) entries.push(entry);
+    }
+  }
+  return entries;
+}
+
+/**
+ * Recursively read a directory entry. Note: `readEntries` is called once (not
+ * drained in a loop); Chromium caps each call at ~100 entries, so directories
+ * with more children are under-read. This matches long-standing behavior and is
+ * intentionally preserved here — do not "fix" without measuring upload impact.
+ */
+async function readDirectoryEntry(
+  directoryEntry: FileSystemDirectoryEntry,
+  path: string
+): Promise<CollectedEntries> {
+  const files: DroppedEntry[] = [];
+  const directories: string[] = [];
+  const children = await readChildren(directoryEntry);
+
+  // No children → an empty directory that must be created explicitly.
+  if (children.length === 0) {
+    directories.push(path);
+    return { files, directories };
+  }
+
+  for (const child of children) {
+    const childPath = path ? `${path}/${child.name}` : child.name;
+    if (child.isFile) {
+      files.push({ file: await readFile(child as FileSystemFileEntry), relativePath: childPath });
+    } else if (child.isDirectory) {
+      const nested = await readDirectoryEntry(child as FileSystemDirectoryEntry, childPath);
+      files.push(...nested.files);
+      directories.push(...nested.directories);
+    }
+  }
+
+  return { files, directories };
+}
+
+/**
+ * Walk already-collected top-level entries into a flat file list plus the paths
+ * of recursively-empty directories.
+ *
+ * Top-level files use their resolved `File.name` as the relative path; files
+ * found inside directories use `entry.name` joined under the directory path.
+ * This asymmetry matches the original handler and is deliberate.
+ */
+export async function readDroppedEntries(entries: FileSystemEntry[]): Promise<CollectedEntries> {
+  const files: DroppedEntry[] = [];
+  const directories: string[] = [];
+
+  for (const entry of entries) {
+    if (entry.isFile) {
+      const file = await readFile(entry as FileSystemFileEntry);
+      files.push({ file, relativePath: file.name });
+    } else if (entry.isDirectory) {
+      const nested = await readDirectoryEntry(entry as FileSystemDirectoryEntry, entry.name);
+      files.push(...nested.files);
+      directories.push(...nested.directories);
+    }
+  }
+
+  return { files, directories };
+}
+
+/**
+ * Resolve where an empty directory (given by its drop-relative path) should be
+ * created: its leaf name and the parent path under `currentPath`. Avoids double
+ * slashes when `currentPath` is the root.
+ */
+export function resolveDirectoryCreation(
+  dirPath: string,
+  currentPath: string
+): { dirName: string; parentPath: string } {
+  const pathParts = dirPath.split('/');
+  const dirName = pathParts[pathParts.length - 1];
+  const parentPath =
+    pathParts.length > 1
+      ? currentPath === '/'
+        ? `/${pathParts.slice(0, -1).join('/')}`
+        : `${currentPath}/${pathParts.slice(0, -1).join('/')}`
+      : currentPath;
+  return { dirName, parentPath };
+}

--- a/packages/frontend/src/utils/formatBytes.ts
+++ b/packages/frontend/src/utils/formatBytes.ts
@@ -1,0 +1,33 @@
+/**
+ * Format a byte count as a human-readable string (binary units: 1 KB = 1024 B).
+ *
+ * Unifies the two size formatters that previously lived in
+ * StorageManagementModal. The differences between them are expressed as
+ * options, keeping a single source of truth for the unit ladder and rounding.
+ *
+ * @param bytes  Size in bytes. `0` is a real size (renders "0 B"); only
+ *               `null`/`undefined` are treated as "missing".
+ * @param options.emptyPlaceholder  Returned for missing input (e.g. "—").
+ *               When omitted, missing input renders as "0 B".
+ * @param options.maxUnit  Highest unit to use: "MB" (default) keeps large
+ *               sizes in MB; "GB" adds a GB tier.
+ */
+export function formatBytes(
+  bytes?: number | null,
+  options: { emptyPlaceholder?: string; maxUnit?: 'MB' | 'GB' } = {}
+): string {
+  const { emptyPlaceholder, maxUnit = 'MB' } = options;
+
+  if (bytes == null) {
+    return emptyPlaceholder ?? '0 B';
+  }
+
+  const KB = 1024;
+  const MB = KB * 1024;
+  const GB = MB * 1024;
+
+  if (bytes < KB) return `${bytes} B`;
+  if (bytes < MB) return `${(bytes / KB).toFixed(1)} KB`;
+  if (maxUnit === 'GB' && bytes >= GB) return `${(bytes / GB).toFixed(1)} GB`;
+  return `${(bytes / MB).toFixed(1)} MB`;
+}

--- a/packages/frontend/src/utils/marqueeSelection.ts
+++ b/packages/frontend/src/utils/marqueeSelection.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure geometry for rubber-band (marquee) selection.
+ *
+ * All coordinates are plain numbers in a single 2-D space (the list's
+ * scroll-content space): callers measure DOM once and translate into this
+ * space, then this module does the math with no DOM access. That keeps the
+ * hit-testing fully unit-testable and independent of how rows are rendered.
+ */
+
+export interface Rect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+/** A list item's identity plus its rectangle in the shared coordinate space. */
+export interface ItemRect extends Rect {
+  path: string;
+}
+
+/**
+ * Build a normalized rectangle from a drag anchor and the current pointer,
+ * regardless of drag direction (always non-negative width/height).
+ */
+export function rectFromPoints(
+  startX: number,
+  startY: number,
+  currentX: number,
+  currentY: number
+): Rect {
+  return {
+    left: Math.min(startX, currentX),
+    top: Math.min(startY, currentY),
+    width: Math.abs(currentX - startX),
+    height: Math.abs(currentY - startY),
+  };
+}
+
+/**
+ * Return the paths of every item whose rectangle overlaps `rect`, in the order
+ * the items were given. Edge-only contact (shared boundary, no area overlap)
+ * does not count as a hit.
+ */
+export function pathsInRect(rect: Rect, items: ItemRect[]): string[] {
+  const right = rect.left + rect.width;
+  const bottom = rect.top + rect.height;
+
+  return items
+    .filter(
+      (item) =>
+        item.left < right &&
+        item.left + item.width > rect.left &&
+        item.top < bottom &&
+        item.top + item.height > rect.top
+    )
+    .map((item) => item.path);
+}

--- a/packages/frontend/src/utils/selectionSet.ts
+++ b/packages/frontend/src/utils/selectionSet.ts
@@ -1,0 +1,44 @@
+/**
+ * Pure set algebra for list selection. Every function returns a NEW set and
+ * never mutates its input, so callers can use the result directly as React
+ * state. No React or DOM — the membership rules live here and are unit-tested
+ * in isolation; the selection hook only adds state and the anchor.
+ */
+
+/** Toggle a single path's membership. */
+export function togglePath(selected: Set<string>, path: string): Set<string> {
+  const next = new Set(selected);
+  if (next.has(path)) next.delete(path);
+  else next.add(path);
+  return next;
+}
+
+/**
+ * Add the inclusive range of `order` between `anchor` and `target` to the
+ * selection. If `anchor` or `target` is not in `order`, the selection is
+ * returned unchanged (as a copy).
+ */
+export function rangeSelect(
+  selected: Set<string>,
+  order: string[],
+  anchor: string,
+  target: string
+): Set<string> {
+  const next = new Set(selected);
+  const start = order.indexOf(anchor);
+  const end = order.indexOf(target);
+  if (start === -1 || end === -1) return next;
+  const [from, to] = start < end ? [start, end] : [end, start];
+  for (let i = from; i <= to; i++) next.add(order[i]);
+  return next;
+}
+
+/** Remove the given paths from the selection. */
+export function removePaths(selected: Set<string>, paths: Iterable<string>): Set<string> {
+  const remove = new Set(paths);
+  const next = new Set<string>();
+  selected.forEach((p) => {
+    if (!remove.has(p)) next.add(p);
+  });
+  return next;
+}


### PR DESCRIPTION
…efactor into hooks/components

Add bulk file operations to the storage management modal and decompose the 1500-line monolith into tested, single-purpose modules.

Features
- Multi-select: per-row checkboxes, cmd/shift-click range, select-all
- Marquee (drag-rectangle) selection over empty list space
- Bulk delete (ConfirmModal, single-vs-bulk message) and bulk ZIP download
- Per-item delete / context-menu delete act on the whole selection when the item is part of a multi-selection

Fixes
- ZIP download no longer reports success when every file fails; partial failures surface a warning and report accurate succeeded/failed counts
- formatBytes renders 0-byte files as "0 B" (was an em dash)

Refactor (behavior-preserving)
- utils: formatBytes, marqueeSelection, selectionSet, fileSystemEntry
- hooks: useStorageSelection, useFolderDownload, useStorageHashSync
- components/storage: StorageItemRow, StorageToolbar, StorageBreadcrumb, StorageContextMenu
- StorageManagementModal.tsx: 1572 -> 681 lines

Adds unit tests for all extracted pure logic (storage deleteItems, download failure handling, formatBytes, marqueeSelection, selectionSet, fileSystemEntry).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
