### PR TITLE
fix(agent): strip orphaned tool blocks from restored session history

### DIFF
--- a/packages/agent/src/runtime/agent/__tests__/session-loader.test.ts
+++ b/packages/agent/src/runtime/agent/__tests__/session-loader.test.ts
@@ -23,7 +23,9 @@ jest.unstable_mockModule('../../../config/index.js', () => ({
   config: {},
 }));
 
-const { loadSessionHistory, applyWindowTruncation } = await import('../session-loader.js');
+const { loadSessionHistory, applyWindowTruncation, sanitizeOrphanedToolBlocks } = await import(
+  '../session-loader.js'
+);
 
 /** Create a minimal mock message object for testing (avoids importing ESM SDK) */
 function createMockMessage(role: string, text: string) {
@@ -41,6 +43,17 @@ function createToolResultMessage(toolUseId: string) {
   return {
     role: 'user',
     content: [{ type: 'toolResultBlock', toolUseId, status: 'success', content: [] }],
+  };
+}
+
+/** Assistant message mixing a text block with a toolUse block (single message). */
+function createTextThenToolUseMessage(text: string, toolUseId: string) {
+  return {
+    role: 'assistant',
+    content: [
+      { type: 'textBlock', text },
+      { type: 'toolUseBlock', toolUseId, name: 'test', input: {} },
+    ],
   };
 }
 
@@ -375,5 +388,178 @@ describe('applyWindowTruncation', () => {
 
     // Falls back to full history
     expect(result).toBe(messages);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeOrphanedToolBlocks
+//
+// Reproduces the crash reported when resuming a session that was interrupted
+// AFTER a toolUse was persisted but BEFORE its toolResult: on resume the
+// restored history ends with an orphaned toolUse, and appending the next user
+// message ("続けてください") yields a tool_use with no following tool_result —
+// Bedrock rejects it with
+//   "tool_use ids were found without tool_result blocks immediately after".
+// ---------------------------------------------------------------------------
+
+describe('sanitizeOrphanedToolBlocks', () => {
+  type Block = { type: string; toolUseId?: string; text?: string };
+  type Msg = { role: string; content: Block[] };
+  const cast = (m: ReturnType<typeof createMockMessage>[]) =>
+    m as unknown as Parameters<typeof sanitizeOrphanedToolBlocks>[0];
+  const blocks = (msg: unknown): Block[] => (msg as Msg).content;
+
+  it('returns the array unchanged (same reference) when there are no tool blocks', () => {
+    const messages = cast([
+      createMockMessage('user', 'Hello'),
+      createMockMessage('assistant', 'Hi!'),
+    ]);
+    const result = sanitizeOrphanedToolBlocks(messages);
+    expect(result).toBe(messages);
+  });
+
+  it('leaves a matched toolUse/toolResult pair intact', () => {
+    const id = 'tu-1';
+    const messages = cast([
+      createMockMessage('user', 'Use the tool'),
+      createToolUseMessage(id) as unknown as ReturnType<typeof createMockMessage>,
+      createToolResultMessage(id) as unknown as ReturnType<typeof createMockMessage>,
+      createMockMessage('assistant', 'Done'),
+    ]);
+    const result = sanitizeOrphanedToolBlocks(messages);
+    expect(result).toBe(messages); // nothing to strip
+    expect(result).toHaveLength(4);
+  });
+
+  it('strips a trailing orphaned toolUse (interrupted-after-toolUse case) but keeps the message slot', () => {
+    const orphan = 'tu-orphan';
+    const messages = cast([
+      createMockMessage('user', 'Run it'),
+      createToolUseMessage(orphan) as unknown as ReturnType<typeof createMockMessage>,
+    ]);
+
+    const result = sanitizeOrphanedToolBlocks(messages);
+
+    // Message COUNT is preserved (do not drop the assistant message — dropping it
+    // would leave user → user adjacency once the resume message is appended).
+    expect(result).toHaveLength(2);
+
+    // The orphaned toolUse block must be gone.
+    const lastBlocks = blocks(result[1]);
+    expect(lastBlocks.some((b) => b.type === 'toolUseBlock')).toBe(false);
+
+    // The emptied message keeps a non-empty placeholder block so Bedrock does
+    // not reject an empty content array.
+    expect(lastBlocks.length).toBeGreaterThan(0);
+    expect(lastBlocks.some((b) => b.type === 'textBlock')).toBe(true);
+  });
+
+  it('preserves a sibling text block when stripping an orphaned toolUse from the same message', () => {
+    const orphan = 'tu-orphan';
+    const messages = cast([
+      createMockMessage('user', 'Run it'),
+      createTextThenToolUseMessage(
+        'Let me run that',
+        orphan
+      ) as unknown as ReturnType<typeof createMockMessage>,
+    ]);
+
+    const result = sanitizeOrphanedToolBlocks(messages);
+
+    const lastBlocks = blocks(result[1]);
+    // toolUse stripped, original text retained (no placeholder needed).
+    expect(lastBlocks.some((b) => b.type === 'toolUseBlock')).toBe(false);
+    expect(lastBlocks).toHaveLength(1);
+    expect(lastBlocks[0].type).toBe('textBlock');
+    expect(lastBlocks[0].text).toBe('Let me run that');
+  });
+
+  it('strips a toolResult that has no preceding toolUse', () => {
+    const messages = cast([
+      createMockMessage('user', 'Hello'),
+      createToolResultMessage('tu-missing') as unknown as ReturnType<typeof createMockMessage>,
+    ]);
+
+    const result = sanitizeOrphanedToolBlocks(messages);
+
+    const lastBlocks = blocks(result[1]);
+    expect(lastBlocks.some((b) => b.type === 'toolResultBlock')).toBe(false);
+    expect(lastBlocks.some((b) => b.type === 'textBlock')).toBe(true);
+  });
+
+  it('does not mutate the original messages array', () => {
+    const orphan = 'tu-orphan';
+    const original = cast([
+      createMockMessage('user', 'Run it'),
+      createToolUseMessage(orphan) as unknown as ReturnType<typeof createMockMessage>,
+    ]);
+    const before = blocks(original[1]).length;
+
+    sanitizeOrphanedToolBlocks(original);
+
+    // Original assistant message still carries its toolUse block.
+    expect(blocks(original[1]).length).toBe(before);
+    expect(blocks(original[1]).some((b) => b.type === 'toolUseBlock')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadSessionHistory: orphan sanitisation runs on ALL paths
+// (early-return-within-window AND post-truncation), because the original bug
+// slipped through both the `messages.length <= windowSize` early return and the
+// "no valid trim point" fallback in applyWindowTruncation.
+// ---------------------------------------------------------------------------
+
+describe('loadSessionHistory orphaned-toolUse sanitisation', () => {
+  const mockSessionConfig: SessionConfig = {
+    sessionId: 'test-session-id' as SessionId,
+    actorId: 'test-actor-id' as IdentityId,
+  };
+
+  function buildStorage(messages: unknown[]): jest.Mocked<SessionStorage> {
+    return {
+      loadMessages: jest.fn<() => Promise<unknown[]>>().mockResolvedValue(messages),
+      saveMessages: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+      appendMessage: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+      clearSession: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<SessionStorage>;
+  }
+
+  it('removes a trailing orphaned toolUse even when history is within windowSize', async () => {
+    // 2 messages, windowSize=40 → hits the early `length <= windowSize` return.
+    const storage = buildStorage([
+      createMockMessage('user', 'Run it'),
+      createToolUseMessage('tu-orphan'),
+    ]);
+
+    const result = (await loadSessionHistory(storage, mockSessionConfig, 40)) as unknown as {
+      role: string;
+      content: { type: string }[];
+    }[];
+
+    expect(result).toHaveLength(2);
+    const last = result[1].content;
+    expect(last.some((b) => b.type === 'toolUseBlock')).toBe(false);
+  });
+
+  it('removes a trailing orphaned toolUse even when no valid trim point exists (fallback path)', async () => {
+    // windowSize=1 over a tool chain forces the "no valid trim point" fallback,
+    // which previously returned the full (unsanitised) history.
+    const storage = buildStorage([
+      createToolUseMessage('tu-1'),
+      createToolResultMessage('tu-1'),
+      createToolUseMessage('tu-orphan'),
+    ]);
+
+    const result = (await loadSessionHistory(storage, mockSessionConfig, 1)) as unknown as {
+      role: string;
+      content: { type: string; toolUseId?: string }[];
+    }[];
+
+    // The orphaned trailing toolUse must not survive on any path.
+    const hasOrphan = result.some((m) =>
+      m.content.some((b) => b.type === 'toolUseBlock' && b.toolUseId === 'tu-orphan')
+    );
+    expect(hasOrphan).toBe(false);
   });
 });

--- a/packages/agent/src/runtime/agent/session-loader.ts
+++ b/packages/agent/src/runtime/agent/session-loader.ts
@@ -4,7 +4,7 @@
  * Loads saved messages from session storage for conversation continuity.
  */
 
-import type { Message } from '@strands-agents/sdk';
+import { Message, TextBlock, type ContentBlock } from '@strands-agents/sdk';
 import { logger } from '../../libs/logger/index.js';
 import type { SessionStorage, SessionConfig } from '../../services/session/types.js';
 
@@ -121,8 +121,102 @@ export function applyWindowTruncation(messages: Message[], windowSize: number): 
 }
 
 /**
+ * Remove orphaned tool blocks from a loaded conversation history.
+ *
+ * WHY: messages are persisted one at a time, in real time, as they are added
+ * (see SessionPersistenceHook.onMessageAdded → storage.appendMessage). When a
+ * long-running agent is interrupted AFTER an assistant `toolUse` block is saved
+ * but BEFORE the matching `toolResult` is produced/saved, the stored history
+ * ends with an orphaned `toolUse`. On resume, that history is restored and the
+ * next user message ("続けてください") is appended after it — so Bedrock sees a
+ * `tool_use` with no following `tool_result` and rejects the request with:
+ *   "tool_use ids were found without tool_result blocks immediately after".
+ *
+ * This pass removes, across the whole history (matched by `toolUseId`):
+ *   - any `toolUseBlock` that has no matching `toolResultBlock`, and
+ *   - any `toolResultBlock` that has no matching `toolUseBlock`.
+ *
+ * Message COUNT is preserved. A whole message is never dropped, because:
+ *   - Dropping a trailing `toolUse`-only assistant message would leave the
+ *     preceding `user` message adjacent to the appended resume `user` message —
+ *     a NEW Bedrock alternation violation.
+ *   - `AgentCoreMemoryStorage.saveMessages` computes new messages via
+ *     `messages.slice(existingCount)` against a fresh raw Memory read; keeping
+ *     the in-memory count aligned with the stored count avoids save drift.
+ * When stripping empties a message's content, a single-space `TextBlock` is
+ * substituted (the same fallback `converters.ts` uses) so Bedrock does not
+ * reject an empty `content` array.
+ *
+ * The returned array is a NEW array when anything changed; otherwise the
+ * original reference is returned unchanged (cheap no-op for tool-free chats).
+ * The input array and its messages are never mutated.
+ *
+ * NOTE: this only sanitises the in-memory history handed to the Agent. The
+ * underlying AgentCore Memory events are NOT modified, so the session-history
+ * API the UI reads (GET /sessions/:id/events) still returns the full record.
+ */
+export function sanitizeOrphanedToolBlocks(messages: Message[]): Message[] {
+  // Collect the toolUseIds that have a corresponding partner of the other kind.
+  const toolUseIds = new Set<string>();
+  const toolResultIds = new Set<string>();
+  for (const message of messages) {
+    for (const block of message.content) {
+      if (block.type === 'toolUseBlock') {
+        if (block.toolUseId) toolUseIds.add(block.toolUseId);
+      } else if (block.type === 'toolResultBlock') {
+        if (block.toolUseId) toolResultIds.add(block.toolUseId);
+      }
+    }
+  }
+
+  // Fast path: no tool blocks at all → nothing to do.
+  if (toolUseIds.size === 0 && toolResultIds.size === 0) {
+    return messages;
+  }
+
+  const isOrphan = (block: ContentBlock): boolean => {
+    if (block.type === 'toolUseBlock') {
+      return !block.toolUseId || !toolResultIds.has(block.toolUseId);
+    }
+    if (block.type === 'toolResultBlock') {
+      return !block.toolUseId || !toolUseIds.has(block.toolUseId);
+    }
+    return false;
+  };
+
+  // Detect whether anything needs stripping before allocating new arrays.
+  const hasOrphans = messages.some((m) => m.content.some(isOrphan));
+  if (!hasOrphans) {
+    return messages;
+  }
+
+  let removedCount = 0;
+  const sanitized = messages.map((message) => {
+    if (!message.content.some(isOrphan)) {
+      return message;
+    }
+    const kept = message.content.filter((block) => !isOrphan(block));
+    removedCount += message.content.length - kept.length;
+    // Never hand Bedrock an empty content array — substitute a placeholder.
+    const content: ContentBlock[] = kept.length > 0 ? kept : [new TextBlock(' ')];
+    return new Message({ role: message.role, content });
+  });
+
+  logger.warn(
+    `Session history: stripped ${removedCount} orphaned tool block(s) (interrupted toolUse/toolResult) from restored history`
+  );
+  return sanitized;
+}
+
+/**
  * Load session history from storage.
  * Returns an empty array if storage or config is not provided.
+ *
+ * The loaded history is always passed through {@link sanitizeOrphanedToolBlocks}
+ * to drop orphaned tool blocks left by an interrupted turn (see that function).
+ * This runs unconditionally — BEFORE windowing — because the bug it fixes slips
+ * through both the early `length <= windowSize` return and the "no valid trim
+ * point" fallback in {@link applyWindowTruncation}.
  *
  * When `windowSize` is provided, the returned history is pre-truncated via
  * {@link applyWindowTruncation} so that no more than `windowSize` messages are
@@ -136,8 +230,10 @@ export async function loadSessionHistory(
   if (!sessionStorage || !sessionConfig) {
     return [];
   }
-  const messages = await sessionStorage.loadMessages(sessionConfig);
-  logger.info(`Session history restored: ${messages.length} messages`);
+  const loaded = await sessionStorage.loadMessages(sessionConfig);
+  logger.info(`Session history restored: ${loaded.length} messages`);
+
+  const messages = sanitizeOrphanedToolBlocks(loaded);
 
   if (windowSize !== undefined) {
     return applyWindowTruncation(messages, windowSize);


### PR DESCRIPTION
## 背景 / 問題

長時間稼働したエージェントが**ツール実行後（`toolUse` 永続化済み）に、対応する `toolResult` が生成・保存される前にセッションが停止**することがまれにある。この状態で「続けてください」で再開すると、復元された履歴の末尾が孤立した `toolUse` になり、その直後に新しい user メッセージが並ぶため Bedrock が以下のエラーで拒否する：

```
[SYSTEM_ERROR] ModelError: messages.40: tool_use ids were found without
tool_result blocks immediately after: tooluse_... Each tool_use block must
have a corresponding tool_result block in the next message.
```

### 原因

メッセージは `SessionPersistenceHook.onMessageAdded → storage.appendMessage` で**1件ずつリアルタイム保存**される。異常停止時は `toolResult` が永遠に保存されず、`AfterInvocationEvent` の `saveMessages` フォールバックも正常終了時しか走らない。

復元時の `applyWindowTruncation` は末尾の孤立 `toolUse` を削るロジックを持つが、**2つの経路で素通りする**：
- `messages.length <= windowSize`（既定 40）の早期 return
- 「有効な切断点なし」時のフルフォールバック return

## 修正

`sanitizeOrphanedToolBlocks()` を追加し、`loadSessionHistory()` で **windowing の前に無条件適用**。

- 履歴全体を `toolUseId` で突き合わせ、対のない `toolUse` / `toolResult` ブロックを除去
- **メッセージ件数は維持**（丸ごと削除しない）。空になったら `TextBlock(' ')` を代入
- 非破壊・変更なしなら同一参照を返す（no-op）

### 設計上の副作用検討

| 観点 | 結論 |
|---|---|
| エージェントのロード | in-memory のみ。`saveMessages` は毎回 Memory を生読みして `slice(existingCount)` するため、件数維持により保存ズレなし |
| 画面表示 | UI は別経路 `GET /sessions/:id/events` で生イベントを読む。Memory は書き換えないので表示は従来どおり全件、孤立 `toolUse` も `ToolUseBlock.tsx` で描画可（クラッシュなし） |

**メッセージ丸ごと削除しない理由**: 末尾 toolUse-only アシスタントメッセージを消すと `user → user("続けてください")` の隣接が生じ、role 交互違反という別の ValidationException を新たに生むため。

## テスト

TDD（RED→GREEN）で実装。`session-loader.test.ts` に 8 ケース追加（孤立検出・除去・placeholder・非破壊・件数維持、`loadSessionHistory` の早期 return／フォールバック両経路の回帰テスト）。

- `tsc -b`: ✅
- `eslint`: ✅
- ユニットテスト: **447 passed / 31 suites**（回帰なし）