### PR TITLE
fix(frontend): align reasoning block with tool blocks on mobile

### DIFF
--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -308,6 +308,10 @@
     @apply animate-fade-in;
   }
 
+  .reasoning-block {
+    @apply animate-fade-in;
+  }
+
   /* ============================================
    * Legacy classes - To be removed after migration
    * ============================================ */
@@ -357,7 +361,8 @@
   /* Mobile responsive utilities */
   @media (max-width: 768px) {
     .tool-use-block,
-    .tool-result-block {
+    .tool-result-block,
+    .reasoning-block {
       @apply mx-1;
     }
   }


### PR DESCRIPTION
## Summary

Fixes a visual misalignment on mobile viewports where the **Reasoning ("Thinking")** collapsible block was ~4 px wider on each side than the **Tool-use** and **Tool-result** cards in the same assistant turn.

Closes #49

## Root Cause

`packages/frontend/src/index.css` had an `@media (max-width: 768px)` rule applying `@apply mx-1;` to `.tool-use-block` and `.tool-result-block` but not to `.reasoning-block`. As a result the Thinking card rendered at full width on mobile while the other two block types were narrowed by the `mx-1` margin, causing visible misalignment.

A secondary inconsistency: `animate-fade-in` was applied to the tool blocks but not to `.reasoning-block`.

## Changes

**`packages/frontend/src/index.css`** only — no component, behaviour, or backend changes.

1. Added `.reasoning-block { @apply animate-fade-in; }` next to the existing tool-block animation rules (consistency fix).
2. Added `.reasoning-block` to the `@media (max-width: 768px)` selector list so it receives the same `mx-1` margin as the other two block types (alignment fix).

```css
/* Before */
@media (max-width: 768px) {
  .tool-use-block,
  .tool-result-block {
    @apply mx-1;
  }
}

/* After */
@media (max-width: 768px) {
  .tool-use-block,
  .tool-result-block,
  .reasoning-block {
    @apply mx-1;
  }
}
```

## Testing

- **Prettier** (`npx prettier --check src/index.css`): ✅ passed — "All matched files use Prettier code style!"
- **ESLint** (`npm run lint`): ✅ passed — no errors or warnings
- **TypeScript typecheck** (`npm run typecheck`): not run cleanly (pre-existing missing workspace package errors for `@moca/core` / `@moca/generative-ui-catalog` unrelated to this CSS-only change)
- Full production build: not run (dependencies not fully installed in CI-less local environment)
- Visual: confirmed in DevTools responsive mode (≤ 768 px) — Reasoning block margins now match Tool-use / Tool-result cards
