### PR TITLE
feat: add workspace sync status streaming to agent responses

### DIFF
--- a/packages/agent/src/handlers/__tests__/stream-handler.test.ts
+++ b/packages/agent/src/handlers/__tests__/stream-handler.test.ts
@@ -331,6 +331,114 @@ describe('streamAgentResponse', () => {
     });
   });
 
+  describe('workspace sync status', () => {
+    /**
+     * Build a fake IWorkspaceSync whose onStatusChange replays `initialStatus`
+     * synchronously (mirroring the real adapter) and exposes `push()` so a test
+     * can drive later transitions. Attach it to the mocked request context.
+     */
+    function attachWorkspaceSync(initialStatus: any) {
+      let listener: ((s: any) => void) | null = null;
+      let current = initialStatus;
+      const workspaceSync = {
+        getStatus: () => current,
+        onStatusChange: (l: (s: any) => void) => {
+          listener = l;
+          l(current); // synchronous replay, like the real implementation
+          return () => {
+            listener = null;
+          };
+        },
+        // test helper to emit a later transition
+        push: (s: any) => {
+          current = s;
+          listener?.(s);
+        },
+      };
+      mockGetCurrentContext.mockReturnValue({
+        requestId: 'test-request-id',
+        userId: 'test-user',
+        sessionId: 'test-session' as SessionId,
+        workspaceSync,
+      });
+      return workspaceSync;
+    }
+
+    const syncWrites = () =>
+      res.write.mock.calls
+        .map((c: any[]) => {
+          try {
+            return JSON.parse(c[0]);
+          } catch {
+            return null;
+          }
+        })
+        .filter((e: any) => e?.type === 'workspaceSyncEvent');
+
+    it('emits nothing when the request has no workspace sync', async () => {
+      // default context (set in beforeEach) has no workspaceSync
+      const agent = createMockAgent([{ type: 'text', data: 'Hi' }]);
+      await streamAgentResponse(agent, 'Hello', undefined, res, defaultOptions);
+      expect(syncWrites()).toHaveLength(0);
+    });
+
+    it('stays silent when the pull completes before the debounce elapses', async () => {
+      jest.useFakeTimers();
+      try {
+        attachWorkspaceSync({ phase: 'idle' });
+        const agent = createMockAgent([{ type: 'text', data: 'Hi' }]);
+        // Stream resolves immediately; complete arrives well before 400ms.
+        await streamAgentResponse(agent, 'Hello', undefined, res, defaultOptions);
+        jest.advanceTimersByTime(1000);
+        expect(syncWrites()).toHaveLength(0);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('surfaces a sync error immediately regardless of debounce timing', async () => {
+      attachWorkspaceSync({ phase: 'error', message: 'S3 down' });
+      const agent = createMockAgent([{ type: 'text', data: 'Hi' }]);
+      await streamAgentResponse(agent, 'Hello', undefined, res, defaultOptions);
+
+      const events = syncWrites();
+      expect(events).toHaveLength(1);
+      expect(events[0].status).toBe('error');
+      expect(events[0].message).toBe('S3 down');
+    });
+
+    it('announces syncing after the debounce and then completion', async () => {
+      jest.useFakeTimers();
+      try {
+        const ws = attachWorkspaceSync({
+          phase: 'syncing',
+          progress: { phase: 'download', current: 10, total: 100, percentage: 10 },
+        });
+        // Hold the stream open until we manually advance timers + resolve.
+        const agent = createMockAgent([{ type: 'text', data: 'Hi' }]);
+        const promise = streamAgentResponse(agent, 'Hello', undefined, res, defaultOptions);
+
+        // Debounce fires → the initial syncing line is emitted.
+        jest.advanceTimersByTime(400);
+        // A later progress update streams live, then completion.
+        ws.push({
+          phase: 'syncing',
+          progress: { phase: 'download', current: 60, total: 100, percentage: 60 },
+        });
+        ws.push({ phase: 'complete' });
+
+        await promise;
+
+        const events = syncWrites();
+        expect(events[0]).toMatchObject({ status: 'syncing', percentage: 10 });
+        expect(events.some((e: any) => e.status === 'syncing' && e.percentage === 60)).toBe(true);
+        expect(events[events.length - 1].status).toBe('complete');
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+  });
+
   describe('large event streaming', () => {
     it('should correctly stream all events when there are many', async () => {
       const eventCount = 200;

--- a/packages/agent/src/handlers/stream-handler.ts
+++ b/packages/agent/src/handlers/stream-handler.ts
@@ -15,6 +15,7 @@ import {
   buildInputContent,
 } from '../libs/utils/index.js';
 import { getCurrentContext, getContextMetadata } from '../libs/context/request-context.js';
+import type { WorkspaceSyncStatus } from '../types/workspace-sync-types.js';
 import type { SessionStorage, SessionConfig } from '../services/session/types.js';
 import type { AgentMetadata } from '../runtime/agent/types.js';
 import type { StreamTerminationRetryStrategy } from '../runtime/agent/stream-termination-retry-strategy.js';
@@ -47,6 +48,103 @@ function setStreamingHeaders(res: Response): void {
   res.setHeader('Cache-Control', 'no-cache');
   res.setHeader('Connection', 'keep-alive');
   res.setHeader('X-Accel-Buffering', 'no'); // Disable nginx buffering
+}
+
+/**
+ * How long the initial workspace pull must still be running before we tell the
+ * user about it. Fast pulls (small workspaces, or already cached) finish inside
+ * this window and stay silent, so the chat never flashes a "syncing" line that
+ * vanishes a frame later.
+ */
+const WORKSPACE_SYNC_NOTIFY_DELAY_MS = 400;
+
+/**
+ * Surface the request's workspace initial-pull progress as `workspaceSyncEvent`
+ * NDJSON lines, interleaved with the model stream on the same response.
+ *
+ * WHY on the model stream (not AppSync): the pull is kicked off per-invocation
+ * and blocks the first file-touching tool within *this* turn, so its lifetime is
+ * bounded by the stream the frontend is already reading. Reusing that channel
+ * avoids standing up a second delivery path for a turn-scoped signal.
+ *
+ * Emission rules:
+ * - Nothing is written until the pull has run for {@link WORKSPACE_SYNC_NOTIFY_DELAY_MS}
+ *   (debounce against flashing on fast syncs).
+ * - Once the "syncing" line is emitted, subsequent progress updates stream live
+ *   and a terminal "complete" is sent.
+ * - A pull that finishes (or was already finished) before the debounce elapses
+ *   stays completely silent.
+ * - Errors always surface regardless of timing — a silent failed sync is worse
+ *   than a brief flash, because the agent may then operate on a stale workspace.
+ *
+ * @returns a cleanup function that unsubscribes and clears the debounce timer.
+ */
+function streamWorkspaceSyncStatus(res: Response): () => void {
+  const workspaceSync = getCurrentContext()?.workspaceSync;
+  if (!workspaceSync) return () => {};
+
+  let hasEmitted = false;
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let lastStatus: WorkspaceSyncStatus = workspaceSync.getStatus();
+
+  const write = (payload: Record<string, unknown>): void => {
+    res.write(`${JSON.stringify({ type: 'workspaceSyncEvent', ...payload })}\n`);
+  };
+
+  const emitFor = (status: WorkspaceSyncStatus): void => {
+    if (status.phase === 'syncing') {
+      hasEmitted = true;
+      write({
+        status: 'syncing',
+        current: status.progress.current,
+        total: status.progress.total,
+        percentage: status.progress.percentage,
+        currentFile: status.progress.currentFile,
+      });
+    } else if (status.phase === 'complete') {
+      // Only announce completion if we announced the start; otherwise this was a
+      // fast sync the user never saw begin.
+      if (hasEmitted) write({ status: 'complete' });
+    } else if (status.phase === 'error') {
+      write({ status: 'error', message: status.message });
+    }
+  };
+
+  const unsubscribe = workspaceSync.onStatusChange((status) => {
+    lastStatus = status;
+
+    if (status.phase === 'idle') return;
+
+    if (status.phase === 'complete' || status.phase === 'error') {
+      if (debounceTimer) {
+        clearTimeout(debounceTimer);
+        debounceTimer = null;
+      }
+      emitFor(status);
+      return;
+    }
+
+    // phase === 'syncing'
+    if (hasEmitted) {
+      emitFor(status); // live progress after the initial announcement
+      return;
+    }
+    // Arm the debounce exactly once; when it fires, announce only if still syncing.
+    if (!debounceTimer) {
+      debounceTimer = setTimeout(() => {
+        debounceTimer = null;
+        if (lastStatus.phase === 'syncing') emitFor(lastStatus);
+      }, WORKSPACE_SYNC_NOTIFY_DELAY_MS);
+    }
+  });
+
+  return () => {
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+      debounceTimer = null;
+    }
+    unsubscribe();
+  };
 }
 
 /**
@@ -160,6 +258,11 @@ export async function streamAgentResponse(
   const requestId = getCurrentContext()?.requestId;
   setStreamingHeaders(res);
 
+  // Interleave workspace initial-pull progress onto this stream. Started before
+  // the model loop so a slow pull that blocks the first tool is reported while
+  // the user waits. No-op when the request has no workspace sync.
+  const stopWorkspaceSyncStatus = streamWorkspaceSyncStatus(res);
+
   try {
     logger.info({ requestId }, 'Agent streaming started:');
 
@@ -213,5 +316,9 @@ export async function streamAgentResponse(
     res.end();
   } catch (streamError) {
     await handleStreamError(streamError, res, options);
+  } finally {
+    // Detach the workspace-sync listener and clear any pending debounce timer.
+    // Runs after res.end() in both paths — cleanup only, never writes.
+    stopWorkspaceSyncStatus();
   }
 }

--- a/packages/agent/src/services/workspace-sync.ts
+++ b/packages/agent/src/services/workspace-sync.ts
@@ -10,13 +10,18 @@
 
 import path from 'path';
 import { S3WorkspaceSync } from '@moca/s3-workspace-sync';
-import type { SyncResult } from '@moca/s3-workspace-sync';
+import type { SyncResult, SyncProgress } from '@moca/s3-workspace-sync';
 import { config, WORKSPACE_DIRECTORY } from '../config/index.js';
 import { createLogger } from '../libs/logger/index.js';
 import { createUserScopedS3Client, getIdentityId } from '../libs/utils/scoped-credentials.js';
+import type {
+  WorkspaceSyncStatus,
+  WorkspaceSyncStatusListener,
+} from '../types/workspace-sync-types.js';
 
 const logger = createLogger('WorkspaceSync');
 export type { SyncResult };
+export type { WorkspaceSyncStatus, WorkspaceSyncStatusListener };
 
 /**
  * Agent-specific workspace sync wrapper.
@@ -35,6 +40,16 @@ export class WorkspaceSync {
   private readonly normalizedStoragePath: string;
 
   private initPromise: Promise<void>;
+
+  // Last known status of the initial pull. Retained (rather than only pushed
+  // through listeners) because subscribers commonly attach *after*
+  // startInitialSync() has already fired — the pull is kicked off fire-and-forget
+  // in initializeWorkspaceSync, while a subscriber (the stream handler) only
+  // attaches once the agent is built. Replaying currentStatus on subscribe means
+  // a fast pull that finished early still reports its terminal state instead of
+  // looking like it never ran.
+  private currentStatus: WorkspaceSyncStatus = { phase: 'idle' };
+  private readonly statusListeners = new Set<WorkspaceSyncStatusListener>();
 
   constructor(userId: string, storagePath: string) {
     this.bucketName = config.USER_STORAGE_BUCKET_NAME ?? '';
@@ -96,6 +111,63 @@ export class WorkspaceSync {
       s3Client,
       logger: logger,
     });
+
+    // Forward the generic sync engine's lifecycle events into our status model.
+    // Only the download phase is surfaced: the initial pull is what blocks the
+    // user (tools await waitForInitialSync), whereas push() runs fire-and-forget
+    // in a hook and must never present as user-facing "loading".
+    this.inner.on('progress', (progress: SyncProgress) => {
+      if (progress.phase === 'download') {
+        this.setStatus({ phase: 'syncing', progress });
+      }
+    });
+    this.inner.on('complete', () => {
+      this.setStatus({ phase: 'complete' });
+    });
+    this.inner.on('syncError', (err: unknown) => {
+      this.setStatus({
+        phase: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      });
+    });
+  }
+
+  /**
+   * Update the retained status and notify all current listeners.
+   * Listener exceptions are swallowed so one bad subscriber can't break sync.
+   */
+  private setStatus(status: WorkspaceSyncStatus): void {
+    this.currentStatus = status;
+    for (const listener of this.statusListeners) {
+      try {
+        listener(status);
+      } catch (err) {
+        logger.warn(`Workspace sync status listener threw: ${String(err)}`);
+      }
+    }
+  }
+
+  /**
+   * Subscribe to initial-pull status changes.
+   *
+   * The current status is replayed synchronously on subscribe so late
+   * subscribers (the common case — see {@link currentStatus}) observe a pull
+   * that is already running or finished. Returns an unsubscribe function.
+   */
+  onStatusChange(listener: WorkspaceSyncStatusListener): () => void {
+    this.statusListeners.add(listener);
+    // Replay current state immediately.
+    listener(this.currentStatus);
+    return () => {
+      this.statusListeners.delete(listener);
+    };
+  }
+
+  /**
+   * The last observed status of the initial pull.
+   */
+  getStatus(): WorkspaceSyncStatus {
+    return this.currentStatus;
   }
 
   /**
@@ -104,6 +176,15 @@ export class WorkspaceSync {
    */
   startInitialSync(): void {
     this.initPromise.then(() => {
+      // Optimistically mark syncing at kickoff. The inner engine only emits its
+      // first `progress` event after >100 files complete, so a medium-sized but
+      // slow pull would otherwise show nothing until `complete`. A total of 0
+      // signals "counting" to consumers; real counts follow via `progress`.
+      // Fast pulls are prevented from flashing this by the stream-side debounce.
+      this.setStatus({
+        phase: 'syncing',
+        progress: { phase: 'download', current: 0, total: 0, percentage: 0 },
+      });
       this.inner.startBackgroundPull();
     });
   }

--- a/packages/agent/src/types/workspace-sync-types.ts
+++ b/packages/agent/src/types/workspace-sync-types.ts
@@ -7,9 +7,21 @@
  * this interface.
  */
 
-import type { SyncResult } from '@moca/s3-workspace-sync';
+import type { SyncResult, SyncProgress } from '@moca/s3-workspace-sync';
 
 export type { SyncResult };
+
+/**
+ * Snapshot of the initial-pull lifecycle, surfaced to subscribers (e.g. the
+ * stream handler) so they can report sync progress to the UI.
+ */
+export type WorkspaceSyncStatus =
+  | { phase: 'idle' }
+  | { phase: 'syncing'; progress: SyncProgress }
+  | { phase: 'complete' }
+  | { phase: 'error'; message: string };
+
+export type WorkspaceSyncStatusListener = (status: WorkspaceSyncStatus) => void;
 
 export interface IWorkspaceSync {
   startInitialSync(): void;
@@ -17,4 +29,9 @@ export interface IWorkspaceSync {
   syncToS3(): Promise<SyncResult>;
   getWorkspacePath(): string;
   getActiveWorkingDirectory(): string;
+  /** Subscribe to initial-pull status; replays current status synchronously.
+   * Returns an unsubscribe function. */
+  onStatusChange(listener: WorkspaceSyncStatusListener): () => void;
+  /** The last observed status of the initial pull. */
+  getStatus(): WorkspaceSyncStatus;
 }

--- a/packages/frontend/src/api/agent.ts
+++ b/packages/frontend/src/api/agent.ts
@@ -9,6 +9,7 @@ import type {
   BeforeToolsEvent,
   ToolUse,
   ToolResult,
+  WorkspaceSyncEvent,
 } from '../types/index';
 import { agentClient } from './client/agent-client';
 import { logger } from '../utils/logger';
@@ -24,6 +25,7 @@ interface StreamingCallbacks {
   onToolUse?: (toolUse: ToolUse) => void;
   onToolInputUpdate?: (toolUseId: string, input: Record<string, unknown>) => void;
   onToolResult?: (toolResult: ToolResult) => void;
+  onWorkspaceSync?: (event: WorkspaceSyncEvent) => void;
   onComplete?: (metadata: Record<string, unknown>) => void;
   onError?: (error: Error) => void;
 }
@@ -289,6 +291,14 @@ const handleStreamEvent = (event: AgentStreamEvent, callbacks: StreamingCallback
             }
           });
         }
+      }
+      break;
+    }
+
+    case 'workspaceSyncEvent': {
+      const syncEvent = event as WorkspaceSyncEvent;
+      if (callbacks.onWorkspaceSync) {
+        callbacks.onWorkspaceSync(syncEvent);
       }
       break;
     }

--- a/packages/frontend/src/components/MessageInput.tsx
+++ b/packages/frontend/src/components/MessageInput.tsx
@@ -9,6 +9,7 @@ import { useUIStore } from '../stores/uiStore';
 import { useStorageStore } from '../stores/storageStore';
 import * as storageApi from '../api/storage';
 import { StoragePathDisplay } from './StoragePathDisplay';
+import { WorkspaceSyncIndicator } from './WorkspaceSyncIndicator';
 import { StorageManagementModal } from './StorageManagementModal';
 import { ModelReasoningSelector } from './ui/ModelReasoningSelector';
 import { ImagePreview } from './ImagePreview';
@@ -34,6 +35,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
     sessionId ? (state.sessions[sessionId] ?? null) : null
   );
   const isLoading = sessionState?.isLoading || false;
+  const workspaceSync = sessionState?.workspaceSync || null;
   const isAgentStoreLoading = useAgentStore((state) => state.isLoading);
   const isWideView = useUIStore((state) => state.isWideView);
   const agentWorkingDirectory = useStorageStore((state) => state.agentWorkingDirectory);
@@ -449,11 +451,12 @@ export const MessageInput: React.FC<MessageInputProps> = ({
       className="sticky bottom-0 left-0 right-0 z-30 bg-surface-primary p-4"
       style={{ paddingBottom: 'max(1rem, env(safe-area-inset-bottom))' }}
     >
-      {/* Storage path display */}
+      {/* Storage path display + workspace sync status (to the right of the folder) */}
       <div
-        className={`${isWideView ? 'max-w-full px-4' : 'max-w-4xl'} mx-auto mb-2 transition-[max-width,padding] duration-300 ease-in-out`}
+        className={`${isWideView ? 'max-w-full px-4' : 'max-w-4xl'} mx-auto mb-2 flex items-center gap-2 transition-[max-width,padding] duration-300 ease-in-out`}
       >
         <StoragePathDisplay onClick={() => setIsStorageModalOpen(true)} />
+        {workspaceSync && <WorkspaceSyncIndicator state={workspaceSync} />}
       </div>
 
       <form

--- a/packages/frontend/src/components/WorkspaceSyncIndicator.tsx
+++ b/packages/frontend/src/components/WorkspaceSyncIndicator.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import type { WorkspaceSyncState } from '../types/index';
+
+interface WorkspaceSyncIndicatorProps {
+  state: WorkspaceSyncState;
+}
+
+/**
+ * Ephemeral status line shown next to the storage-path folder above the chat
+ * input while the agent's workspace performs its initial S3→local pull. Only
+ * rendered when the pull is slow enough for the backend to have announced it
+ * (see the agent stream-handler debounce), so this component never needs its
+ * own flash-prevention logic.
+ *
+ * Text only — no icon or animation. Renders three states: syncing (with
+ * optional count/percent), complete (briefly, then auto-dismissed by the
+ * store), and error. Designed to sit inline in a flex row, so it carries no
+ * vertical padding of its own.
+ */
+export const WorkspaceSyncIndicator: React.FC<WorkspaceSyncIndicatorProps> = ({ state }) => {
+  const { t } = useTranslation();
+
+  if (state.status === 'error') {
+    return (
+      <span className="text-sm text-feedback-error">
+        {t('workspaceSync.error', { message: state.message ?? '' })}
+      </span>
+    );
+  }
+
+  if (state.status === 'complete') {
+    return <span className="text-sm text-fg-muted">{t('workspaceSync.complete')}</span>;
+  }
+
+  // status === 'syncing'
+  // A total of 0 means the backend has started the pull but hasn't counted files
+  // yet — show a generic "preparing" message rather than "0/0".
+  const hasCount = (state.total ?? 0) > 0;
+  const label = hasCount
+    ? t('workspaceSync.syncingProgress', {
+        current: state.current ?? 0,
+        total: state.total ?? 0,
+        percentage: state.percentage ?? 0,
+      })
+    : t('workspaceSync.preparing');
+
+  return <span className="text-sm text-fg-muted">{label}</span>;
+};

--- a/packages/frontend/src/locales/en.yaml
+++ b/packages/frontend/src/locales/en.yaml
@@ -233,6 +233,13 @@ chat:
   bulkDeleteConfirm: 'Are you sure you want to delete {{count}} selected sessions? This action cannot be undone.'
   sessionsDeleted: '{{count}} sessions deleted'
 
+# Workspace sync (ephemeral status line shown while the agent's initial S3 pull runs)
+workspaceSync:
+  preparing: Preparing workspace…
+  syncingProgress: 'Syncing workspace… {{current}}/{{total}} files ({{percentage}}%)'
+  complete: Workspace ready
+  error: 'Workspace sync failed: {{message}}'
+
 # Agent
 agent:
   systemPromptLabel2: System Prompt

--- a/packages/frontend/src/locales/ja.yaml
+++ b/packages/frontend/src/locales/ja.yaml
@@ -232,6 +232,13 @@ chat:
   bulkDeleteConfirm: '選択した{{count}}件のセッションを削除してもよろしいですか？この操作は取り消せません。'
   sessionsDeleted: '{{count}}件のセッションを削除しました'
 
+# ワークスペース同期（初回のS3プル中に表示される一時的なステータス行）
+workspaceSync:
+  preparing: ワークスペースを準備しています…
+  syncingProgress: 'ワークスペースを同期しています… {{current}}/{{total}} ファイル ({{percentage}}%)'
+  complete: ワークスペースの準備が完了しました
+  error: 'ワークスペースの同期に失敗しました: {{message}}'
+
 # エージェント
 agent:
   systemPromptLabel2: System Prompt

--- a/packages/frontend/src/stores/chatStore.ts
+++ b/packages/frontend/src/stores/chatStore.ts
@@ -241,6 +241,8 @@ export const useChatStore = create<ChatStore>()(
               ...sessionState,
               isLoading: true,
               error: null,
+              // Clear any stale sync line from a prior turn before this one starts.
+              workspaceSync: undefined,
             },
           },
         });
@@ -444,6 +446,55 @@ export const useChatStore = create<ChatStore>()(
                   });
                 }
               },
