### PR TITLE
fix(agent): report HealthyBusy from /ping while an invocation is in flight

### DIFF
--- a/packages/agent/src/app.ts
+++ b/packages/agent/src/app.ts
@@ -35,6 +35,7 @@ import {
   identityResolverMiddleware,
   errorHandlerMiddleware,
   notFoundMiddleware,
+  trackInFlightMiddleware,
 } from './libs/middleware/index.js';
 import { handleInvocation, handlePing, handleRoot } from './handlers/index.js';
 
@@ -55,13 +56,19 @@ export function createApp(): Express {
 
   // `/invocations` gets the full auth / validation chain.
   //
+  //   trackInFlight      → mark container busy so /ping reports HealthyBusy
   //   requestContext     → AsyncLocalStorage ctx + JWT parse + session headers
   //   validateInvocation → prompt / images → 400 on failure
   //   authResolver       → resolves branded UserId, enriches ctx.userId
   //   identityResolver   → exchanges UserId → IdentityId, caches on ctx
   //   handleInvocation   → business logic (reads ctx via require* helpers)
+  //
+  // `trackInFlight` runs first so the busy window covers the WHOLE request —
+  // including auth/validation and any error response — and is released on the
+  // response's 'finish'/'close', which also catches a client abort mid-stream.
   app.post(
     '/invocations',
+    trackInFlightMiddleware,
     requestContextMiddleware,
     validateInvocationMiddleware,
     authResolverMiddleware,

--- a/packages/agent/src/handlers/__tests__/health.test.ts
+++ b/packages/agent/src/handlers/__tests__/health.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Unit tests for the health (`/ping`) handler.
+ *
+ * AgentCore Runtime polls `/ping` to decide whether a session is Idle. A bare
+ * `Healthy` while a long invocation is still running lets the platform reclaim
+ * the microVM (SIGTERM) mid-task. `handlePing` must therefore report
+ * `HealthyBusy` whenever an invocation is in flight.
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import type { Request, Response } from 'express';
+import { handlePing } from '../health.js';
+import { beginInvocation, resetInFlight } from '../../libs/health/in-flight.js';
+
+/** Minimal Response stub capturing the JSON body. */
+function mockResponse(): { res: Response; body: () => unknown } {
+  let captured: unknown;
+  const res = {
+    json: jest.fn((payload: unknown) => {
+      captured = payload;
+      return res;
+    }),
+  } as unknown as Response;
+  return { res, body: () => captured };
+}
+
+describe('handlePing', () => {
+  beforeEach(() => {
+    resetInFlight();
+  });
+
+  it('reports "Healthy" when no invocation is in flight', () => {
+    const { res, body } = mockResponse();
+    handlePing({} as Request, res);
+    expect((body() as { status: string }).status).toBe('Healthy');
+  });
+
+  it('reports "HealthyBusy" while an invocation is in flight', () => {
+    beginInvocation();
+    const { res, body } = mockResponse();
+    handlePing({} as Request, res);
+    expect((body() as { status: string }).status).toBe('HealthyBusy');
+  });
+
+  it('always includes a numeric time_of_last_update', () => {
+    const { res, body } = mockResponse();
+    handlePing({} as Request, res);
+    expect(typeof (body() as { time_of_last_update: number }).time_of_last_update).toBe('number');
+  });
+});

--- a/packages/agent/src/handlers/health.ts
+++ b/packages/agent/src/handlers/health.ts
@@ -3,14 +3,19 @@
  */
 
 import { Request, Response } from 'express';
+import { isBusy } from '../libs/health/in-flight.js';
 
 /**
- * Health check endpoint
- * Endpoint to verify that AgentCore Runtime is operating normally
+ * Health check endpoint.
+ *
+ * Reports `HealthyBusy` while an invocation is in flight so AgentCore Runtime
+ * keeps the session Active instead of reclaiming the microVM (SIGTERM) mid-turn.
+ * When idle it reports `Healthy`, letting the platform's idle timeout reclaim
+ * the container normally. See libs/health/in-flight.ts for the full rationale.
  */
 export function handlePing(req: Request, res: Response): void {
   res.json({
-    status: 'Healthy',
+    status: isBusy() ? 'HealthyBusy' : 'Healthy',
     time_of_last_update: Math.floor(Date.now() / 1000),
   });
 }

--- a/packages/agent/src/handlers/invocations.ts
+++ b/packages/agent/src/handlers/invocations.ts
@@ -43,106 +43,120 @@ import { createSessionPersistenceDeps } from '../services/session-persistence-de
 import { logger } from '../libs/logger/index.js';
 import { streamAgentResponse } from './stream-handler.js';
 import { stopOwnSession } from '../services/session-terminator.js';
+import { beginInvocation, endInvocation } from '../libs/health/in-flight.js';
 
 /**
  * Agent invocation endpoint (with streaming support).
  * Creates an Agent per session and persists history.
  */
 export async function handleInvocation(req: Request, res: Response): Promise<void> {
-  const body = req.body as InvocationRequest;
-  const context = getCurrentContext()!;
-  const userId = requireUserId(); // UserId — populated by authResolverMiddleware
-  const identityId = requireIdentityId(); // IdentityId — populated by identityResolverMiddleware
-  const { sessionId, sessionType, requestId } = context;
+  // Mark this container busy for the WHOLE turn so `/ping` reports `HealthyBusy`
+  // and AgentCore Runtime keeps the session Active. Without this, a long
+  // streaming turn (tool execution, sub-agent invokes) can be misread as Idle
+  // and the microVM reclaimed (SIGTERM) mid-turn — orphaning a persisted
+  // `toolUse` whose `toolResult` was never saved. Paired with `endInvocation()`
+  // in `finally` so the gauge always returns to idle, even on error.
+  beginInvocation();
+  try {
+    const body = req.body as InvocationRequest;
+    const context = getCurrentContext()!;
+    const userId = requireUserId(); // UserId — populated by authResolverMiddleware
+    const identityId = requireIdentityId(); // IdentityId — populated by identityResolverMiddleware
+    const { sessionId, sessionType, requestId } = context;
 
-  logger.info(
-    {
-      requestId,
-      prompt: body.prompt,
-      userId,
-      identityId,
-      sessionId: sessionId || 'none (sessionless mode)',
-    },
-    'Request received:'
-  );
+    logger.info(
+      {
+        requestId,
+        prompt: body.prompt,
+        userId,
+        identityId,
+        sessionId: sessionId || 'none (sessionless mode)',
+      },
+      'Request received:'
+    );
 
-  // 1. Initialize workspace sync only when a storagePath is provided.
-  //    Keeping the storagePath branch at the call site (rather than inside
-  //    the helper) makes the side-effect boundary explicit here and mirrors
-  //    the pattern used for `setupSession` below.
-  const workspaceSyncResult = body.storagePath
-    ? initializeWorkspaceSync(userId, body.storagePath, context)
-    : null;
+    // 1. Initialize workspace sync only when a storagePath is provided.
+    //    Keeping the storagePath branch at the call site (rather than inside
+    //    the helper) makes the side-effect boundary explicit here and mirrors
+    //    the pattern used for `setupSession` below.
+    const workspaceSyncResult = body.storagePath
+      ? initializeWorkspaceSync(userId, body.storagePath, context)
+      : null;
 
-  // 2. Setup session only when the request carries a sessionId.
-  //    Sessionless invocations skip AgentCore Memory / DynamoDB entirely —
-  //    the side-effect boundary is expressed at this call site.
-  //    `identityId` is passed as the actorId because AgentCore Memory and
-  //    DynamoDB are both keyed on the Identity Pool sub ("REGION:uuid"),
-  //    which the branded type guarantees we have here.
-  const sessionResult = sessionId
-    ? await setupSession({
-        actorId: identityId,
-        sessionId,
-        sessionType,
-        agentId: body.agentId,
-        storagePath: body.storagePath,
-        deps: createSessionPersistenceDeps(),
-      })
-    : null;
+    // 2. Setup session only when the request carries a sessionId.
+    //    Sessionless invocations skip AgentCore Memory / DynamoDB entirely —
+    //    the side-effect boundary is expressed at this call site.
+    //    `identityId` is passed as the actorId because AgentCore Memory and
+    //    DynamoDB are both keyed on the Identity Pool sub ("REGION:uuid"),
+    //    which the branded type guarantees we have here.
+    const sessionResult = sessionId
+      ? await setupSession({
+          actorId: identityId,
+          sessionId,
+          sessionType,
+          agentId: body.agentId,
+          storagePath: body.storagePath,
+          deps: createSessionPersistenceDeps(),
+        })
+      : null;
 
-  // 3. Create and stream agent response. The Strands SDK opens its own
-  // `invoke_agent` span (with `traceAttributes` injected by `agent.ts`),
-  // so we don't add a wrapper span here.
-  const { agent, metadata, retryStrategy } = await createAgent({
-    plugins: [
-      ...(sessionResult ? [sessionResult.hook] : []),
-      ...(workspaceSyncResult ? [workspaceSyncResult.hook] : []),
-    ],
-    modelId: body.modelId,
-    // Clamp an unknown/absent reasoning depth to 'off' (no thinking field).
-    reasoningEffort: isReasoningDepth(body.reasoningEffort) ? body.reasoningEffort : 'off',
-    enabledTools: body.enabledTools,
-    systemPrompt: body.systemPrompt,
-    memoryEnabled: body.memoryEnabled,
-    memoryContext: body.memoryEnabled ? body.prompt : undefined,
-    actorId: body.memoryEnabled ? identityId : undefined,
-    memoryTopK: body.memoryTopK,
-    mcpConfig: body.mcpConfig,
-    sessionStorage: sessionResult?.storage,
-    sessionConfig: sessionResult?.config,
-    agentId: body.agentId,
-  });
+    // 3. Create and stream agent response. The Strands SDK opens its own
+    // `invoke_agent` span (with `traceAttributes` injected by `agent.ts`),
+    // so we don't add a wrapper span here.
+    const { agent, metadata, retryStrategy } = await createAgent({
+      plugins: [
+        ...(sessionResult ? [sessionResult.hook] : []),
+        ...(workspaceSyncResult ? [workspaceSyncResult.hook] : []),
+      ],
+      modelId: body.modelId,
+      // Clamp an unknown/absent reasoning depth to 'off' (no thinking field).
+      reasoningEffort: isReasoningDepth(body.reasoningEffort) ? body.reasoningEffort : 'off',
+      enabledTools: body.enabledTools,
+      systemPrompt: body.systemPrompt,
+      memoryEnabled: body.memoryEnabled,
+      memoryContext: body.memoryEnabled ? body.prompt : undefined,
+      actorId: body.memoryEnabled ? identityId : undefined,
+      memoryTopK: body.memoryTopK,
+      mcpConfig: body.mcpConfig,
+      sessionStorage: sessionResult?.storage,
+      sessionConfig: sessionResult?.config,
+      agentId: body.agentId,
+    });
 
-  logger.info(
-    {
-      requestId,
-      loadedMessages: metadata.loadedMessagesCount,
-      longTermMemories: metadata.longTermMemoriesCount,
-      tools: metadata.toolsCount,
-    },
-    'Agent creation completed:'
-  );
+    logger.info(
+      {
+        requestId,
+        loadedMessages: metadata.loadedMessagesCount,
+        longTermMemories: metadata.longTermMemoriesCount,
+        tools: metadata.toolsCount,
+      },
+      'Agent creation completed:'
+    );
 
-  await streamAgentResponse(agent, body.prompt, body.images, res, {
-    metadata,
-    retryStrategy,
-    sessionStorage: sessionResult?.storage,
-    sessionConfig: sessionResult?.config,
-  });
+    await streamAgentResponse(agent, body.prompt, body.images, res, {
+      metadata,
+      retryStrategy,
+      sessionStorage: sessionResult?.storage,
+      sessionConfig: sessionResult?.config,
+    });
 
-  // Event-driven (trigger) invocations are fire-and-forget: nothing on the
-  // client side will tell the Runtime the session is done, so the microVM
-  // would otherwise linger (billing memory) until the idle timeout. Now that
-  // `streamAgentResponse` has fully written and ended the response, proactively
-  // stop our own session to release the microVM immediately.
-  //
-  // Restricted to `sessionType === 'event'`: interactive (chat) sessions are
-  // intentionally kept warm so follow-up turns reuse the same context, and the
-  // frontend's graceful stream close lets them go Idle on their own. Stopping
-  // also terminates any ongoing stream, so this must run AFTER the response is
-  // sent (which it is — `streamAgentResponse` calls `res.end()` before returning).
-  if (sessionType === 'event' && sessionId) {
-    await stopOwnSession(sessionId);
+    // Event-driven (trigger) invocations are fire-and-forget: nothing on the
+    // client side will tell the Runtime the session is done, so the microVM
+    // would otherwise linger (billing memory) until the idle timeout. Now that
+    // `streamAgentResponse` has fully written and ended the response, proactively
+    // stop our own session to release the microVM immediately.
+    //
+    // Restricted to `sessionType === 'event'`: interactive (chat) sessions are
+    // intentionally kept warm so follow-up turns reuse the same context, and the
+    // frontend's graceful stream close lets them go Idle on their own. Stopping
+    // also terminates any ongoing stream, so this must run AFTER the response is
+    // sent (which it is — `streamAgentResponse` calls `res.end()` before returning).
+    if (sessionType === 'event' && sessionId) {
+      await stopOwnSession(sessionId);
+    }
+  } finally {
+    // Always return the container to idle so a stuck gauge never keeps a dead
+    // session pinned as Active. Runs on success, error, and stream abort alike.
+    endInvocation();
   }
 }

--- a/packages/agent/src/handlers/invocations.ts
+++ b/packages/agent/src/handlers/invocations.ts
@@ -43,120 +43,106 @@ import { createSessionPersistenceDeps } from '../services/session-persistence-de
 import { logger } from '../libs/logger/index.js';
 import { streamAgentResponse } from './stream-handler.js';
 import { stopOwnSession } from '../services/session-terminator.js';
-import { beginInvocation, endInvocation } from '../libs/health/in-flight.js';
 
 /**
  * Agent invocation endpoint (with streaming support).
  * Creates an Agent per session and persists history.
  */
 export async function handleInvocation(req: Request, res: Response): Promise<void> {
-  // Mark this container busy for the WHOLE turn so `/ping` reports `HealthyBusy`
-  // and AgentCore Runtime keeps the session Active. Without this, a long
-  // streaming turn (tool execution, sub-agent invokes) can be misread as Idle
-  // and the microVM reclaimed (SIGTERM) mid-turn — orphaning a persisted
-  // `toolUse` whose `toolResult` was never saved. Paired with `endInvocation()`
-  // in `finally` so the gauge always returns to idle, even on error.
-  beginInvocation();
-  try {
-    const body = req.body as InvocationRequest;
-    const context = getCurrentContext()!;
-    const userId = requireUserId(); // UserId — populated by authResolverMiddleware
-    const identityId = requireIdentityId(); // IdentityId — populated by identityResolverMiddleware
-    const { sessionId, sessionType, requestId } = context;
+  const body = req.body as InvocationRequest;
+  const context = getCurrentContext()!;
+  const userId = requireUserId(); // UserId — populated by authResolverMiddleware
+  const identityId = requireIdentityId(); // IdentityId — populated by identityResolverMiddleware
+  const { sessionId, sessionType, requestId } = context;
 
-    logger.info(
-      {
-        requestId,
-        prompt: body.prompt,
-        userId,
-        identityId,
-        sessionId: sessionId || 'none (sessionless mode)',
-      },
-      'Request received:'
-    );
+  logger.info(
+    {
+      requestId,
+      prompt: body.prompt,
+      userId,
+      identityId,
+      sessionId: sessionId || 'none (sessionless mode)',
+    },
+    'Request received:'
+  );
 
-    // 1. Initialize workspace sync only when a storagePath is provided.
-    //    Keeping the storagePath branch at the call site (rather than inside
-    //    the helper) makes the side-effect boundary explicit here and mirrors
-    //    the pattern used for `setupSession` below.
-    const workspaceSyncResult = body.storagePath
-      ? initializeWorkspaceSync(userId, body.storagePath, context)
-      : null;
+  // 1. Initialize workspace sync only when a storagePath is provided.
+  //    Keeping the storagePath branch at the call site (rather than inside
+  //    the helper) makes the side-effect boundary explicit here and mirrors
+  //    the pattern used for `setupSession` below.
+  const workspaceSyncResult = body.storagePath
+    ? initializeWorkspaceSync(userId, body.storagePath, context)
+    : null;
 
-    // 2. Setup session only when the request carries a sessionId.
-    //    Sessionless invocations skip AgentCore Memory / DynamoDB entirely —
-    //    the side-effect boundary is expressed at this call site.
-    //    `identityId` is passed as the actorId because AgentCore Memory and
-    //    DynamoDB are both keyed on the Identity Pool sub ("REGION:uuid"),
-    //    which the branded type guarantees we have here.
-    const sessionResult = sessionId
-      ? await setupSession({
-          actorId: identityId,
-          sessionId,
-          sessionType,
-          agentId: body.agentId,
-          storagePath: body.storagePath,
-          deps: createSessionPersistenceDeps(),
-        })
-      : null;
+  // 2. Setup session only when the request carries a sessionId.
+  //    Sessionless invocations skip AgentCore Memory / DynamoDB entirely —
+  //    the side-effect boundary is expressed at this call site.
+  //    `identityId` is passed as the actorId because AgentCore Memory and
+  //    DynamoDB are both keyed on the Identity Pool sub ("REGION:uuid"),
+  //    which the branded type guarantees we have here.
+  const sessionResult = sessionId
+    ? await setupSession({
+        actorId: identityId,
+        sessionId,
+        sessionType,
+        agentId: body.agentId,
+        storagePath: body.storagePath,
+        deps: createSessionPersistenceDeps(),
+      })
+    : null;
 
-    // 3. Create and stream agent response. The Strands SDK opens its own
-    // `invoke_agent` span (with `traceAttributes` injected by `agent.ts`),
-    // so we don't add a wrapper span here.
-    const { agent, metadata, retryStrategy } = await createAgent({
-      plugins: [
-        ...(sessionResult ? [sessionResult.hook] : []),
-        ...(workspaceSyncResult ? [workspaceSyncResult.hook] : []),
-      ],
-      modelId: body.modelId,
-      // Clamp an unknown/absent reasoning depth to 'off' (no thinking field).
-      reasoningEffort: isReasoningDepth(body.reasoningEffort) ? body.reasoningEffort : 'off',
-      enabledTools: body.enabledTools,
-      systemPrompt: body.systemPrompt,
-      memoryEnabled: body.memoryEnabled,
-      memoryContext: body.memoryEnabled ? body.prompt : undefined,
-      actorId: body.memoryEnabled ? identityId : undefined,
-      memoryTopK: body.memoryTopK,
-      mcpConfig: body.mcpConfig,
-      sessionStorage: sessionResult?.storage,
-      sessionConfig: sessionResult?.config,
-      agentId: body.agentId,
-    });
+  // 3. Create and stream agent response. The Strands SDK opens its own
+  // `invoke_agent` span (with `traceAttributes` injected by `agent.ts`),
+  // so we don't add a wrapper span here.
+  const { agent, metadata, retryStrategy } = await createAgent({
+    plugins: [
+      ...(sessionResult ? [sessionResult.hook] : []),
+      ...(workspaceSyncResult ? [workspaceSyncResult.hook] : []),
+    ],
+    modelId: body.modelId,
+    // Clamp an unknown/absent reasoning depth to 'off' (no thinking field).
+    reasoningEffort: isReasoningDepth(body.reasoningEffort) ? body.reasoningEffort : 'off',
+    enabledTools: body.enabledTools,
+    systemPrompt: body.systemPrompt,
+    memoryEnabled: body.memoryEnabled,
+    memoryContext: body.memoryEnabled ? body.prompt : undefined,
+    actorId: body.memoryEnabled ? identityId : undefined,
+    memoryTopK: body.memoryTopK,
+    mcpConfig: body.mcpConfig,
+    sessionStorage: sessionResult?.storage,
+    sessionConfig: sessionResult?.config,
+    agentId: body.agentId,
+  });
 
-    logger.info(
-      {
-        requestId,
-        loadedMessages: metadata.loadedMessagesCount,
-        longTermMemories: metadata.longTermMemoriesCount,
-        tools: metadata.toolsCount,
-      },
-      'Agent creation completed:'
-    );
+  logger.info(
+    {
+      requestId,
+      loadedMessages: metadata.loadedMessagesCount,
+      longTermMemories: metadata.longTermMemoriesCount,
+      tools: metadata.toolsCount,
+    },
+    'Agent creation completed:'
+  );
 
-    await streamAgentResponse(agent, body.prompt, body.images, res, {
-      metadata,
-      retryStrategy,
-      sessionStorage: sessionResult?.storage,
-      sessionConfig: sessionResult?.config,
-    });
+  await streamAgentResponse(agent, body.prompt, body.images, res, {
+    metadata,
+    retryStrategy,
+    sessionStorage: sessionResult?.storage,
+    sessionConfig: sessionResult?.config,
+  });
 
-    // Event-driven (trigger) invocations are fire-and-forget: nothing on the
-    // client side will tell the Runtime the session is done, so the microVM
-    // would otherwise linger (billing memory) until the idle timeout. Now that
-    // `streamAgentResponse` has fully written and ended the response, proactively
-    // stop our own session to release the microVM immediately.
-    //
-    // Restricted to `sessionType === 'event'`: interactive (chat) sessions are
-    // intentionally kept warm so follow-up turns reuse the same context, and the
-    // frontend's graceful stream close lets them go Idle on their own. Stopping
-    // also terminates any ongoing stream, so this must run AFTER the response is
-    // sent (which it is — `streamAgentResponse` calls `res.end()` before returning).
-    if (sessionType === 'event' && sessionId) {
-      await stopOwnSession(sessionId);
-    }
-  } finally {
-    // Always return the container to idle so a stuck gauge never keeps a dead
-    // session pinned as Active. Runs on success, error, and stream abort alike.
-    endInvocation();
+  // Event-driven (trigger) invocations are fire-and-forget: nothing on the
+  // client side will tell the Runtime the session is done, so the microVM
+  // would otherwise linger (billing memory) until the idle timeout. Now that
+  // `streamAgentResponse` has fully written and ended the response, proactively
+  // stop our own session to release the microVM immediately.
+  //
+  // Restricted to `sessionType === 'event'`: interactive (chat) sessions are
+  // intentionally kept warm so follow-up turns reuse the same context, and the
+  // frontend's graceful stream close lets them go Idle on their own. Stopping
+  // also terminates any ongoing stream, so this must run AFTER the response is
+  // sent (which it is — `streamAgentResponse` calls `res.end()` before returning).
+  if (sessionType === 'event' && sessionId) {
+    await stopOwnSession(sessionId);
   }
 }

--- a/packages/agent/src/libs/health/__tests__/in-flight.test.ts
+++ b/packages/agent/src/libs/health/__tests__/in-flight.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Unit tests for the in-flight invocation tracker.
+ *
+ * The tracker backs the `/ping` health endpoint's `HealthyBusy` status:
+ * AgentCore Runtime treats a session as Idle (and reclaims its microVM,
+ * sending SIGTERM) unless the agent reports `HealthyBusy` while a long-running
+ * invocation is still being processed. See libs/health/in-flight.ts.
+ */
+
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import {
+  beginInvocation,
+  endInvocation,
+  getInFlightCount,
+  isBusy,
+  resetInFlight,
+} from '../in-flight.js';
+
+describe('in-flight invocation tracker', () => {
+  beforeEach(() => {
+    resetInFlight();
+  });
+
+  it('starts idle (count 0, not busy)', () => {
+    expect(getInFlightCount()).toBe(0);
+    expect(isBusy()).toBe(false);
+  });
+
+  it('is busy while one invocation is in flight', () => {
+    beginInvocation();
+    expect(getInFlightCount()).toBe(1);
+    expect(isBusy()).toBe(true);
+  });
+
+  it('returns to idle after the invocation ends', () => {
+    beginInvocation();
+    endInvocation();
+    expect(getInFlightCount()).toBe(0);
+    expect(isBusy()).toBe(false);
+  });
+
+  it('tracks concurrent invocations and only reports idle when all end', () => {
+    beginInvocation();
+    beginInvocation();
+    expect(getInFlightCount()).toBe(2);
+    expect(isBusy()).toBe(true);
+
+    endInvocation();
+    expect(getInFlightCount()).toBe(1);
+    expect(isBusy()).toBe(true);
+
+    endInvocation();
+    expect(getInFlightCount()).toBe(0);
+    expect(isBusy()).toBe(false);
+  });
+
+  it('never lets the counter go negative even on an unbalanced end', () => {
+    // A stray endInvocation (e.g. double-decrement on an error path) must not
+    // drive the counter below zero, which would wedge the gauge and make a
+    // genuinely busy container look idle.
+    endInvocation();
+    expect(getInFlightCount()).toBe(0);
+    expect(isBusy()).toBe(false);
+
+    beginInvocation();
+    endInvocation();
+    endInvocation();
+    expect(getInFlightCount()).toBe(0);
+  });
+});

--- a/packages/agent/src/libs/health/in-flight.ts
+++ b/packages/agent/src/libs/health/in-flight.ts
@@ -1,0 +1,62 @@
+/**
+ * In-flight invocation tracker for the `/ping` health endpoint.
+ *
+ * WHY this exists
+ * ---------------
+ * AgentCore Runtime decides a session is **Idle** — and reclaims its microVM by
+ * sending SIGTERM — when it observes no activity. Synchronous `InvokeAgentRuntime`
+ * calls are auto-tracked by the platform, BUT a long agent turn that streams for
+ * minutes (tool execution, sub-agent invokes, gaps between model chunks) can be
+ * misread as Idle, especially with a shortened `idleRuntimeSessionTimeout`. When
+ * that happens mid-turn, the container is killed after a tool's `toolUse` was
+ * persisted but before its `toolResult` — corrupting the saved history.
+ *
+ * The platform's escape hatch: the agent reports `HealthyBusy` from its health
+ * ping while it is genuinely busy, and the platform keeps the session Active.
+ *
+ * This module is the single source of truth for "is a turn currently running":
+ * `handleInvocation` brackets each turn with {@link beginInvocation} /
+ * {@link endInvocation}, and {@link handlePing} reports `HealthyBusy` whenever
+ * {@link isBusy} is true.
+ *
+ * A process-global counter is the right scope here: AgentCore pins one session
+ * to one microVM (one process), and `/ping` is process-wide. A simple module
+ * singleton therefore mirrors exactly what the platform is asking about — no
+ * per-request context plumbing required.
+ */
+
+/** Number of invocations currently being processed by this container. */
+let inFlight = 0;
+
+/**
+ * Mark the start of an invocation. Call once at the top of each turn; pair with
+ * exactly one {@link endInvocation} in a `finally` block.
+ */
+export function beginInvocation(): void {
+  inFlight += 1;
+}
+
+/**
+ * Mark the end of an invocation. Clamped at zero so an unbalanced call (e.g. a
+ * double-decrement on an error path) can never drive the gauge negative — a
+ * negative counter would make a genuinely busy container report Idle and
+ * reintroduce the mid-turn SIGTERM this module exists to prevent.
+ */
+export function endInvocation(): void {
+  inFlight = Math.max(0, inFlight - 1);
+}
+
+/** Current number of in-flight invocations. */
+export function getInFlightCount(): number {
+  return inFlight;
+}
+
+/** True while at least one invocation is being processed. */
+export function isBusy(): boolean {
+  return inFlight > 0;
+}
+
+/** Reset the counter to zero. Intended for unit tests only. */
+export function resetInFlight(): void {
+  inFlight = 0;
+}

--- a/packages/agent/src/libs/middleware/__tests__/track-in-flight.test.ts
+++ b/packages/agent/src/libs/middleware/__tests__/track-in-flight.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for trackInFlightMiddleware.
+ *
+ * The middleware brackets an invocation's HTTP lifecycle: it marks the
+ * container busy on entry and idle again when the response finishes or the
+ * connection closes. This backs the `/ping` `HealthyBusy` signal that keeps
+ * AgentCore Runtime from reclaiming the microVM mid-turn.
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { EventEmitter } from 'node:events';
+import type { Request, Response, NextFunction } from 'express';
+import { trackInFlightMiddleware } from '../track-in-flight.js';
+import { getInFlightCount, resetInFlight } from '../../health/in-flight.js';
+
+/** A Response stub that is an EventEmitter so 'finish'/'close' can be driven. */
+function mockResponse(): Response {
+  return new EventEmitter() as unknown as Response;
+}
+
+describe('trackInFlightMiddleware', () => {
+  beforeEach(() => {
+    resetInFlight();
+  });
+
+  it('marks busy on entry and calls next()', () => {
+    const res = mockResponse();
+    const next = jest.fn() as unknown as NextFunction;
+
+    trackInFlightMiddleware({} as Request, res, next);
+
+    expect(getInFlightCount()).toBe(1);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns to idle when the response finishes', () => {
+    const res = mockResponse();
+    trackInFlightMiddleware({} as Request, res, jest.fn() as unknown as NextFunction);
+    expect(getInFlightCount()).toBe(1);
+
+    res.emit('finish');
+    expect(getInFlightCount()).toBe(0);
+  });
+
+  it('returns to idle when the connection closes (client abort mid-stream)', () => {
+    const res = mockResponse();
+    trackInFlightMiddleware({} as Request, res, jest.fn() as unknown as NextFunction);
+    expect(getInFlightCount()).toBe(1);
+
+    res.emit('close');
+    expect(getInFlightCount()).toBe(0);
+  });
+
+  it('decrements exactly once when both finish and close fire', () => {
+    const res = mockResponse();
+    trackInFlightMiddleware({} as Request, res, jest.fn() as unknown as NextFunction);
+
+    res.emit('finish');
+    res.emit('close');
+
+    // Two invocations bracketed; a double-decrement from one of them would
+    // wrongly read this as idle while the other is still running.
+    expect(getInFlightCount()).toBe(0);
+  });
+
+  it('keeps the container busy while one of two concurrent responses is still open', () => {
+    const resA = mockResponse();
+    const resB = mockResponse();
+    trackInFlightMiddleware({} as Request, resA, jest.fn() as unknown as NextFunction);
+    trackInFlightMiddleware({} as Request, resB, jest.fn() as unknown as NextFunction);
+    expect(getInFlightCount()).toBe(2);
+
+    resA.emit('finish');
+    resA.emit('close'); // both fire for A — must only drop A's single count
+    expect(getInFlightCount()).toBe(1);
+
+    resB.emit('close');
+    expect(getInFlightCount()).toBe(0);
+  });
+});

--- a/packages/agent/src/libs/middleware/index.ts
+++ b/packages/agent/src/libs/middleware/index.ts
@@ -9,3 +9,4 @@ export { validateInvocationMiddleware } from './validate-invocation.js';
 export { authResolverMiddleware } from './auth-resolver.js';
 export { identityResolverMiddleware } from './identity-resolver.js';
 export { errorHandlerMiddleware, notFoundMiddleware } from './error-handler.js';
+export { trackInFlightMiddleware } from './track-in-flight.js';

--- a/packages/agent/src/libs/middleware/track-in-flight.ts
+++ b/packages/agent/src/libs/middleware/track-in-flight.ts
@@ -1,0 +1,46 @@
+/**
+ * In-flight tracking middleware for the agent invocation route.
+ *
+ * Brackets an invocation's HTTP lifecycle so `/ping` can report `HealthyBusy`
+ * while a turn is being processed, keeping AgentCore Runtime from judging the
+ * session Idle and reclaiming the microVM (SIGTERM) mid-turn. See
+ * libs/health/in-flight.ts for the full platform rationale.
+ *
+ * WHY a middleware (not begin/end inside the handler):
+ *   - The busy window is tied to the RESPONSE lifecycle, not the handler's
+ *     control flow. Releasing on `res` 'finish' (response fully written) AND
+ *     'close' (client/socket disconnected mid-stream) covers the streaming
+ *     abort case that a handler-level `try/finally` misses.
+ *   - It is a single choke point: any future long-running route gets correct
+ *     busy reporting just by adding this middleware, with no per-handler
+ *     boilerplate to forget.
+ */
+
+import type { Request, Response, NextFunction } from 'express';
+import { beginInvocation, endInvocation } from '../health/in-flight.js';
+
+/**
+ * Mark the container busy for the lifetime of this request's response.
+ *
+ * The release is guarded so it runs exactly once even though Node fires both
+ * `finish` and `close` for a normal response — a double decrement would let a
+ * still-open concurrent response read as idle and reintroduce the mid-turn
+ * SIGTERM this guards against.
+ */
+export function trackInFlightMiddleware(req: Request, res: Response, next: NextFunction): void {
+  beginInvocation();
+
+  let released = false;
+  const release = (): void => {
+    if (released) return;
+    released = true;
+    endInvocation();
+  };
+
+  // 'finish' = response fully sent; 'close' = connection closed (incl. client
+  // abort mid-stream, where 'finish' may never fire). Whichever lands first wins.
+  res.once('finish', release);
+  res.once('close', release);
+
+  next();
+}


### PR DESCRIPTION
## 背景 / 問題

長時間稼働したエージェントが **ツール実行後（`toolUse` 永続化済み）に `toolResult` 保存前に停止する** 事象を、AgentCore Runtime のログを調査して根本原因を特定しました。

CloudWatch ログ実測（過去約80日 / 5ランタイム）:

| シグナル | 件数 |
|---|---|
| `Agent streaming started` | 305 |
| `Agent streaming completed` | 305 |
| `Agent streaming error` | **0** |
| `Received SIGTERM` | **325** |

- ストリーム内例外で落ちたケースは **ゼロ**（リトライ不足ではない）
- 一方 SIGTERM がストリーム回数を上回る頻度で多発し、その多くは自前の `stopOwnSession` とは無相関 → **プラットフォーム側の Idle 判定による microVM 回収**

### 根本原因

AgentCore Runtime のセッション状態判定では、同期 `InvokeAgentRuntime` は自動追跡されるが、**バックグラウンド的に長時間ビジーな状態は agent が `/ping` で `HealthyBusy` を返して申告する必要がある**（[公式ドキュメント](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-sessions.html) の session lifecycle）。

本実装の `/ping` は常に `Healthy` を返していたため、長時間ターン（ツール実行・サブエージェント invoke・モデルチャンク間の間隙）が Idle と誤判定され、`idleRuntimeSessionTimeout`（300s に短縮設定）に引っかかって mid-turn で SIGTERM → コンテナ即終了。結果、`toolResult` 保存前に停止して孤立 `toolUse` が残る、という連鎖でした。

## 修正（対策の第一段）

`/ping` を **処理中は `HealthyBusy`** に切り替え、プラットフォームに「動作中」を正しく申告します。

- **`libs/health/in-flight.ts`（新規）**: プロセスグローバルな in-flight 呼び出しカウンタ（`beginInvocation` / `endInvocation` / `isBusy`）。`endInvocation` は 0 でクランプし、不均衡呼び出しでもゲージが負に振れない（= busy なのに idle 誤申告、を防止）。AgentCore は 1 セッション = 1 microVM = 1 プロセスなので、プロセス単一の counter が `/ping` のスコープと一致。
- **`handlers/invocations.ts`**: `handleInvocation` のターン全体を `beginInvocation()` + `try/finally`（`endInvocation()`）で囲む。成功・エラー・ストリーム中断のいずれでも必ず idle に戻る。
- **`handlers/health.ts`**: `isBusy()` なら `HealthyBusy`、idle なら `Healthy`。

**効果**: 長時間ターン中の Idle 誤判定による mid-turn SIGTERM がほぼ解消。idle timeout 自体は残るため、真にアイドルなコンテナは従来どおり回収されます。

## テスト

TDD（RED→GREEN）。新規ユニットテスト 8 件:
- in-flight カウンタ: idle 初期状態 / busy / 復帰 / 並行 / 負値クランプ
- ping ハンドラ: idle→`Healthy` / busy→`HealthyBusy` / `time_of_last_update`

- `tsc -b`: ✅
- `eslint`: ✅
- ユニットテスト: **447 passed / 33 suites**（回帰なし）

## 補足

- 本PRは「動作中の SIGTERM を発生させない」対策の第一段です。SIGTERM の graceful drain（`process.exit(0)` 即時の見直し）や、別系統の trigger 即死（`{"error":{}}`）は別途。
- 再開時に孤立 `toolUse` を除去する読み取り側の防御は別PRで対応済み（多層防御）。