### PR TITLE
docs: add add-bedrock-model skill and align SSoT comments

### DIFF
--- a/.agents/skills/add-bedrock-model/SKILL.md
+++ b/.agents/skills/add-bedrock-model/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: add-bedrock-model
+description: How to add, remove, or modify a Bedrock model in the Moca app. Covers the SSoT in @moca/core, the decision tree (standard Converse model vs region-pinned vs new non-Converse endpoint), the files each case touches, the non-obvious pitfalls (region/IAM sync, reasoning effort caps, maxOutputTokens hard limits, data-retention prerequisites), and how to verify.
+---
+
+# Adding a Bedrock Model
+
+The canonical model list is `packages/libs/core/src/bedrock-models.ts` —
+`BEDROCK_MODEL_DEFINITIONS`. It is the **Single Source of Truth**. Every consumer
+(frontend selector, agent model factory, CDK config + IAM) derives its list from
+this array. **Do not** hand-maintain a second copy anywhere.
+
+Read that file first — its JSDoc is authoritative and kept in sync with the code.
+This skill is the *decision tree and pitfalls* layer on top of it.
+
+## Step 0 — Classify what you're adding (do this first)
+
+Most additions are Case A and touch **one file**. Do not over-engineer.
+
+```
+Is the model invoked through the standard Bedrock Converse API?
+├─ YES → Is it available in the deployment region (BEDROCK_REGION)?
+│        ├─ YES → CASE A: standard model. One edit to bedrock-models.ts. Done.
+│        └─ NO  → CASE B: add `region` pin. Still only bedrock-models.ts,
+│                 but read the region/IAM note below.
+└─ NO (OpenAI-compatible / other transport) →
+         ├─ It uses an EXISTING endpoint ('bedrock-openai' or 'mantle')?
+         │  → CASE C1: add `endpoint` to the entry. Still only bedrock-models.ts.
+         └─ It needs a BRAND-NEW transport (new base URL / API shape / IAM)?
+            → CASE C2: multi-file change. See "Case C2" below.
+```
+
+"Converse or not?" is a property of the model on Bedrock, not a choice. Anthropic,
+Amazon Nova, and Qwen models today use Converse. OpenAI models (gpt-5.x, gpt-oss)
+do **not** — they use OpenAI-compatible endpoints. If unsure, check the AWS
+Bedrock model card / API reference for the model.
+
+---
+
+## Case A — Standard Converse model (the common case)
+
+Add one entry to `BEDROCK_MODEL_DEFINITIONS`, ordered by preference (newest/most
+capable first — order drives the default UI selection). Fields:
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `id` | ✅ | Full model id **including** the cross-region inference-profile prefix (`global.` / `us.` / `eu.` / `apac.` / `jp.`) if the model has one. Bare id (no prefix) for In-Region-only models. Copy it exactly from the AWS Bedrock console / `get-foundation-model` — a typo fails the live integration test, not silently in prod. |
+| `name` | ✅ | UI display name, e.g. `Claude Opus 4.8`. |
+| `provider` | ✅ | One of `PROVIDERS` (`Anthropic` / `Amazon` / `Qwen` / `OpenAI`). Adding a new provider is a one-line change to `PROVIDERS` in the same file. |
+| `maxOutputTokens` | ✅ | See the **maxOutputTokens** pitfall below — do NOT trust the marketing number. |
+| `reasoningCapable` | optional | `true` only for extended-thinking models. Omit for others (Nova, Qwen, gpt-oss). |
+| `reasoningMaxEffort` | optional | Only when `reasoningCapable`. See the **reasoning effort cap** pitfall. |
+| `region` | optional | Case B only — see below. |
+| `endpoint` | optional | Case C only — see below. |
+
+That's the entire change for Case A. `bin/app.ts` dynamic-imports this list into
+CDK (`buildModelCatalog`), the frontend projects it into `FALLBACK_MODELS`, and
+the agent reads it at model-creation time. Nothing else to touch.
+
+---
+
+## Case B — Region-pinned model
+
+Set `region` when the model must be invoked in a **specific** region regardless of
+`BEDROCK_REGION` — e.g. an In-Region-only model not yet rolled out to the deploy
+region (despite the docs), or one whose account prerequisite is only enabled in
+certain regions.
+
+Two things follow **automatically** from the `region` value (no manual sync):
+- The agent routes this model's calls to `region` (`createBedrockModel` →
+  `getModelRegion`).
+- CDK scopes the inference-profile IAM ARN to `region` (`deriveBedrockIamResources`
+  reads `model.region`), so the pinned invocation is authorized.
+
+⚠️ **The pin must be correct, because both consumers trust it.** A wrong region
+here produces an IAM ARN that doesn't match the region the agent invokes in →
+`AccessDenied` at invocation time, not synth time. Verify the model actually
+resolves in that region before committing (see Verification).
+
+> The *only* place a `region` pin must be repeated by hand is a per-environment
+> `bedrockModels` override hardcoded in `packages/cdk/config/environments.ts`
+> (that override replaces the whole catalog by design). The default catalog needs
+> no sync.
+
+---
+
+## Case C — Non-Converse endpoint (transport)
+
+The `endpoint` field selects a non-Converse *transport* — an endpoint URL + SDK
+client + IAM service, independent of the model's vendor. Two exist today (both
+verified live):
+
+| `endpoint` | Host / API | IAM | Today |
+|-----------|-----------|-----|-------|
+| `'bedrock-openai'` | `bedrock-runtime.{region}.amazonaws.com/openai/v1`, OpenAI **Chat Completions** | `bedrock:InvokeModel*` + `bedrock:CallWithBearerToken` | gpt-oss |
+| `'mantle'` | `bedrock-mantle.{region}.api.aws/openai/v1`, OpenAI **Responses** API | separate `bedrock-mantle:` service (`CreateInference`/`Get*`/`List*` on `project/*` + `CallWithBearerToken`) | gpt-5.x |
+
+The two APIs are **mutually exclusive** on each host — Mantle rejects Chat
+Completions and the runtime host rejects the Responses API. Pick the one the model
+actually speaks.
+
+### Case C1 — model on an existing endpoint
+
+Add the entry with `endpoint: 'bedrock-openai'` (or `'mantle'`). One file.
+`createBedrockModel` routes off the field into `createBedrockOpenAiModel`, and the
+CDK IAM statements are gated by `hasEndpointModel(models, endpoint)` — already
+present for both existing endpoints, so adding another model of the same endpoint
+needs no IAM change. (If the new model pins a region, follow Case B too.)
+
+### Case C2 — brand-new transport
+
+This is the only multi-file change. You are adding a value to the `BedrockEndpoint`
+union, so you must teach every layer about it:
+
+1. **`packages/libs/core/src/bedrock-models.ts`** — add the literal to the
+   `BedrockEndpoint` type, document it in the `endpoint` JSDoc, add the model entry.
+2. **`packages/agent/src/config/bedrock-openai-model.ts`** — extend
+   `resolveEndpoint()` (base URL + `api` mode) and, if the model is a reasoning
+   model with the tool-call truncation issue, `responsesParams()`. (See the
+   `reasoning.effort: 'none'` note there — it is a correctness fix, not an
+   optimization, for gpt-5.x-style models on the Responses API.) If the transport
+   is NOT OpenAI-compatible at all, `createBedrockModel` in `bedrock.ts` needs a
+   new branch instead.
+3. **CDK IAM — BOTH roles** (they must mirror each other):
+   - `packages/cdk/lib/constructs/agentcore/agentcore-runtime.ts`
+   - `packages/cdk/lib/constructs/api/backend-api.ts`
+   Add a `hasEndpointModel(props.bedrockModels, '<new-endpoint>')`-gated policy
+   statement with the endpoint's IAM service/actions. Miss one role and you get an
+   auth error at runtime for that path only.
+4. **`packages/cdk/config/environment-types.ts`** — the `BedrockEndpoint` type
+   there is CDK's structural mirror (CDK doesn't import core). Add the literal.
+5. Tests — see below.
+
+---
+
+## Pitfalls (learned the hard way — do not skip)
+
+- **`maxOutputTokens` — verify the real ceiling, don't trust docs.** The Bedrock
+  runtime enforces hard limits that differ from marketing numbers. Example: current
+  Anthropic models cap at exactly `128000`; sending `131072` fails *every* request
+  with `ValidationException "exceeds the model limit of 128000"`. Match the value
+  the runtime actually accepts (the integration test / a live `ConverseCommand`
+  confirms it).
+
+- **Reasoning effort cap (`reasoningMaxEffort`).** `output_config.effort: 'max'` is
+  **Opus-tier only**. On non-Opus reasoning models (e.g. Sonnet) Bedrock rejects
+  `'max'`, so set `reasoningMaxEffort: 'high'`. The UI hides depths above the cap
+  and `getReasoningConfig` clamps the sent effort. Omit for Opus-tier (defaults to
+  `'max'`).
+
+- **Reasoning request shape is fixed.** Current Anthropic-on-Bedrock models require
+  `{ thinking: { type: 'adaptive' }, output_config: { effort } }` and REJECT the
+  legacy `{ thinking: { type: 'enabled', budget_tokens } }`. This lives in
+  `ReasoningRequestConfig` — don't reintroduce budget_tokens.
+
+- **Account-level prerequisites (data retention).** Some models (Mythos-class, e.g.
+  Fable 5) can only be invoked when the account's Bedrock **Data Retention mode** is
+  `provider_data_share` in the invocation region — otherwise *every* request fails
+  with `ValidationException: data retention mode 'default' is not available for this
+  model`, regardless of the request body. This is an account/region setting, not a
+  code fix. Note it in the entry's comment and don't region-pin it into a region
+  that lacks the setting.
+
+- **Bare id vs inference-profile prefix drives IAM shape.** A prefixed id
+  (`global.*`, `us.*`, …) gets **both** an inference-profile ARN (region-scoped) and
+  a foundation-model ARN. A bare In-Region id (e.g. `qwen.*`, `openai.gpt-oss-*`)
+  gets **only** the foundation-model ARN. `deriveBedrockIamResources` handles this
+  by prefix-matching — just make sure the `id` string is correct.
+
+- **Prompt caching is Anthropic-only.** The SDK `cacheConfig: 'auto'` strategy
+  no-ops for non-Anthropic families (Nova, Qwen, OpenAI) — expected, don't try to
+  force cachePoints onto them.
+
+---
+
+## Verification
+
+Per project policy, prefer running the repo's own checks over ad-hoc live AWS
+calls. In order:
+
+1. **Type + unit tests** (fast, no AWS creds):
+   ```bash
+   npm run build:ts
+   npm run test -w packages/libs/core     # bedrock-models.test.ts — structure/accessor assertions
+   npm run test -w packages/frontend      # models.test.ts — fallback projection
+   npm run test -w packages/agent         # bedrock.test.ts — model factory routing
+   ```
+   Add/extend assertions in `packages/libs/core/src/__tests__/bedrock-models.test.ts`
+   for the new entry (max tokens, region pin, endpoint, reasoning cap as applicable).
+
+2. **CDK synth + IAM** (Case B/C especially — confirms ARNs/statements resolve):
+   ```bash
+   npm run test -w packages/cdk           # includes bedrock model validation
+   ```
+
+3. **Live integration (opt-in, needs AWS creds with `bedrock:InvokeModel`).** This
+   is the executable form of "verify the inference-profile id resolves before
+   merging" — a typo'd or not-yet-GA id fails here instead of in production. Use a
+   **ReadOnly / least-privilege** role and a region where the models are enabled:
+   ```bash
+   cd packages/libs/core
+   RUN_BEDROCK_MODEL_INTEGRATION=1 BEDROCK_REGION=<region-with-model> \
+     npm run test:integration
+   ```
+   For a new non-Converse endpoint, also run the agent integration tests
+   (`packages/agent`, `openai-model.integration.test.ts` and friends) — likewise
+   opt-in and creds-gated.
+
+## Removing / modifying a model
+
+Same SSoT: edit or delete the entry in `bedrock-models.ts`. Because everything
+derives from it, removal propagates automatically. Watch for a hardcoded default
+model id fallback (e.g. `DEFAULT_MODEL_ID` in the frontend `models.ts`) if you
+remove what was the first/default entry.

