### PR TITLE
feat(frontend): sync browser tab title with active session

### DIFF
--- a/packages/frontend/src/hooks/useDocumentTitle.ts
+++ b/packages/frontend/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,41 @@
+/**
+ * Document (browser tab) title sync hook
+ *
+ * Keeps `document.title` in sync with the active session: when a past
+ * session is selected, the tab shows that session's title instead of the
+ * static app name. Falls back to {@link APP_TITLE} when no session is
+ * active, the session list has not loaded yet, or a session has no title.
+ *
+ * Subscribing to the `sessions` array (not just `activeSessionId`) means
+ * the tab title automatically follows late title updates — e.g. the
+ * auto-naming that runs after the first streamed response
+ * (`updateSessionTitle`).
+ */
+
+import { useEffect } from 'react';
+import { useSessionStore } from '../stores/sessionStore';
+
+/**
+ * Default browser tab title. Mirrors the static `<title>` in `index.html`,
+ * which still covers the initial load and unselected states.
+ */
+export const APP_TITLE = 'Multi-agent Orchestration Chat';
+
+export function useDocumentTitle(): void {
+  const activeSessionId = useSessionStore((state) => state.activeSessionId);
+  const sessions = useSessionStore((state) => state.sessions);
+
+  useEffect(() => {
+    const activeSession = activeSessionId
+      ? sessions.find((session) => session.sessionId === activeSessionId)
+      : undefined;
+
+    document.title = activeSession?.title?.trim()
+      ? activeSession.title
+      : APP_TITLE;
+
+    return () => {
+      document.title = APP_TITLE;
+    };
+  }, [activeSessionId, sessions]);
+}

--- a/packages/frontend/src/layouts/MainLayout.tsx
+++ b/packages/frontend/src/layouts/MainLayout.tsx
@@ -20,6 +20,7 @@ import { useSessionStore } from '../stores/sessionStore';
 import { useSwipeGesture } from '../hooks/useSwipeGesture';
 import { useSidebarShortcut } from '../hooks/useSidebarShortcut';
 import { useNewChatShortcut } from '../hooks/useNewChatShortcut';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { useShortcutsHelp } from '../hooks/useShortcutsHelp';
 import { ShortcutsModal } from '../components/ShortcutsModal';
 
@@ -144,6 +145,9 @@ export function MainLayout() {
       narrowDesktopQuery.removeEventListener('change', handleResize);
     };
   }, [setSidebarOpen, setMobileView, setNarrowDesktop]);
+
+  // Sync the browser tab title with the active session's title
+  useDocumentTitle();
 
   // Cmd+B / Ctrl+B shortcut to toggle sidebar (desktop only)
   useSidebarShortcut();

--- a/packages/frontend/src/stores/appsyncConnectionStore.ts
+++ b/packages/frontend/src/stores/appsyncConnectionStore.ts
@@ -50,8 +50,8 @@ interface AppSyncConnectionState {
 
   // Internal refs (not reactive - prefixed with _ to indicate internal use)
   _ws: WebSocket | null;
-  _reconnectTimeout: NodeJS.Timeout | null;
-  _keepAliveTimeout: NodeJS.Timeout | null;
+  _reconnectTimeout: ReturnType<typeof setTimeout> | null;
+  _keepAliveTimeout: ReturnType<typeof setTimeout> | null;
   _reconnectAttempts: number;
   _isConnecting: boolean;
   _subscriptionHandlers: Map<string, SubscriptionHandler>;


### PR DESCRIPTION
Add `useDocumentTitle` hook that updates `document.title` based on the active session's title, falling back to the app name when no session is selected or the title is empty. Subscribing to the sessions array ensures the tab title follows late updates such as auto-naming after the first streamed response.

Also replace `NodeJS.Timeout` with `ReturnType<typeof setTimeout>` in the AppSync connection store for browser-environment type correctness.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
