### PR TITLE
fix(frontend): switch selected agent when clicking a running [Sub] session

### DIFF
--- a/packages/frontend/src/hooks/useSessionEventsSubscription.ts
+++ b/packages/frontend/src/hooks/useSessionEventsSubscription.ts
@@ -89,13 +89,24 @@ export function useSessionEventsSubscription() {
           // Check if session already exists (might be added optimistically)
           const exists = store.sessions.some((s) => s.sessionId === event.sessionId);
           if (!exists) {
-            store.addOptimisticSession(event.sessionId, event.title, event.sessionType);
-          } else if (event.sessionType) {
+            store.addOptimisticSession(
+              event.sessionId,
+              event.title,
+              event.sessionType,
+              event.agentId
+            );
+          } else {
             // WHY: The session may have been added optimistically before the
             // stream event arrived (e.g., HTTP POST /sessions response) without
-            // a sessionType. Patch it here so the sidebar badge (`[Sub]` /
-            // `[Event]`) renders without requiring a page reload.
-            store.updateSessionType(event.sessionId, event.sessionType);
+            // a sessionType / agentId. Patch them here so the sidebar badge
+            // (`[Sub]` / `[Event]`) renders and clicking the session switches
+            // the selected agent without requiring a page reload.
+            if (event.sessionType) {
+              store.updateSessionType(event.sessionId, event.sessionType);
+            }
+            if (event.agentId) {
+              store.updateSessionAgentId(event.sessionId, event.agentId);
+            }
           }
           break;
         }
@@ -109,6 +120,13 @@ export function useSessionEventsSubscription() {
           // defensively in case an INSERT event was missed.
           if (event.sessionType) {
             store.updateSessionType(event.sessionId, event.sessionType);
+          }
+          // Backfill agentId in case the optimistic add ran before the
+          // agentId-bearing event arrived. Required so clicking a `[Sub]`
+          // session while the agent is still running switches the selected
+          // agent in the header.
+          if (event.agentId) {
+            store.updateSessionAgentId(event.sessionId, event.agentId);
           }
           break;
         }