--- a/packages/cdk/bin/app.ts
+++ b/packages/cdk/bin/app.ts
@@ -5,103 +5,130 @@ import { AwsSolutionsChecks } from 'cdk-nag';
 import { AgentCoreStack } from '../lib/agentcore-stack';
 import { AgentCoreGatewayTargetStack } from '../lib/agentcore-gateway-target-stack';
 import { WafStack } from '../lib/waf-stack';
-import { getEnvironmentConfig, Environment } from '../config';
+import {
+  getEnvironmentConfig,
+  buildModelCatalog,
+  type ModelCatalog,
+  Environment,
+} from '../config';
 
-const app = new cdk.App();
-cdk.Aspects.of(app).add(new AwsSolutionsChecks({ verbose: true }));
-
-// Get environment from Context (default: default)
-const envContext = app.node.tryGetContext('env') as Environment | undefined;
-const envName: Environment = envContext || 'default';
-
-// Get environment configuration
-const envConfig = getEnvironmentConfig(envName);
-
-// Stack name: MocaAgentCoreApp (default), MocaAgentCoreAppDev, MocaAgentCoreAppStg, MocaAgentCoreAppPrd, MocaAgentCoreAppPr123
-let stackName: string;
-if (!envContext) {
-  stackName = 'MocaAgentCoreApp';
-} else if (envName.startsWith('pr-')) {
-  // PR environment: MocaAgentCoreAppPr123
-  const prNumber = envName.replace('pr-', '');
-  stackName = `MocaAgentCoreAppPr${prNumber}`;
-} else {
-  // Standard environment: capitalize first letter
-  stackName = `MocaAgentCoreApp${envName.charAt(0).toUpperCase() + envName.slice(1)}`;
+/**
+ * Load the Bedrock model catalog from @moca/core (the single source of truth).
+ * Uses dynamic import because @moca/core is ESM and this CDK app compiles as
+ * CommonJS (a static import would emit a `require` of an ESM module → TS1479).
+ * The catalog is passed explicitly into getEnvironmentConfig so the "load core
+ * first" ordering is enforced by the type system, not a runtime precondition.
+ */
+async function loadModelCatalog(): Promise<ModelCatalog> {
+  const core = await import('@moca/core');
+  return buildModelCatalog(core.PROVIDERS, core.BEDROCK_MODEL_DEFINITIONS);
 }
 
-// WAF Stack: creates CloudFront WAF WebACL in us-east-1 (required for CloudFront scope).
-// The WebACL ARN is passed cross-region to AgentCoreStack via crossRegionReferences.
-//
-// Each deploy-region gets its own WAF stack in us-east-1 to avoid resource conflicts when
-// deploying to multiple regions from the same account:
-//   - ap-northeast-1 → MocaAgentCoreAppApNortheast1Waf / moca-ap-northeast-1-cloudfront-waf
-//   - us-west-2      → MocaAgentCoreAppUsWest2Waf      / moca-us-west-2-cloudfront-waf
-const deployRegion = process.env.CDK_DEFAULT_REGION ?? 'us-east-1';
+async function main(): Promise<void> {
+  const modelCatalog = await loadModelCatalog();
 
-// Convert region to PascalCase for use in stack name: ap-northeast-1 → ApNortheast1
-const regionPascal = deployRegion
-  .split('-')
-  .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
-  .join('');
+  const app = new cdk.App();
+  cdk.Aspects.of(app).add(new AwsSolutionsChecks({ verbose: true }));
 
-// WAF resource prefix includes the deploy region to ensure uniqueness across regions
-const wafResourcePrefix = `${envConfig.resourcePrefix}-${deployRegion}`;
+  // Get environment from Context (default: default)
+  const envContext = app.node.tryGetContext('env') as Environment | undefined;
+  const envName: Environment = envContext || 'default';
 
-// WAF stack name includes the region so each deploy-region has its own independent stack
-const wafStackName = `${stackName}${regionPascal}Waf`;
+  // Get environment configuration
+  const envConfig = getEnvironmentConfig(envName, modelCatalog);
 
-const wafStack = new WafStack(app, wafStackName, {
-  env: {
-    account: envConfig.awsAccount || process.env.CDK_DEFAULT_ACCOUNT,
-    // WAF for CloudFront must always be in us-east-1
-    region: 'us-east-1',
-  },
-  resourcePrefix: wafResourcePrefix,
-  description: `Amazon Bedrock AgentCore WAF (CloudFront) - ${envName.toUpperCase()} environment`,
-  terminationProtection: envConfig.deletionProtection,
+  // Stack name: MocaAgentCoreApp (default), MocaAgentCoreAppDev, MocaAgentCoreAppStg, MocaAgentCoreAppPrd, MocaAgentCoreAppPr123
+  let stackName: string;
+  if (!envContext) {
+    stackName = 'MocaAgentCoreApp';
+  } else if (envName.startsWith('pr-')) {
+    // PR environment: MocaAgentCoreAppPr123
+    const prNumber = envName.replace('pr-', '');
+    stackName = `MocaAgentCoreAppPr${prNumber}`;
+  } else {
+    // Standard environment: capitalize first letter
+    stackName = `MocaAgentCoreApp${envName.charAt(0).toUpperCase() + envName.slice(1)}`;
+  }
+
+  // WAF Stack: creates CloudFront WAF WebACL in us-east-1 (required for CloudFront scope).
+  // The WebACL ARN is passed cross-region to AgentCoreStack via crossRegionReferences.
+  //
+  // Each deploy-region gets its own WAF stack in us-east-1 to avoid resource conflicts when
+  // deploying to multiple regions from the same account:
+  //   - ap-northeast-1 → MocaAgentCoreAppApNortheast1Waf / moca-ap-northeast-1-cloudfront-waf
+  //   - us-west-2      → MocaAgentCoreAppUsWest2Waf      / moca-us-west-2-cloudfront-waf
+  const deployRegion = process.env.CDK_DEFAULT_REGION ?? 'us-east-1';
+
+  // Convert region to PascalCase for use in stack name: ap-northeast-1 → ApNortheast1
+  const regionPascal = deployRegion
+    .split('-')
+    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+    .join('');
+
+  // WAF resource prefix includes the deploy region to ensure uniqueness across regions
+  const wafResourcePrefix = `${envConfig.resourcePrefix}-${deployRegion}`;
+
+  // WAF stack name includes the region so each deploy-region has its own independent stack
+  const wafStackName = `${stackName}${regionPascal}Waf`;
+
+  const wafStack = new WafStack(app, wafStackName, {
+    env: {
+      account: envConfig.awsAccount || process.env.CDK_DEFAULT_ACCOUNT,
+      // WAF for CloudFront must always be in us-east-1
+      region: 'us-east-1',
+    },
+    resourcePrefix: wafResourcePrefix,
+    description: `Amazon Bedrock AgentCore WAF (CloudFront) - ${envName.toUpperCase()} environment`,
+    terminationProtection: envConfig.deletionProtection,
+  });
+
+  // Core Stack: manages foundational resources (Gateway, Cognito, Memory, Storage, Runtime, Frontend).
+  // Gateway targets are separated into AgentCoreGatewayTargetStack to split the deployment unit,
+  // allowing each target to be deployed independently without affecting core infrastructure.
+  const coreStack = new AgentCoreStack(app, stackName, {
+    env: {
+      account: envConfig.awsAccount || process.env.CDK_DEFAULT_ACCOUNT,
+      region: process.env.CDK_DEFAULT_REGION,
+    },
+    // Enable cross-region references so that WafStack (us-east-1) ARN can be referenced
+    // by AgentCoreStack (e.g., ap-northeast-1) without manual SSM/export wiring.
+    crossRegionReferences: true,
+    envConfig: envConfig,
+    tavilyApiKeySecretName: envConfig.tavilyApiKeySecretName,
+    description: `Amazon Bedrock AgentCore - ${envName.toUpperCase()} environment`,
+    terminationProtection: envConfig.deletionProtection,
+    webAclArn: wafStack.webAclArn,
+  });
+  coreStack.addDependency(wafStack);
+
+  // Gateway Target Stack: manages Gateway targets (Lambda Tools) as a separate deployment unit.
+  // By splitting targets into their own stack, additions, changes, and removals of targets
+  // can be deployed independently without impacting core resources.
+  // Uses Fn::ImportValue (via coreStackName) for cross-stack Gateway reference,
+  // or accepts direct Gateway attributes (gatewayArn, etc.) for connecting to externally managed Gateways.
+  const targetStackName = `${stackName}Targets`;
+  const targetStack = new AgentCoreGatewayTargetStack(app, targetStackName, {
+    env: {
+      account: envConfig.awsAccount || process.env.CDK_DEFAULT_ACCOUNT,
+      region: process.env.CDK_DEFAULT_REGION,
+    },
+    envConfig: envConfig,
+    coreStackName: stackName,
+    description: `Amazon Bedrock AgentCore Gateway Targets - ${envName.toUpperCase()} environment`,
+    terminationProtection: envConfig.deletionProtection,
+  });
+  targetStack.addDependency(coreStack);
+
+  // Output environment information
+  console.log(`🚀 Deploying AgentCore Stack for environment: ${envName}`);
+  console.log(`📦 Core Stack Name: ${stackName}`);
+  console.log(`📦 Target Stack Name: ${targetStackName}`);
+  console.log(`🌍 Region: ${process.env.CDK_DEFAULT_REGION || 'not set (will use AWS_REGION)'}`);
+  console.log(`🔒 Deletion Protection: ${envConfig.deletionProtection ? 'ENABLED' : 'DISABLED'}`);
+}
+
+// Entry point. A synth/deploy failure must exit non-zero so CI/CDK surfaces it.
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
 });
-
-// Core Stack: manages foundational resources (Gateway, Cognito, Memory, Storage, Runtime, Frontend).
-// Gateway targets are separated into AgentCoreGatewayTargetStack to split the deployment unit,
-// allowing each target to be deployed independently without affecting core infrastructure.
-const coreStack = new AgentCoreStack(app, stackName, {
-  env: {
-    account: envConfig.awsAccount || process.env.CDK_DEFAULT_ACCOUNT,
-    region: process.env.CDK_DEFAULT_REGION,
-  },
-  // Enable cross-region references so that WafStack (us-east-1) ARN can be referenced
-  // by AgentCoreStack (e.g., ap-northeast-1) without manual SSM/export wiring.
-  crossRegionReferences: true,
-  envConfig: envConfig,
-  tavilyApiKeySecretName: envConfig.tavilyApiKeySecretName,
-  description: `Amazon Bedrock AgentCore - ${envName.toUpperCase()} environment`,
-  terminationProtection: envConfig.deletionProtection,
-  webAclArn: wafStack.webAclArn,
-});
-coreStack.addDependency(wafStack);
-
-// Gateway Target Stack: manages Gateway targets (Lambda Tools) as a separate deployment unit.
-// By splitting targets into their own stack, additions, changes, and removals of targets
-// can be deployed independently without impacting core resources.
-// Uses Fn::ImportValue (via coreStackName) for cross-stack Gateway reference,
-// or accepts direct Gateway attributes (gatewayArn, etc.) for connecting to externally managed Gateways.
-const targetStackName = `${stackName}Targets`;
-const targetStack = new AgentCoreGatewayTargetStack(app, targetStackName, {
-  env: {
-    account: envConfig.awsAccount || process.env.CDK_DEFAULT_ACCOUNT,
-    region: process.env.CDK_DEFAULT_REGION,
-  },
-  envConfig: envConfig,
-  coreStackName: stackName,
-  description: `Amazon Bedrock AgentCore Gateway Targets - ${envName.toUpperCase()} environment`,
-  terminationProtection: envConfig.deletionProtection,
-});
-targetStack.addDependency(coreStack);
-
-// Output environment information
-console.log(`🚀 Deploying AgentCore Stack for environment: ${envName}`);
-console.log(`📦 Core Stack Name: ${stackName}`);
-console.log(`📦 Target Stack Name: ${targetStackName}`);
-console.log(`🌍 Region: ${process.env.CDK_DEFAULT_REGION || 'not set (will use AWS_REGION)'}`);
-console.log(`🔒 Deletion Protection: ${envConfig.deletionProtection ? 'ENABLED' : 'DISABLED'}`);

--- a/packages/cdk/config/environment-types.ts
+++ b/packages/cdk/config/environment-types.ts
@@ -10,6 +10,21 @@ import * as cdk from 'aws-cdk-lib';
 export type Environment = 'default' | 'dev' | 'stg' | 'prd' | string; // Allow dynamic PR environments
 
 /**
+ * Model provider + non-Converse endpoint unions.
+ *
+ * These MIRROR @moca/core's `Provider` / `BedrockEndpoint`, re-declared here
+ * rather than imported because @moca/core is ESM and this file is compiled as
+ * CommonJS by CDK's ts-node/ts-jest (a type-only import of an ESM module from
+ * CJS under Node16 requires a `resolution-mode` attribute and jest cannot
+ * resolve the package at all). Drift is guarded at RUNTIME instead: the actual
+ * provider allowlist and default model list flow from core via
+ * buildModelCatalog() and are passed into getEnvironmentConfig(), so a mismatch
+ * surfaces at synth time, not from these compile-time aliases.
+ */
+export type Provider = 'Anthropic' | 'Amazon' | 'Qwen' | 'OpenAI';
+export type BedrockEndpoint = 'bedrock-openai' | 'mantle';
+
+/**
  * Bedrock model configuration for frontend model selector
  */
 export interface BedrockModelConfig {
@@ -21,8 +36,8 @@ export interface BedrockModelConfig {
   id: string;
   /** Display name (e.g., 'Claude Sonnet 4.6') */
   name: string;
-  /** Provider name */
-  provider: 'Anthropic' | 'Amazon' | 'Qwen' | 'OpenAI';
+  /** Provider name (from @moca/core's Provider union — the single source). */
+  provider: Provider;
   /**
    * Optional invocation-region pin.
    *
@@ -35,9 +50,11 @@ export interface BedrockModelConfig {
    * is authorized. Omit for models invoked in the deployment region (the common
    * case).
    *
-   * MUST be kept in sync with the `region` field of the matching entry in
-   * BEDROCK_MODEL_DEFINITIONS (packages/libs/core/src/bedrock-models.ts) — CDK
-   * does not import @moca/core, so the two lists are synced by hand.
+   * For the default model list this is DERIVED from the matching
+   * BEDROCK_MODEL_DEFINITIONS entry (packages/libs/core/src/bedrock-models.ts)
+   * via buildModelCatalog(), so it cannot drift. This field only needs setting
+   * on a hand-authored per-environment `bedrockModels` override in
+   * environments.ts, where it must match that model's core region pin.
    */
   region?: string;
   /**
@@ -54,10 +71,12 @@ export interface BedrockModelConfig {
    *     / `List*` on `project/*` + `CallWithBearerToken`), NOT `bedrock:`. Today:
    *     gpt-5.x (Mantle also hosts non-OpenAI vendors — vendor-neutral name).
    *
-   * MUST mirror `endpoint` on the matching BEDROCK_MODEL_DEFINITIONS entry.
+   * Type is @moca/core's BedrockEndpoint (the single source). When the default
+   * model list is derived from BEDROCK_MODEL_DEFINITIONS this cannot drift; a
+   * hand-authored per-env override still gets compile-time checking.
    * Omit for Converse-API models.
    */
-  endpoint?: 'bedrock-openai' | 'mantle';
+  endpoint?: BedrockEndpoint;
 }
 
 /**
@@ -216,10 +235,11 @@ export interface EnvironmentConfig {
    * Available Bedrock models for frontend model selector (optional)
    * Each model ID should include the cross-region inference profile prefix
    * (e.g., 'global.', 'jp.', 'us.', 'eu.', 'apac.')
-   * @default The bedrockModels list in DEFAULT_CONFIG
-   *   (packages/cdk/config/environment-utils.ts); Claude Opus 4.8 is the
-   *   default-selected model. See that list for the authoritative set, which
-   *   grows as new models are added.
+   * @default The catalog derived from @moca/core's BEDROCK_MODEL_DEFINITIONS
+   *   (packages/libs/core/src/bedrock-models.ts), loaded via buildModelCatalog()
+   *   in bin/app.ts; Claude Opus 4.8 is the default-selected model. That file is
+   *   the authoritative set and grows as new models are added — set this field
+   *   only to override the catalog for a single environment.
    */
   bedrockModels?: BedrockModelConfig[];
 

--- a/packages/cdk/config/environment-utils.test.ts
+++ b/packages/cdk/config/environment-utils.test.ts
@@ -1,12 +1,18 @@
 import {
   deriveBedrockIamResources,
-  hasBedrockOpenAiModel,
-  hasMantleModel,
+  hasEndpointModel,
   validateBedrockModelsForTest,
+  buildModelCatalog,
 } from './environment-utils';
 
 const REGION = 'us-east-1';
 const ACCOUNT = '123456789012';
+
+// Provider allowlist these tests validate against. Passed explicitly to
+// validateBedrockModelsForTest (which has no built-in default) so the allowlist
+// under test is visible here rather than hidden in the helper. Mirrors
+// @moca/core's PROVIDERS; core can't be imported in CDK's CommonJS jest.
+const TEST_PROVIDERS = ['Anthropic', 'Amazon', 'Qwen', 'OpenAI'] as const;
 
 describe('deriveBedrockIamResources', () => {
   // ── ARN format helpers ──────────────────────────────────────────────────────
@@ -381,7 +387,7 @@ describe('validateBedrockModels — region pin format', () => {
     ];
     expect(() => deriveBedrockIamResources(models, REGION, ACCOUNT)).not.toThrow();
     // Validation lives on the config path; assert there via the exported guard.
-    expect(() => validateBedrockModelsForTest(models)).toThrow(/region/i);
+    expect(() => validateBedrockModelsForTest(models, TEST_PROVIDERS)).toThrow(/region/i);
   });
 
   it('accepts a model with a well-formed region pin', () => {
@@ -393,7 +399,7 @@ describe('validateBedrockModels — region pin format', () => {
         region: 'ap-northeast-1',
       },
     ];
-    expect(() => validateBedrockModelsForTest(models)).not.toThrow();
+    expect(() => validateBedrockModelsForTest(models, TEST_PROVIDERS)).not.toThrow();
   });
 
   it('accepts the OpenAI provider', () => {
@@ -404,63 +410,75 @@ describe('validateBedrockModels — region pin format', () => {
         provider: 'OpenAI' as const,
       },
     ];
-    expect(() => validateBedrockModelsForTest(models)).not.toThrow();
+    expect(() => validateBedrockModelsForTest(models, TEST_PROVIDERS)).not.toThrow();
   });
 });
 
 // The two non-Converse endpoints gate DIFFERENT IAM: bedrock-openai (gpt-oss) →
 // bedrock:CallWithBearerToken; mantle (gpt-5.x) → the separate bedrock-mantle:
-// service statements. Each helper must match only its endpoint.
-describe('hasBedrockOpenAiModel', () => {
-  it('is true only when a bedrock-openai (gpt-oss) model is configured', () => {
-    expect(
-      hasBedrockOpenAiModel([
-        { id: 'openai.gpt-oss-20b-1:0', name: 'GPT-OSS 20B', provider: 'OpenAI', endpoint: 'bedrock-openai' },
-      ])
-    ).toBe(true);
-  });
+// service statements. hasEndpointModel must match ONLY the requested endpoint.
+describe('hasEndpointModel', () => {
+  const OSS = {
+    id: 'openai.gpt-oss-20b-1:0',
+    name: 'GPT-OSS 20B',
+    provider: 'OpenAI' as const,
+    endpoint: 'bedrock-openai' as const,
+  };
+  const MANTLE = {
+    id: 'openai.gpt-5.5',
+    name: 'GPT-5.5',
+    provider: 'OpenAI' as const,
+    region: 'us-east-1',
+    endpoint: 'mantle' as const,
+  };
+  const CONVERSE = { id: 'qwen.qwen3-coder-next', name: 'Qwen3', provider: 'Qwen' as const };
 
-  it('is false when only a mantle (gpt-5.x) model is configured', () => {
-    expect(
-      hasBedrockOpenAiModel([
-        { id: 'openai.gpt-5.5', name: 'GPT-5.5', provider: 'OpenAI', region: 'us-east-1', endpoint: 'mantle' },
-      ])
-    ).toBe(false);
+  it('matches only the requested endpoint, not the sibling one', () => {
+    expect(hasEndpointModel([OSS], 'bedrock-openai')).toBe(true);
+    expect(hasEndpointModel([OSS], 'mantle')).toBe(false);
+    expect(hasEndpointModel([MANTLE], 'mantle')).toBe(true);
+    expect(hasEndpointModel([MANTLE], 'bedrock-openai')).toBe(false);
   });
 
   it('is false for Converse models and empty lists', () => {
-    expect(
-      hasBedrockOpenAiModel([
-        { id: 'qwen.qwen3-coder-next', name: 'Qwen3', provider: 'Qwen' },
-      ])
-    ).toBe(false);
-    expect(hasBedrockOpenAiModel([])).toBe(false);
+    expect(hasEndpointModel([CONVERSE], 'bedrock-openai')).toBe(false);
+    expect(hasEndpointModel([CONVERSE], 'mantle')).toBe(false);
+    expect(hasEndpointModel([], 'mantle')).toBe(false);
+  });
+
+  it('detects the endpoint among a mixed model list', () => {
+    expect(hasEndpointModel([CONVERSE, OSS, MANTLE], 'mantle')).toBe(true);
+    expect(hasEndpointModel([CONVERSE, OSS, MANTLE], 'bedrock-openai')).toBe(true);
   });
 });
 
-describe('hasMantleModel', () => {
-  it('is true only when a mantle (gpt-5.x) model is configured', () => {
-    expect(
-      hasMantleModel([
-        { id: 'openai.gpt-5.4', name: 'GPT-5.4', provider: 'OpenAI', region: 'us-east-1', endpoint: 'mantle' },
-      ])
-    ).toBe(true);
+// buildModelCatalog projects @moca/core's model definitions to the CDK-relevant
+// fields. This is the seam that replaced the hand-maintained DEFAULT_CONFIG list,
+// so it must copy id/name/provider/region/endpoint and drop everything else
+// (maxOutputTokens, reasoning*) that CDK does not use.
+describe('buildModelCatalog', () => {
+  const CORE_DEFS = [
+    { id: 'global.anthropic.claude-opus-4-8', name: 'Opus', provider: 'Anthropic' as const, maxOutputTokens: 128000, reasoningCapable: true },
+    { id: 'openai.gpt-5.5', name: 'GPT-5.5', provider: 'OpenAI' as const, maxOutputTokens: 128000, region: 'us-east-1', endpoint: 'mantle' as const },
+    { id: 'openai.gpt-oss-120b-1:0', name: 'GPT-OSS 120B', provider: 'OpenAI' as const, maxOutputTokens: 131072, endpoint: 'bedrock-openai' as const },
+  ];
+
+  it('carries providers through verbatim', () => {
+    const cat = buildModelCatalog(['Anthropic', 'OpenAI'], CORE_DEFS);
+    expect(cat.providers).toEqual(['Anthropic', 'OpenAI']);
   });
 
-  it('is false when only a bedrock-openai (gpt-oss) model is configured', () => {
-    expect(
-      hasMantleModel([
-        { id: 'openai.gpt-oss-20b-1:0', name: 'GPT-OSS 20B', provider: 'OpenAI', endpoint: 'bedrock-openai' },
-      ])
-    ).toBe(false);
+  it('projects only id/name/provider/region/endpoint (drops maxOutputTokens/reasoning)', () => {
+    const cat = buildModelCatalog(['Anthropic', 'OpenAI'], CORE_DEFS);
+    expect(cat.defaultModels).toEqual([
+      { id: 'global.anthropic.claude-opus-4-8', name: 'Opus', provider: 'Anthropic' },
+      { id: 'openai.gpt-5.5', name: 'GPT-5.5', provider: 'OpenAI', region: 'us-east-1', endpoint: 'mantle' },
+      { id: 'openai.gpt-oss-120b-1:0', name: 'GPT-OSS 120B', provider: 'OpenAI', endpoint: 'bedrock-openai' },
+    ]);
   });
 
-  it('is false for Converse models and empty lists', () => {
-    expect(
-      hasMantleModel([
-        { id: 'global.anthropic.claude-opus-4-8', name: 'Opus', provider: 'Anthropic' },
-      ])
-    ).toBe(false);
-    expect(hasMantleModel([])).toBe(false);
+  it('omits region/endpoint keys entirely when the model has none (Converse models)', () => {
+    const cat = buildModelCatalog(['Anthropic'], CORE_DEFS.slice(0, 1));
+    expect(Object.keys(cat.defaultModels[0])).toEqual(['id', 'name', 'provider']);
   });
 });

--- a/packages/cdk/config/environment-utils.ts
+++ b/packages/cdk/config/environment-utils.ts
@@ -6,11 +6,71 @@
 import * as cdk from 'aws-cdk-lib';
 import type {
   BedrockModelConfig,
+  BedrockEndpoint,
+  Provider,
   Environment,
   EnvironmentConfig,
   EnvironmentConfigInput,
 } from './environment-types';
 import { BASE_PREFIX, environments } from './environments';
+
+/**
+ * The Bedrock model catalog, loaded from @moca/core by the composition root
+ * (bin/app.ts) and passed explicitly into {@link getEnvironmentConfig}.
+ *
+ * WHY passed as an argument rather than imported: @moca/core is an ESM package
+ * (`type: module`); CDK compiles as CommonJS (ts-node / ts-jest, `module:
+ * Node16`/`commonjs`), so a static `import { BEDROCK_MODEL_DEFINITIONS }` emits
+ * a `require()` of an ESM module (TS1479) and jest cannot resolve the package
+ * at all. bin/app.ts is the one place that can `await import('@moca/core')`, so
+ * it loads the catalog once and threads it through the config functions. Passing
+ * it (rather than stashing it in module state) makes "load core before resolving
+ * config" a compile-time signature requirement instead of a runtime precondition.
+ */
+export interface ModelCatalog {
+  /** Providers allowlist (core PROVIDERS). */
+  readonly providers: readonly Provider[];
+  /**
+   * Default enabled models, projected from core's BEDROCK_MODEL_DEFINITIONS to
+   * the CDK-relevant fields (id/name/provider/region/endpoint).
+   */
+  readonly defaultModels: readonly BedrockModelConfig[];
+}
+
+/**
+ * The subset of a @moca/core BedrockModelDefinition that CDK config needs.
+ * Kept structural (not an import of the core type) so this stays a plain
+ * projection contract; bin/app.ts passes core's definitions straight in.
+ */
+interface CoreModelDefinition {
+  readonly id: string;
+  readonly name: string;
+  readonly provider: Provider;
+  readonly region?: string;
+  readonly endpoint?: BedrockModelConfig['endpoint'];
+}
+
+/**
+ * Build a {@link ModelCatalog} from @moca/core's PROVIDERS + BEDROCK_MODEL_DEFINITIONS.
+ * Called by bin/app.ts after dynamic-importing core. Projects each model to the
+ * CDK-relevant fields (id/name/provider/region/endpoint); maxOutputTokens and
+ * reasoning metadata are intentionally dropped — CDK does not use them.
+ */
+export function buildModelCatalog(
+  providers: readonly Provider[],
+  definitions: readonly CoreModelDefinition[]
+): ModelCatalog {
+  return {
+    providers,
+    defaultModels: definitions.map((m) => ({
+      id: m.id,
+      name: m.name,
+      provider: m.provider,
+      ...(m.region !== undefined ? { region: m.region } : {}),
+      ...(m.endpoint !== undefined ? { endpoint: m.endpoint } : {}),
+    })),
+  };
+}
 
 const INFERENCE_PROFILE_STRIP = /^(global|us|eu|apac|jp)\./;
 
@@ -76,132 +136,28 @@ const DEFAULT_CONFIG = {
   // Default geo restriction: Japan and United States
   // Override per-environment in environments.ts if needed
   cloudFrontGeoRestriction: ['JP', 'US'] as string[],
-  /**
-   * CDK intentionally does not depend on @moca/core to keep infrastructure free
-   * of runtime library dependencies. Keep this list in sync with
-   * BEDROCK_MODEL_DEFINITIONS in packages/libs/core/src/bedrock-models.ts —
-   * including the optional `region` pin: if a model sets `region` there it must
-   * set the SAME `region` here, because deriveBedrockIamResources() uses it to
-   * scope the inference-profile IAM ARN. An out-of-sync region pin grants the
-   * wrong-region ARN and the agent's invocation fails with AccessDenied.
-   * (validateBedrockModels() enforces id/name/provider/region shape at synth time.)
-   */
-  bedrockModels: [
-    {
-      // Default model. No account-level prerequisite, so it works out of the box.
-      id: 'global.anthropic.claude-opus-4-8',
-      name: 'Claude Opus 4.8',
-      provider: 'Anthropic',
-    },
-    {
-      // Requires Bedrock Data Retention mode `provider_data_share` in the
-      // deployment region — see the registry note in
-      // packages/libs/core/src/bedrock-models.ts and the README. No region pin
-      // in this OSS default: Fable 5 is invoked in the deploy region, so
-      // deriveBedrockIamResources() scopes its inference-profile IAM ARN to the
-      // deploy region. If your deploy region cannot enable provider_data_share,
-      // pin Fable 5 to a region that has it by overriding bedrockModels (with a
-      // `region`) for your environment in environments.ts — and mirror that
-      // region in BEDROCK_MODEL_DEFINITIONS so the agent invokes there too.
-      id: 'global.anthropic.claude-fable-5',
-      name: 'Claude Fable 5',
-      provider: 'Anthropic',
-    },
-    {
-      id: 'global.anthropic.claude-opus-4-7',
-      name: 'Claude Opus 4.7',
-      provider: 'Anthropic',
-    },
-    {
-      id: 'global.anthropic.claude-opus-4-6-v1',
-      name: 'Claude Opus 4.6',
-      provider: 'Anthropic',
-    },
-    {
-      id: 'global.anthropic.claude-sonnet-5',
-      name: 'Claude Sonnet 5',
-      provider: 'Anthropic',
-    },
-    {
-      id: 'global.anthropic.claude-sonnet-4-6',
-      name: 'Claude Sonnet 4.6',
-      provider: 'Anthropic',
-    },
-    {
-      id: 'global.amazon.nova-2-lite-v1:0',
-      name: 'Nova Lite 2',
-      provider: 'Amazon',
-    },
-    {
-      // In-Region only, bare id (no -v1:0 suffix). maxOutputTokens lives in
-      // BEDROCK_MODEL_DEFINITIONS (@moca/core) — CDK config carries id/name/provider only.
-      id: 'qwen.qwen3-coder-next',
-      name: 'Qwen3 Coder Next',
-      provider: 'Qwen',
-    },
-    {
-      // OpenAI GPT-5.5 via Bedrock Mantle (OpenAI-compatible Responses API).
-      // Region pin us-east-1: only region hosting gpt-5.5 (404 elsewhere). MUST
-      // match BEDROCK_MODEL_DEFINITIONS so the Mantle base URL and this grant
-      // target the same region. Bare id → foundation-model ARN only. Requires
-      // bedrock:CallWithBearerToken (see BedrockBearerTokenAuth statement).
-      id: 'openai.gpt-5.5',
-      name: 'GPT-5.5',
-      provider: 'OpenAI',
-      region: 'us-east-1',
-      endpoint: 'mantle',
-    },
-    {
-      // OpenAI GPT-5.4 via Bedrock Mantle. Pinned to us-east-1 to match GPT-5.5
-      // (also available in us-west-2).
-      id: 'openai.gpt-5.4',
-      name: 'GPT-5.4',
-      provider: 'OpenAI',
-      region: 'us-east-1',
-      endpoint: 'mantle',
-    },
-    {
-      // OpenAI GPT-OSS (open-weight) via Bedrock's OpenAI-compatible Chat
-      // Completions endpoint. Bare id → foundation-model ARN only (same IAM
-      // shape as qwen.*). No region pin: available in ap-northeast-1 and
-      // us-east-1/us-east-2/us-west-2, so it is invoked in the deploy region.
-      // These invocations additionally require bedrock:CallWithBearerToken — see
-      // the BedrockBearerTokenAuth statement added when an OpenAI model is enabled.
-      id: 'openai.gpt-oss-120b-1:0',
-      name: 'GPT-OSS 120B',
-      provider: 'OpenAI',
-      endpoint: 'bedrock-openai',
-    },
-    {
-      id: 'openai.gpt-oss-20b-1:0',
-      name: 'GPT-OSS 20B',
-      provider: 'OpenAI',
-      endpoint: 'bedrock-openai',
-    },
-  ] satisfies BedrockModelConfig[],
+  // NOTE: the default Bedrock model list is NOT hardcoded here anymore. It is
+  // derived from @moca/core's BEDROCK_MODEL_DEFINITIONS (the single source of
+  // truth) via buildModelCatalog() and passed into getEnvironmentConfig();
+  // resolveConfig() reads it from that catalog. This removes the hand-synced
+  // duplicate that previously drifted from core (a wrong region/endpoint here
+  // silently mis-scoped IAM → AccessDenied).
 };
 
-const VALID_PROVIDERS: readonly string[] = ['Anthropic', 'Amazon', 'Qwen', 'OpenAI'];
-
 /**
- * Whether any configured model uses the `bedrock-openai` endpoint (gpt-oss, via
- * bedrock-runtime `/openai/v1`). These are authorized by the standard
- * `bedrock:InvokeModel*` grant plus `bedrock:CallWithBearerToken` (the
- * bearer-token auth path). Used to gate that CallWithBearerToken statement.
+ * Whether any configured model uses the given non-Converse Bedrock endpoint.
+ * Used by the task-role IAM to gate the endpoint-specific statements, which
+ * differ by AWS service:
+ *   - `'bedrock-openai'` (gpt-oss, bedrock-runtime `/openai/v1`) →
+ *     `bedrock:InvokeModel*` + `bedrock:CallWithBearerToken`.
+ *   - `'mantle'` (gpt-5.x, Bedrock Mantle host) → the SEPARATE `bedrock-mantle:`
+ *     service (CreateInference / Get* / List* on `project/*` + CallWithBearerToken).
  */
-export function hasBedrockOpenAiModel(models: BedrockModelConfig[]): boolean {
-  return models.some((m) => m.endpoint === 'bedrock-openai');
-}
-
-/**
- * Whether any configured model uses the `mantle` endpoint (gpt-5.x today, via
- * the Bedrock Mantle host). These are authorized by the SEPARATE
- * **`bedrock-mantle:`** service — NOT `bedrock:` — so they need their own IAM
- * statement (CreateInference / Get* / List* on `project/*` +
- * bedrock-mantle:CallWithBearerToken). Used to gate that Mantle statement.
- */
-export function hasMantleModel(models: BedrockModelConfig[]): boolean {
-  return models.some((m) => m.endpoint === 'mantle');
+export function hasEndpointModel(
+  models: BedrockModelConfig[],
+  endpoint: BedrockEndpoint
+): boolean {
+  return models.some((m) => m.endpoint === endpoint);
 }
 
 /**
@@ -261,7 +217,11 @@ function validateCognitoDomainPrefix(prefix: string | undefined, env: Environmen
  * Validate bedrockModels configuration
  * Called during resolveConfig so errors surface at cdk synth / deploy time.
  */
-function validateBedrockModels(models: BedrockModelConfig[], env: Environment): void {
+function validateBedrockModels(
+  models: BedrockModelConfig[],
+  env: Environment,
+  validProviders: readonly string[]
+): void {
   if (models.length === 0) {
     throw new Error(`[${env}] bedrockModels must contain at least one model`);
   }
@@ -279,9 +239,9 @@ function validateBedrockModels(models: BedrockModelConfig[], env: Environment): 
     if (!model.name || typeof model.name !== 'string') {
       throw new Error(`[${env}] bedrockModels: missing name for model "${model.id}"`);
     }
-    if (!VALID_PROVIDERS.includes(model.provider)) {
+    if (!validProviders.includes(model.provider)) {
       throw new Error(
-        `[${env}] bedrockModels: invalid provider "${model.provider}" for model "${model.id}". Must be one of: ${VALID_PROVIDERS.join(', ')}`
+        `[${env}] bedrockModels: invalid provider "${model.provider}" for model "${model.id}". Must be one of: ${validProviders.join(', ')}`
       );
     }
     if (model.region !== undefined && !AWS_REGION_TOKEN.test(model.region)) {
@@ -297,9 +257,16 @@ function validateBedrockModels(models: BedrockModelConfig[], env: Environment): 
  * Test-only wrapper around the private validateBedrockModels(). Lets unit tests
  * assert validation behavior (e.g. region-pin format) without going through the
  * full getEnvironmentConfig() path. Not used by production code.
+ *
+ * @param validProviders required provider allowlist. Callers pass it explicitly
+ *   (rather than a hardcoded default here) so this file holds NO second copy of
+ *   the provider list — the test decides which allowlist it is asserting against.
  */
-export function validateBedrockModelsForTest(models: BedrockModelConfig[]): void {
-  validateBedrockModels(models, 'default');
+export function validateBedrockModelsForTest(
+  models: BedrockModelConfig[],
+  validProviders: readonly string[]
+): void {
+  validateBedrockModels(models, 'default', validProviders);
 }
 
 /**
@@ -321,9 +288,15 @@ function getDefaultResourcePrefix(env: Environment): string {
  * @param input Partial environment configuration input
  * @returns Full configuration with all defaults applied
  */
-function resolveConfig(env: Environment, input: EnvironmentConfigInput): EnvironmentConfig {
-  const bedrockModels = input.bedrockModels ?? DEFAULT_CONFIG.bedrockModels;
-  validateBedrockModels(bedrockModels, env);
+function resolveConfig(
+  env: Environment,
+  input: EnvironmentConfigInput,
+  catalog: ModelCatalog
+): EnvironmentConfig {
+  // Per-env override wins; otherwise use the default model list derived from
+  // @moca/core (the single source), not a hand-maintained copy.
+  const bedrockModels = input.bedrockModels ?? [...catalog.defaultModels];
+  validateBedrockModels(bedrockModels, env, catalog.providers);
   validateCognitoDomainPrefix(input.cognitoDomainPrefix, env);
 
   return {
@@ -392,14 +365,19 @@ function getPrEnvironmentConfig(env: string): EnvironmentConfigInput {
 }
 
 /**
- * Get environment configuration with defaults applied
+ * Get environment configuration with defaults applied.
+ *
  * @param env Environment name (default, dev, stg, prd, or pr-{number})
+ * @param catalog Model catalog loaded from @moca/core (see {@link buildModelCatalog}).
+ *   Passing it explicitly makes "load core before resolving config" a
+ *   compile-time requirement — the composition root (bin/app.ts) awaits the
+ *   dynamic import of core and hands the catalog in.
  * @returns Full environment configuration with all defaults applied
  */
-export function getEnvironmentConfig(env: Environment): EnvironmentConfig {
+export function getEnvironmentConfig(env: Environment, catalog: ModelCatalog): EnvironmentConfig {
   // Check if it's a PR environment (e.g., pr-123)
   if (env.startsWith('pr-')) {
-    return resolveConfig(env, getPrEnvironmentConfig(env));
+    return resolveConfig(env, getPrEnvironmentConfig(env), catalog);
   }
 
   const config = environments[env];
@@ -408,5 +386,5 @@ export function getEnvironmentConfig(env: Environment): EnvironmentConfig {
       `Unknown environment: ${env}. Valid values are: default, dev, stg, prd, or pr-{number}`
     );
   }
-  return resolveConfig(env, config);
+  return resolveConfig(env, config, catalog);
 }

--- a/packages/cdk/config/index.ts
+++ b/packages/cdk/config/index.ts
@@ -23,6 +23,7 @@ export { BASE_PREFIX, environments } from './environments';
 export {
   getEnvironmentConfig,
   deriveBedrockIamResources,
-  hasBedrockOpenAiModel,
-  hasMantleModel,
+  hasEndpointModel,
+  buildModelCatalog,
+  type ModelCatalog,
 } from './environment-utils';

--- a/packages/cdk/lib/constructs/agentcore/agentcore-runtime.ts
+++ b/packages/cdk/lib/constructs/agentcore/agentcore-runtime.ts
@@ -15,8 +15,7 @@ import { AgentCoreGateway } from './agentcore-gateway';
 import {
   BedrockModelConfig,
   deriveBedrockIamResources,
-  hasBedrockOpenAiModel,
-  hasMantleModel,
+  hasEndpointModel,
 } from '../../../config';
 import * as path from 'path';
 
@@ -420,7 +419,7 @@ export class AgentCoreRuntime extends Construct {
     // resource type, so it must be Resource:'*'. Foundation-model invoke itself
     // is already covered by BedrockModelInvocation above. Granted only when a
     // gpt-oss model is enabled (least-privilege).
-    if (hasBedrockOpenAiModel(props.bedrockModels)) {
+    if (hasEndpointModel(props.bedrockModels, 'bedrock-openai')) {
       this.runtime.addToRolePolicy(
         new iam.PolicyStatement({
           sid: 'BedrockBearerTokenAuth',
@@ -439,7 +438,7 @@ export class AgentCoreRuntime extends Construct {
     // AmazonBedrockMantleInferenceAccess policy. Without CreateInference the
     // runtime gets a 401 "not authorized to perform bedrock-mantle:CreateInference".
     // Granted only when a gpt-5.x (Mantle) model is enabled (least-privilege).
-    if (hasMantleModel(props.bedrockModels)) {
+    if (hasEndpointModel(props.bedrockModels, 'mantle')) {
       this.runtime.addToRolePolicy(
         new iam.PolicyStatement({
           sid: 'BedrockMantleInference',

--- a/packages/cdk/lib/constructs/api/backend-api.ts
+++ b/packages/cdk/lib/constructs/api/backend-api.ts
@@ -11,8 +11,7 @@ import { CognitoAuth } from '../auth';
 import {
   BedrockModelConfig,
   deriveBedrockIamResources,
-  hasBedrockOpenAiModel,
-  hasMantleModel,
+  hasEndpointModel,
 } from '../../../config';
 import * as path from 'path';
 
@@ -165,7 +164,7 @@ export class BackendApi extends Construct {
     // Mirrors the runtime role: these authenticate InvokeModel with a
     // locally-minted bearer token, gated by bedrock:CallWithBearerToken
     // (Read-level, no resource type → Resource:'*'). gpt-oss only.
-    if (hasBedrockOpenAiModel(props.bedrockModels)) {
+    if (hasEndpointModel(props.bedrockModels, 'bedrock-openai')) {
       lambdaExecutionRole.addToPolicy(
         new iam.PolicyStatement({
           effect: iam.Effect.ALLOW,
@@ -179,7 +178,7 @@ export class BackendApi extends Construct {
     // service (NOT bedrock:). Mirrors the runtime role and the AWS-managed
     // AmazonBedrockMantleInferenceAccess policy: CreateInference / Get* / List* on
     // the Mantle project resource + its own CallWithBearerToken. gpt-5.x only.
-    if (hasMantleModel(props.bedrockModels)) {
+    if (hasEndpointModel(props.bedrockModels, 'mantle')) {
       lambdaExecutionRole.addToPolicy(
         new iam.PolicyStatement({
           effect: iam.Effect.ALLOW,

--- a/packages/frontend/src/config/models.ts
+++ b/packages/frontend/src/config/models.ts
@@ -5,20 +5,17 @@
  * Falls back to BEDROCK_MODEL_DEFINITIONS from @moca/core (Single Source of Truth).
  */
 
-import { BEDROCK_MODEL_DEFINITIONS } from '@moca/core';
+import { BEDROCK_MODEL_DEFINITIONS, PROVIDERS, type Provider } from '@moca/core';
 
 export interface BedrockModel {
   id: string;
   name: string;
-  provider: 'Anthropic' | 'Amazon' | 'Qwen' | 'OpenAI';
+  provider: Provider;
 }
 
-const VALID_PROVIDERS: ReadonlySet<BedrockModel['provider']> = new Set([
-  'Anthropic',
-  'Amazon',
-  'Qwen',
-  'OpenAI',
-]);
+// Provider allowlist for runtime validation of the CDK-injected model list,
+// derived from @moca/core's PROVIDERS so it can never drift from the union.
+const VALID_PROVIDERS: ReadonlySet<Provider> = new Set(PROVIDERS);
 
 /**
  * Fallback model list derived from the canonical BEDROCK_MODEL_DEFINITIONS.

--- a/packages/libs/core/src/bedrock-models.ts
+++ b/packages/libs/core/src/bedrock-models.ts
@@ -2,14 +2,21 @@
  * Canonical Bedrock model definitions — Single Source of Truth.
  *
  * This file is the ONLY place to add, remove, or modify Bedrock model metadata.
- * It is imported by:
- *   - packages/frontend  (FALLBACK_MODELS)
- *   - packages/agent     (resolveMaxTokens)
+ * Every consumer derives its list from here — adding a standard (Converse-API)
+ * model to the deployment's default catalog is a single edit to this file:
+ *   - packages/frontend  — FALLBACK_MODELS projects id/name/provider.
+ *   - packages/agent     — getMaxOutputTokens / getModelRegion / getReasoningConfig
+ *                          / getBedrockEndpoint read the entry at model creation.
+ *   - packages/cdk       — bin/app.ts dynamic-imports @moca/core and threads the
+ *                          catalog (id/name/provider/region/endpoint) through
+ *                          buildModelCatalog() into the env config + IAM. No
+ *                          hand-synced copy lives in CDK anymore.
  *
- * NOTE: packages/cdk intentionally does NOT import from @moca/core to keep
- * CDK infrastructure free of runtime library dependencies. When adding a model
- * here, also update DEFAULT_CONFIG.bedrockModels in
- * packages/cdk/config/environment-utils.ts.
+ * The only cases that need edits BEYOND this file: (a) a per-environment
+ * override that hardcodes `bedrockModels` in packages/cdk/config/environments.ts
+ * (that copy is manual by design), and (b) a model on a NEW non-Converse
+ * endpoint — see {@link BedrockModelDefinition.endpoint}. See the
+ * add-bedrock-model skill for the full decision tree.
  */
 
 /**
@@ -37,13 +44,23 @@ export const REASONING_DEPTHS = ['off', 'low', 'high', 'max'] as const;
  */
 export const EFFORT_ORDER: readonly Exclude<ReasoningDepth, 'off'>[] = ['low', 'high', 'max'];
 
+/**
+ * Model providers. Single source of truth for the provider union — consumed by
+ * the frontend model selector and CDK's config validation instead of each
+ * re-declaring the literal. Adding a provider is a one-line change here.
+ */
+export const PROVIDERS = ['Anthropic', 'Amazon', 'Qwen', 'OpenAI'] as const;
+
+/** A model provider name. See {@link PROVIDERS}. */
+export type Provider = (typeof PROVIDERS)[number];
+
 export interface BedrockModelDefinition {
   /** Full model ID including cross-region inference profile prefix */
   readonly id: string;
   /** Display name shown in the UI model selector */
   readonly name: string;
   /** Provider */
-  readonly provider: 'Anthropic' | 'Amazon' | 'Qwen' | 'OpenAI';
+  readonly provider: Provider;
   /**
    * Maximum output tokens supported by this model.
    * Sources: Anthropic docs 2026-04, AWS docs.
@@ -78,10 +95,11 @@ export interface BedrockModelDefinition {
    * (global.*, us.*, …) ALSO needs an inference-profile ARN, which is
    * region-scoped. CDK's deriveBedrockIamResources() therefore scopes that ARN to
    * THIS region (not the deployment region) so the pinned-region invocation is
-   * authorized. For that to work the matching CDK config entry
-   * (DEFAULT_CONFIG.bedrockModels in packages/cdk/config/environment-utils.ts)
-   * MUST carry the same `region` value — the two lists are synced by hand because
-   * CDK does not import @moca/core.
+   * authorized. This `region` value flows into CDK automatically: bin/app.ts
+   * dynamic-imports this list and buildModelCatalog() projects `region` into the
+   * CDK config, so the IAM ARN is derived from the same value the agent invokes
+   * with — no hand-sync. (Only a per-environment `bedrockModels` override in
+   * environments.ts must carry `region` itself, since it replaces this list.)
    *
    * Omit for models available in the deployment region (the common case).
    */
@@ -128,11 +146,13 @@ export type BedrockEndpoint = 'bedrock-openai' | 'mantle';
  *
  * Ordering: preferred/newest models first (affects default selection in UI).
  *
- * When adding a model, also update:
- *   - packages/cdk/config/environment-utils.ts  DEFAULT_CONFIG.bedrockModels
- *     (mirror id/name/provider AND `region` if the model pins one — the region
- *     pin drives CDK's inference-profile IAM ARN, so an out-of-sync CDK entry
- *     causes AccessDenied at invocation time).
+ * CDK reads this list at synth time (bin/app.ts dynamic-imports it into
+ * buildModelCatalog), so id/name/provider/region/endpoint flow into the env
+ * config and IAM automatically — no hand-synced copy to update. A model's
+ * `region` pin drives CDK's inference-profile IAM ARN straight from this entry,
+ * so keep it accurate here (a wrong region → AccessDenied at invocation time).
+ * The one exception is a per-environment `bedrockModels` override hardcoded in
+ * environments.ts, which is manual by design.
  */
 export const BEDROCK_MODEL_DEFINITIONS = [
   {

--- a/packages/libs/core/src/index.ts
+++ b/packages/libs/core/src/index.ts
@@ -56,11 +56,13 @@ export { SYSTEM_USER_ID } from './system-ids.js';
 export type {
   BedrockModelDefinition,
   BedrockEndpoint,
+  Provider,
   ReasoningDepth,
   ReasoningRequestConfig,
 } from './bedrock-models.js';
 export {
   BEDROCK_MODEL_DEFINITIONS,
+  PROVIDERS,
   REASONING_DEPTHS,
   EFFORT_ORDER,
   getMaxOutputTokens,


### PR DESCRIPTION
## What

Adds a project skill documenting how to add / remove / modify a Bedrock model in Moca, and fixes stale comments that no longer match the SSoT wiring.

### New skill — `.agents/skills/add-bedrock-model/SKILL.md`
Documents the full path for a model change:
- **Decision tree** — standard Converse model vs region-pinned vs new non-Converse endpoint. Most additions are one edit to `packages/libs/core/src/bedrock-models.ts`.
- **Which files each case touches** — Case A/B/C1 are single-file; only a brand-new transport (Case C2) is multi-file (core type + agent factory + both CDK IAM roles + CDK type mirror).
- **Pitfalls** — `maxOutputTokens` hard limits that differ from the docs, reasoning `effort: max` being Opus-tier only, the adaptive-thinking request shape, data-retention prerequisites (Fable 5), bare-id vs inference-profile-prefix IAM shape, and Anthropic-only prompt caching.
- **Verification** — repo tests first (type / unit / CDK synth), then opt-in live integration with least-privilege creds.

### Comment fixes
`bedrock-models.ts` and `environment-types.ts` still claimed CDK hand-syncs a duplicate model list. That is no longer true — `bin/app.ts` dynamic-imports `@moca/core` via `buildModelCatalog()`, so `id/name/provider/region/endpoint` flow into the CDK config and IAM automatically. Only a per-environment `bedrockModels` override in `environments.ts` remains manual. Comments now reflect this.

## Notes
- Base is `feat/openai-models-bedrock` (this work sits on top of it), so the diff is just the docs commit.
- `packages/cdk/config/environments.ts` was intentionally **not** committed — it holds local-only environment settings.

## Test plan
- [x] `npm run build:ts` passes (comment-only changes to source; no behavior change).