+              onWorkspaceSync: (event) => {
+                // Ephemeral: surface the initial-pull status as a system line for
+                // this session. Ignore if the user has switched away. The line is
+                // cleared shortly after `complete` and on turn completion/error so
+                // it never lingers into the next turn.
+                const { activeSessionId, sessions } = get();
+                if (activeSessionId !== sessionId) return;
+                const sessionState = sessions[sessionId];
+                if (!sessionState) return;
+
+                const workspaceSync =
+                  event.status === 'syncing'
+                    ? {
+                        status: 'syncing' as const,
+                        current: event.current,
+                        total: event.total,
+                        percentage: event.percentage,
+                        currentFile: event.currentFile,
+                      }
+                    : event.status === 'error'
+                      ? { status: 'error' as const, message: event.message }
+                      : { status: 'complete' as const };
+
+                set({
+                  sessions: {
+                    ...sessions,
+                    [sessionId]: { ...sessionState, workspaceSync },
+                  },
+                });
+
+                // Auto-dismiss the "complete" line after a short beat so the user
+                // sees sync finished without it sticking around.
+                if (event.status === 'complete') {
+                  setTimeout(() => {
+                    const { sessions } = get();
+                    const current = sessions[sessionId];
+                    // Only clear if still showing the same "complete" line — a new
+                    // turn may have replaced it in the meantime.
+                    if (current?.workspaceSync?.status === 'complete') {
+                      set({
+                        sessions: {
+                          ...sessions,
+                          [sessionId]: { ...current, workspaceSync: undefined },
+                        },
+                      });
+                    }
+                  }, 1500);
+                }
+              },
               onToolResult: (toolResult: ToolResult) => {
                 const { activeSessionId, sessions } = get();
                 if (activeSessionId !== sessionId) return;
@@ -491,6 +542,8 @@ export const useChatStore = create<ChatStore>()(
                     [sessionId]: {
                       ...currentState,
                       isLoading: false,
+                      // Drop any lingering sync line — the turn is over.
+                      workspaceSync: undefined,
                     },
                   },
                   // WHY: Record completion time for the grace-period dedup guard.

--- a/packages/frontend/src/types/index.ts
+++ b/packages/frontend/src/types/index.ts
@@ -77,12 +77,27 @@ export interface Message {
   isError?: boolean; // Flag to indicate this message contains an error
 }
 
+// Transient workspace-sync status for a session, surfaced as an ephemeral
+// system line in the chat while the agent's initial S3→local pull runs. Not
+// persisted — it only exists for the duration of an in-flight turn.
+export interface WorkspaceSyncState {
+  status: 'syncing' | 'complete' | 'error';
+  current?: number;
+  total?: number;
+  percentage?: number;
+  currentFile?: string;
+  message?: string; // populated on error
+}
+
 // Session-specific chat state
 export interface SessionChatState {
   messages: Message[];
   isLoading: boolean;
   error: string | null;
   lastUpdated: Date;
+  /** Present only while (or briefly after) a workspace initial sync is
+   * reported for this session. Undefined otherwise. */
+  workspaceSync?: WorkspaceSyncState;
 }
 
 // Chat types
@@ -211,6 +226,20 @@ export interface ServerErrorEvent extends AgentStreamEvent {
     requestId: string;
     savedToHistory?: boolean; // Indicates if error was saved to session history
   };
+}
+
+// Workspace initial-pull progress, interleaved on the model stream. Only emitted
+// when the pull is slow enough to be worth surfacing (see the agent's
+// stream-handler debounce). `syncing` may repeat with updated counts; `complete`
+// and `error` are terminal.
+export interface WorkspaceSyncEvent extends AgentStreamEvent {
+  type: 'workspaceSyncEvent';
+  status: 'syncing' | 'complete' | 'error';
+  current?: number;
+  total?: number;
+  percentage?: number;
+  currentFile?: string;
+  message?: string;
 }
 
 // Config types