--- a/packages/frontend/src/stores/__tests__/sessionStore.agentId.test.ts
+++ b/packages/frontend/src/stores/__tests__/sessionStore.agentId.test.ts
@@ -1,0 +1,71 @@
+/**
+ * sessionStore — agentId handling for optimistically-added sessions.
+ *
+ * Regression coverage for the bug where clicking a `[Sub]` session while the
+ * spawning agent is still running did not switch the selected agent in the
+ * header. Root cause: optimistically-added sub-agent sessions dropped the
+ * `agentId` carried by the DynamoDB-stream event, so `selectSession` skipped
+ * `selectAgent`. See GitHub issue #52.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useSessionStore } from '../sessionStore';
+
+// A valid 33-char alphanumeric SessionId (see @moca/core/session-id).
+const SESSION_ID = 'abcdefghij0123456789ABCDEFGHIJ012';
+// A valid UUIDv7-shaped AgentId (see @moca/core/agent-id).
+const AGENT_ID = '019573e4-5a1b-7c2d-8e3f-4a5b6c7d8e9f';
+const OTHER_AGENT_ID = '019573e4-5a1b-7c2d-8e3f-4a5b6c7d8e00';
+
+describe('sessionStore agentId backfill', () => {
+  beforeEach(() => {
+    useSessionStore.setState({ sessions: [] });
+  });
+
+  it('stores agentId passed to addOptimisticSession', () => {
+    useSessionStore.getState().addOptimisticSession(SESSION_ID, '[Sub] worker', 'subagent', AGENT_ID);
+
+    const session = useSessionStore.getState().sessions.find((s) => s.sessionId === SESSION_ID);
+    expect(session?.agentId).toBe(AGENT_ID);
+  });
+
+  it('drops a malformed agentId rather than branding it', () => {
+    useSessionStore.getState().addOptimisticSession(SESSION_ID, '[Sub] worker', 'subagent', 'not-an-id');
+
+    const session = useSessionStore.getState().sessions.find((s) => s.sessionId === SESSION_ID);
+    expect(session?.agentId).toBeUndefined();
+  });
+
+  it('backfills agentId on a session that was added without one', () => {
+    const store = useSessionStore.getState();
+    store.addOptimisticSession(SESSION_ID, '[Sub] worker', 'subagent');
+    expect(
+      useSessionStore.getState().sessions.find((s) => s.sessionId === SESSION_ID)?.agentId
+    ).toBeUndefined();
+
+    store.updateSessionAgentId(SESSION_ID, AGENT_ID);
+
+    const session = useSessionStore.getState().sessions.find((s) => s.sessionId === SESSION_ID);
+    expect(session?.agentId).toBe(AGENT_ID);
+  });
+
+  it('ignores a malformed agentId in updateSessionAgentId', () => {
+    const store = useSessionStore.getState();
+    store.addOptimisticSession(SESSION_ID, '[Sub] worker', 'subagent', AGENT_ID);
+
+    store.updateSessionAgentId(SESSION_ID, 'not-an-id');
+
+    const session = useSessionStore.getState().sessions.find((s) => s.sessionId === SESSION_ID);
+    expect(session?.agentId).toBe(AGENT_ID);
+  });
+
+  it('updates agentId when a different valid value arrives', () => {
+    const store = useSessionStore.getState();
+    store.addOptimisticSession(SESSION_ID, '[Sub] worker', 'subagent', AGENT_ID);
+
+    store.updateSessionAgentId(SESSION_ID, OTHER_AGENT_ID);
+
+    const session = useSessionStore.getState().sessions.find((s) => s.sessionId === SESSION_ID);
+    expect(session?.agentId).toBe(OTHER_AGENT_ID);
+  });
+});

--- a/packages/frontend/src/stores/sessionStore.ts
+++ b/packages/frontend/src/stores/sessionStore.ts
@@ -19,7 +19,7 @@ import { useStorageStore } from './storageStore';
 import { logger } from '../utils/logger';
 import { extractErrorMessage } from '../utils/store-helpers';
 import { generateSessionId } from '../utils/sessionId';
-import { isSessionId } from '@moca/core';
+import { isSessionId, isAgentId } from '@moca/core';
 
 /**
  * Default page size for session list
@@ -66,9 +66,15 @@ interface SessionActions {
   refreshSessions: () => Promise<void>;
   createNewSession: () => string;
   finalizeNewSession: () => void;
-  addOptimisticSession: (sessionId: string, title?: string, sessionType?: SessionType) => void;
+  addOptimisticSession: (
+    sessionId: string,
+    title?: string,
+    sessionType?: SessionType,
+    agentId?: string
+  ) => void;
   updateSessionTitle: (sessionId: string, title: string) => void;
   updateSessionType: (sessionId: string, sessionType: SessionType) => void;
+  updateSessionAgentId: (sessionId: string, agentId: string) => void;
 }
 
 /**
@@ -435,7 +441,12 @@ export const useSessionStore = create<SessionStore>()(
         logger.log('New session creation completed');
       },
 
-      addOptimisticSession: (sessionId: string, title?: string, sessionType?: SessionType) => {
+      addOptimisticSession: (
+        sessionId: string,
+        title?: string,
+        sessionType?: SessionType,
+        agentId?: string
+      ) => {
         const { sessions } = get();
 
         // Validate at the boundary: callers pass raw strings (AppSync events,
@@ -461,6 +472,9 @@ export const useSessionStore = create<SessionStore>()(
           sessionId,
           title: title || 'New conversation...',
           sessionType,
+          // Narrow to branded `AgentId` at the boundary; drop malformed values
+          // rather than forcing the branded type onto an unvalidated string.
+          agentId: agentId && isAgentId(agentId) ? agentId : undefined,
           createdAt: new Date().toISOString(),
           updatedAt: new Date().toISOString(),
         };
@@ -503,6 +517,31 @@ export const useSessionStore = create<SessionStore>()(
 
         set({ sessions: updatedSessions });
         logger.log(`Updated session type: ${sessionId} - "${sessionType}"`);
+      },
+
+      updateSessionAgentId: (sessionId: string, agentId: string) => {
+        const { sessions } = get();
+
+        // Narrow to branded `AgentId` at the boundary; ignore malformed values.
+        if (!isAgentId(agentId)) {
+          logger.warn(`Invalid agentId format, skipping agentId patch: "${agentId}"`);
+          return;
+        }
+
+        // Skip update if already set to the same value to avoid unnecessary
+        // re-renders and log noise (INSERT + MODIFY stream events often
+        // deliver the same agentId in quick succession).
+        const target = sessions.find((s) => s.sessionId === sessionId);
+        if (!target || target.agentId === agentId) {
+          return;
+        }
+
+        const updatedSessions = sessions.map((session) =>
+          session.sessionId === sessionId ? { ...session, agentId } : session
+        );
+
+        set({ sessions: updatedSessions });
+        logger.log(`Updated session agentId: ${sessionId} - "${agentId}"`);
       },
     }),
     {


### PR DESCRIPTION
## Summary

Fixes #52.

Clicking a `[Sub] xxxx` session in the sidebar **while the spawning agent is still running** opened the session view but did **not** switch the selected agent name in the top-left header. It only worked after the run finished or after a page reload.

## Root Cause

Sub-agent sessions are inserted into the sidebar in real time via DynamoDB Streams → AppSync Events. The stream event carries `agentId`, but the subscription handler dropped it: `addOptimisticSession(sessionId, title, sessionType)` did not accept `agentId`, so the optimistic `SessionSummary.agentId` was `undefined`. Because `selectSession` restores the selected agent **only when the session has an `agentId`**, the header stayed unchanged. After the run, `fetchSessions` replaced the optimistic entry with the canonical record (which has `agentId`), so it self-healed.

## Changes

- `addOptimisticSession` now accepts an optional `agentId`, narrowed to the branded `AgentId` at the boundary (mirrors the existing `isSessionId` guard); malformed values are dropped.
- The `INSERT` handler passes `event.agentId`.
- New `updateSessionAgentId` (analogous to `updateSessionType`) backfills `agentId` on `MODIFY` and on the already-exists `INSERT` branch, covering the case where the optimistic add ran before the `agentId`-bearing event arrived.

## Affected Files

- `packages/frontend/src/hooks/useSessionEventsSubscription.ts`
- `packages/frontend/src/stores/sessionStore.ts`
- `packages/frontend/src/stores/__tests__/sessionStore.agentId.test.ts` (new)

## Testing

- New unit tests for agentId storage/backfill and malformed-value handling (5 cases).
- `npm run test` (frontend): 200 passed.
- `npm run typecheck`: clean.
- `npm run lint`: clean.