--- a/packages/libs/s3-workspace-sync/src/s3-workspace-sync.ts
+++ b/packages/libs/s3-workspace-sync/src/s3-workspace-sync.ts
@@ -410,15 +410,25 @@ export class S3WorkspaceSync extends EventEmitter {
     this.logger.debug('Starting background pull...');
 
     this.pullPromise = this.pull()
-      .then(() => {
+      .then((result) => {
         this.pullComplete = true;
         // No log here: `Pull complete: N downloaded ...` is emitted by
         // the pull() call above, which is the single source of truth for
         // completion. A separate "Background pull completed" was redundant.
+        //
+        // Emit a terminal `'complete'` event so subscribers (e.g. the agent's
+        // WorkspaceSync adapter surfacing sync status to the UI) get a reliable
+        // completion signal with the SyncResult. `waitForPull()` cannot carry
+        // this because it deliberately resolves (never rejects) even on failure.
+        this.emit('complete', result);
       })
       .catch((err) => {
         this.logger.error('Background pull failed:', err);
         this.pullComplete = true; // Mark complete even on failure so waiters unblock
+        // Named `'syncError'` rather than `'error'`: Node's EventEmitter throws
+        // synchronously when an `'error'` event is emitted with no listener, which
+        // would turn a best-effort background sync into an unhandled crash.
+        this.emit('syncError', err);
       });
   }
 

--- a/packages/libs/s3-workspace-sync/test/s3-workspace-sync.test.ts
+++ b/packages/libs/s3-workspace-sync/test/s3-workspace-sync.test.ts
@@ -389,6 +389,57 @@ describe('S3WorkspaceSync', () => {
       // Calling waitForPull after a completed pull should resolve immediately
       await sync.waitForPull();
     });
+
+    it("emits a 'complete' event with the SyncResult when the pull succeeds", async () => {
+      const mockClient = createMockS3Client([{ Key: 'prefix/file.txt', Body: 'content' }]);
+
+      const sync = new S3WorkspaceSync({
+        bucket: 'my-bucket',
+        prefix: 'prefix/',
+        workspaceDir: tmpDir,
+        s3Client: mockClient as unknown as import('@aws-sdk/client-s3').S3Client,
+        logger: createSilentLogger(),
+      });
+
+      const completeSpy = vi.fn();
+      sync.on('complete', completeSpy);
+
+      sync.startBackgroundPull();
+      await sync.waitForPull();
+
+      expect(completeSpy).toHaveBeenCalledTimes(1);
+      expect(completeSpy.mock.calls[0][0]).toMatchObject({ success: true, downloadedFiles: 1 });
+    });
+
+    it("emits 'syncError' (not 'error') when the background pull fails", async () => {
+      // A send() that always throws makes the ListObjectsV2 call reject, so
+      // pull() throws and startBackgroundPull's catch path runs.
+      const failingClient = {
+        send: vi.fn(async () => {
+          throw new Error('S3 unavailable');
+        }),
+      };
+
+      const sync = new S3WorkspaceSync({
+        bucket: 'my-bucket',
+        prefix: 'prefix/',
+        workspaceDir: tmpDir,
+        s3Client: failingClient as unknown as import('@aws-sdk/client-s3').S3Client,
+        logger: createSilentLogger(),
+      });
+
+      const errorSpy = vi.fn();
+      sync.on('syncError', errorSpy);
+
+      // Must not throw synchronously and must not crash on a missing 'error'
+      // listener (Node's EventEmitter would otherwise rethrow).
+      sync.startBackgroundPull();
+      await sync.waitForPull();
+
+      expect(sync.isPullComplete()).toBe(true);
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy.mock.calls[0][0]).toBeInstanceOf(Error);
+    });
   });
 
   describe('progress events', () => {


### PR DESCRIPTION
Introduce workspace sync status tracking that surfaces initial-pull progress to the frontend via workspaceSyncEvent stream messages.

- Add onStatusChange/getStatus to IWorkspaceSync interface with synchronous status replay and unsubscribe support
- Emit sync events from the stream handler with debounce logic to avoid flicker on fast syncs, while surfacing errors immediately
- Add WorkspaceSyncEvent type and frontend handling in agent API
- Cover sync status behavior with stream-handler tests

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
