### PR TITLE
feat: stop/interrupt running agent turns

### DIFF
--- a/packages/agent/src/app.ts
+++ b/packages/agent/src/app.ts
@@ -29,6 +29,7 @@ import cors from 'cors';
 import {
   corsOptions,
   requestContextMiddleware,
+  stopDispatchMiddleware,
   asyncHandler,
   validateInvocationMiddleware,
   authResolverMiddleware,
@@ -58,6 +59,7 @@ export function createApp(): Express {
   //
   //   trackInFlight      → mark container busy so /ping reports HealthyBusy
   //   requestContext     → AsyncLocalStorage ctx + JWT parse + session headers
+  //   stopDispatch       → { action: 'stop' } → cancel in-flight turn + ack (short-circuit)
   //   validateInvocation → prompt / images → 400 on failure
   //   authResolver       → resolves branded UserId, enriches ctx.userId
   //   identityResolver   → exchanges UserId → IdentityId, caches on ctx
@@ -65,11 +67,17 @@ export function createApp(): Express {
   //
   // `trackInFlight` runs first so the busy window covers the WHOLE request —
   // including auth/validation and any error response — and is released on the
-  // response's 'finish'/'close', which also catches a client abort mid-stream.
+  // response's 'finish'/'close'.
+  //
+  // `stopDispatch` runs after requestContext (it needs the authenticated
+  // sessionId) but before validateInvocation (a stop carries no prompt, so it
+  // must not be 400'd for that). It handles the out-of-band cancel command that
+  // AgentCore's session-sticky routing delivers to this same microVM.
   app.post(
     '/invocations',
     trackInFlightMiddleware,
     requestContextMiddleware,
+    stopDispatchMiddleware,
     validateInvocationMiddleware,
     authResolverMiddleware,
     identityResolverMiddleware,

--- a/packages/agent/src/handlers/__tests__/cancellation.e2e.test.ts
+++ b/packages/agent/src/handlers/__tests__/cancellation.e2e.test.ts
@@ -1,0 +1,123 @@
+/**
+ * End-to-end cancellation test — real Strands Agent, no AWS.
+ *
+ * The unit tests for stream-handler mock the agent. This test exercises the
+ * ACTUAL SDK cancellation contract our design relies on, driving a real
+ * `Agent` with a slow in-process `Model` and cancelling via the same external
+ * `cancelSignal` the handler wires up. It proves, end to end:
+ *
+ *   1. an external AbortSignal fired mid-stream makes `agent.stream(...)` return
+ *      an AgentResult with `stopReason: 'cancelled'` (not throw);
+ *   2. after cancellation `agent.messages` is left in a reinvokable state — no
+ *      dangling toolUse without a matching toolResult — so history stays
+ *      consistent (the invariant our handler leans on instead of hand-repairing);
+ *   3. the agent can be reinvoked cleanly after a cancel.
+ *
+ * If a future SDK bump changes any of these, this test fails loudly — which is
+ * exactly the signal we want, since the whole feature is built on them.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import { Agent, Model } from '@strands-agents/sdk';
+import type { Message } from '@strands-agents/sdk';
+
+/**
+ * A model that streams a few text deltas with a delay between each, giving the
+ * test a window to abort mid-generation. Honours the AbortSignal the SDK passes
+ * through `options.abortSignal` so cancellation is prompt.
+ */
+class SlowTextModel extends Model {
+  private config = { modelId: 'slow-test-model' };
+
+  updateConfig(modelConfig: { modelId: string }): void {
+    this.config = { ...this.config, ...modelConfig };
+  }
+
+  getConfig(): { modelId: string } {
+    return this.config;
+  }
+
+  async *stream(_messages: Message[], options?: { abortSignal?: AbortSignal }): AsyncIterable<any> {
+    yield { type: 'modelMessageStartEvent', role: 'assistant' };
+    yield { type: 'modelContentBlockStartEvent' };
+    for (let i = 0; i < 20; i++) {
+      if (options?.abortSignal?.aborted) break;
+      yield { type: 'modelContentBlockDeltaEvent', delta: { type: 'textDelta', text: `tok${i} ` } };
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    yield { type: 'modelContentBlockStopEvent' };
+    yield { type: 'modelMessageStopEvent', stopReason: 'endTurn' };
+  }
+}
+
+/** Assert there is no toolUse block left without a matching toolResult. */
+function hasDanglingToolUse(messages: Message[]): boolean {
+  const toolUseIds = new Set<string>();
+  const toolResultIds = new Set<string>();
+  for (const m of messages) {
+    for (const block of m.content as any[]) {
+      if (block?.type === 'toolUseBlock' && block.toolUseId) toolUseIds.add(block.toolUseId);
+      if (block?.type === 'toolResultBlock' && block.toolUseId) toolResultIds.add(block.toolUseId);
+    }
+  }
+  return [...toolUseIds].some((id) => !toolResultIds.has(id));
+}
+
+describe('agent cancellation (real SDK, no AWS)', () => {
+  it('returns stopReason "cancelled" when the external cancelSignal fires mid-stream', async () => {
+    const agent = new Agent({ model: new SlowTextModel() });
+    const controller = new AbortController();
+
+    const stream = agent.stream('Write a long essay', { cancelSignal: controller.signal });
+
+    // Consume a couple of events, then abort — same shape as the handler's
+    // res 'close' → controller.abort() path.
+    let eventCount = 0;
+    let result: any;
+    const pump = (async () => {
+      let next = await stream.next();
+      while (!next.done) {
+        eventCount++;
+        if (eventCount === 2) controller.abort();
+        next = await stream.next();
+      }
+      result = next.value;
+    })();
+    await pump;
+
+    expect(result?.stopReason).toBe('cancelled');
+  });
+
+  it('leaves messages reinvokable (no dangling toolUse) after cancellation', async () => {
+    const agent = new Agent({ model: new SlowTextModel() });
+    const controller = new AbortController();
+
+    const stream = agent.stream('Do something', { cancelSignal: controller.signal });
+    let next = await stream.next();
+    let count = 0;
+    while (!next.done) {
+      if (++count === 2) controller.abort();
+      next = await stream.next();
+    }
+
+    expect(hasDanglingToolUse(agent.messages)).toBe(false);
+  });
+
+  it('can be reinvoked after a cancellation and complete normally', async () => {
+    const agent = new Agent({ model: new SlowTextModel() });
+    const controller = new AbortController();
+
+    // First turn: cancel it.
+    const stream = agent.stream('First', { cancelSignal: controller.signal });
+    let next = await stream.next();
+    let count = 0;
+    while (!next.done) {
+      if (++count === 2) controller.abort();
+      next = await stream.next();
+    }
+
+    // Second turn: fresh signal, run to completion.
+    const result = await agent.invoke('Second');
+    expect(result.stopReason).toBe('endTurn');
+  });
+});

--- a/packages/agent/src/handlers/__tests__/stream-handler.test.ts
+++ b/packages/agent/src/handlers/__tests__/stream-handler.test.ts
@@ -46,29 +46,64 @@ jest.unstable_mockModule('../../libs/context/request-context.js', () => ({
 
 const { streamAgentResponse } = await import('../stream-handler.js');
 import type { StreamOptions } from '../stream-handler.js';
+// The cancel registry is a dependency-free module singleton; use the real one
+// so we can assert this turn's Agent gets registered / unregistered.
+const { isRegistered, cancelAgent, resetRegistry } = await import(
+  '../../libs/health/agent-cancel-registry.js'
+);
 import type { IdentityId, SessionId } from '@moca/core';
 
-/** Create a mock Express Response */
+/**
+ * Create a mock Express Response.
+ *
+ * Supports `once`/`on`/`emit` so tests can simulate a client disconnect
+ * (`res.emit('close')`). `end()` flips `writableEnded` to mirror Express, so
+ * the handler's "close after finish is benign" guard can be exercised.
+ */
 function createMockResponse() {
+  const listeners: Record<string, () => void> = {};
   const res: any = {
     setHeader: jest.fn(),
     write: jest.fn(),
-    end: jest.fn(),
+    writableEnded: false,
+    end: jest.fn(() => {
+      res.writableEnded = true;
+    }),
+    once: jest.fn((event: string, cb: () => void) => {
+      listeners[event] = cb;
+      return res;
+    }),
+    on: jest.fn((event: string, cb: () => void) => {
+      listeners[event] = cb;
+      return res;
+    }),
+    emit: (event: string) => listeners[event]?.(),
   };
   return res;
 }
 
-/** Create a mock Agent with configurable stream behavior */
-function createMockAgent(events: unknown[] = [{ type: 'text', data: 'Hello' }]) {
+/**
+ * Create a mock Agent with configurable stream behavior.
+ *
+ * `agent.stream()` returns a real async generator whose *return value* is the
+ * `AgentResult` (carrying `stopReason`) — matching the SDK contract that the
+ * handler reads to distinguish a cancelled turn from a completed one.
+ */
+function createMockAgent(
+  events: unknown[] = [{ type: 'text', data: 'Hello' }],
+  result: { stopReason?: string } = { stopReason: 'endTurn' }
+) {
   return {
     messages: [{ role: 'user' }, { role: 'assistant' }],
-    stream: jest.fn().mockReturnValue({
-      async *[Symbol.asyncIterator]() {
+    cancel: jest.fn(),
+    stream: jest.fn().mockImplementation(() =>
+      (async function* () {
         for (const event of events) {
           yield event;
         }
-      },
-    }),
+        return result;
+      })()
+    ),
   } as any;
 }
 
@@ -91,6 +126,7 @@ describe('streamAgentResponse', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    resetRegistry();
     res = createMockResponse();
     defaultOptions = {
       metadata: {
@@ -328,6 +364,140 @@ describe('streamAgentResponse', () => {
       const errorEvent = JSON.parse(errorWrite![0]);
       expect(errorEvent.error.message).not.toContain('partial content');
       expect(errorEvent.error.message).not.toContain('embedded quotes');
+    });
+  });
+
+  describe('cancellation', () => {
+    it('registers the agent in the cancel registry while a turn is in flight', async () => {
+      // A stream that parks mid-turn, so we can observe the registration before
+      // the turn settles.
+      let releaseGate: () => void = () => {};
+      const gate = new Promise<void>((resolve) => {
+        releaseGate = resolve;
+      });
+      const agent = {
+        messages: [],
+        cancel: jest.fn(),
+        stream: jest.fn().mockImplementation(() =>
+          (async function* () {
+            yield { type: 'text', data: 'partial' };
+            await gate;
+            return { stopReason: 'endTurn' };
+          })()
+        ),
+      } as any;
+
+      const promise = streamAgentResponse(agent, 'Hello', undefined, res, defaultOptions);
+      await Promise.resolve();
+
+      // The registry now holds this turn's agent, so a stop command targeting
+      // 'test-session' can reach it.
+      expect(isRegistered('test-session')).toBe(true);
+
+      releaseGate();
+      await promise;
+    });
+
+    it('a registry cancel drives the turn to stopReason cancelled', async () => {
+      // Real cancellation path: agent.cancel() (invoked via the registry by the
+      // stop command) makes the parked stream resolve as cancelled.
+      let aborted = false;
+      const agent = {
+        messages: [],
+        cancel: jest.fn(() => {
+          aborted = true;
+        }),
+        stream: jest.fn().mockImplementation(() =>
+          (async function* () {
+            yield { type: 'text', data: 'partial' };
+            // Poll the cancel flag the way the SDK checks its internal signal.
+            while (!aborted) await new Promise((r) => setTimeout(r, 5));
+            return { stopReason: 'cancelled' };
+          })()
+        ),
+      } as any;
+
+      const promise = streamAgentResponse(agent, 'Hello', undefined, res, defaultOptions);
+      await Promise.resolve();
+
+      // Simulate the stop command landing on this microVM.
+      expect(cancelAgent('test-session')).toBe(true);
+      expect(agent.cancel).toHaveBeenCalledTimes(1);
+
+      await promise;
+
+      const writes = res.write.mock.calls.map((c: any[]) => JSON.parse(c[0].trim()));
+      expect(writes.map((w: any) => w.type)).toContain('serverCancelledEvent');
+    });
+
+    it('unregisters the agent after the turn settles', async () => {
+      const agent = createMockAgent([]);
+
+      await streamAgentResponse(agent, 'Hello', undefined, res, defaultOptions);
+
+      expect(isRegistered('test-session')).toBe(false);
+    });
+
+    it('should emit serverCancelledEvent (not completion) when stopReason is cancelled', async () => {
+      const agent = createMockAgent([{ type: 'text', data: 'partial' }], {
+        stopReason: 'cancelled',
+      });
+
+      await streamAgentResponse(agent, 'Hello', undefined, res, defaultOptions);
+
+      const writes = res.write.mock.calls.map((c: any[]) => JSON.parse(c[0].trim()));
+      const types = writes.map((w: any) => w.type);
+      expect(types).toContain('serverCancelledEvent');
+      expect(types).not.toContain('serverCompletionEvent');
+    });
+
+    it('should not treat a cancelled turn as an error', async () => {
+      const mockAppendMessage = jest.fn<any>().mockResolvedValue(undefined);
+      const options: StreamOptions = {
+        ...defaultOptions,
+        sessionStorage: { appendMessage: mockAppendMessage } as any,
+        sessionConfig: {
+          sessionId: 'test-session' as SessionId,
+          actorId: 'test-actor' as IdentityId,
+        },
+      };
+      const agent = createMockAgent([{ type: 'text', data: 'partial' }], {
+        stopReason: 'cancelled',
+      });
+
+      await streamAgentResponse(agent, 'Hello', undefined, res, options);
+
+      const writes = res.write.mock.calls.map((c: any[]) => JSON.parse(c[0].trim()));
+      expect(writes.map((w: any) => w.type)).not.toContain('serverErrorEvent');
+      // Cancellation history integrity is the SDK's responsibility (it appends a
+      // synthetic assistant/tool-result), so the handler must NOT write its own
+      // error message into session history.
+      expect(mockAppendMessage).not.toHaveBeenCalled();
+    });
+
+    it('should end the response after a cancelled turn', async () => {
+      const agent = createMockAgent([{ type: 'text', data: 'partial' }], {
+        stopReason: 'cancelled',
+      });
+
+      await streamAgentResponse(agent, 'Hello', undefined, res, defaultOptions);
+
+      expect(res.end).toHaveBeenCalledTimes(1);
+    });
+
+    it('should still stream events that arrived before cancellation', async () => {
+      const agent = createMockAgent(
+        [
+          { type: 'text', data: 'chunk-1' },
+          { type: 'text', data: 'chunk-2' },
+        ],
+        { stopReason: 'cancelled' }
+      );
+
+      await streamAgentResponse(agent, 'Hello', undefined, res, defaultOptions);
+
+      const writes = res.write.mock.calls.map((c: any[]) => JSON.parse(c[0].trim()));
+      expect(writes.filter((w: any) => w.type === 'text')).toHaveLength(2);
     });
   });
 

--- a/packages/agent/src/handlers/invocations.ts
+++ b/packages/agent/src/handlers/invocations.ts
@@ -43,6 +43,7 @@ import { createSessionPersistenceDeps } from '../services/session-persistence-de
 import { logger } from '../libs/logger/index.js';
 import { streamAgentResponse } from './stream-handler.js';
 import { stopOwnSession } from '../services/session-terminator.js';
+import { subAgentTaskManager } from '../services/sub-agent-task-manager.js';
 
 /**
  * Agent invocation endpoint (with streaming support).
@@ -130,12 +131,23 @@ export async function handleInvocation(req: Request, res: Response): Promise<voi
     'Agent creation completed:'
   );
 
-  await streamAgentResponse(agent, body.prompt, body.images, res, {
+  const streamResult = await streamAgentResponse(agent, body.prompt, body.images, res, {
     metadata,
     retryStrategy,
     sessionStorage: sessionResult?.storage,
     sessionConfig: sessionResult?.config,
   });
+
+  // When the main turn was cancelled (client disconnect / stop), also stop any
+  // sub-agent tasks it spawned. They run detached via agent.invoke and are keyed
+  // by parentSessionId (this turn's sessionId), so they'd otherwise keep the
+  // microVM busy after the user stopped the parent.
+  if (streamResult.cancelled && sessionId) {
+    const cancelledCount = subAgentTaskManager.cancelTasksByParentSession(sessionId);
+    if (cancelledCount > 0) {
+      logger.info({ requestId, sessionId, cancelledCount }, 'Cancelled sub-agent tasks:');
+    }
+  }
 
   // Event-driven (trigger) invocations are fire-and-forget: nothing on the
   // client side will tell the Runtime the session is done, so the microVM

--- a/packages/agent/src/handlers/stream-handler.ts
+++ b/packages/agent/src/handlers/stream-handler.ts
@@ -15,6 +15,7 @@ import {
   buildInputContent,
 } from '../libs/utils/index.js';
 import { getCurrentContext, getContextMetadata } from '../libs/context/request-context.js';
+import { registerAgent, unregisterAgent } from '../libs/health/agent-cancel-registry.js';
 import type { SessionStorage, SessionConfig } from '../services/session/types.js';
 import type { AgentMetadata } from '../runtime/agent/types.js';
 import type { StreamTerminationRetryStrategy } from '../runtime/agent/stream-termination-retry-strategy.js';
@@ -51,12 +52,22 @@ function setStreamingHeaders(res: Response): void {
 
 /**
  * Send a completion event with metadata.
+ *
+ * `type` is `serverCancelledEvent` when the turn was interrupted (client
+ * disconnect / `agent.cancel()`), else `serverCompletionEvent`. Both carry the
+ * same metadata shape so the frontend can settle the streaming message
+ * identically; only the discriminator differs.
  */
-function sendCompletionEvent(res: Response, agent: Agent, options: StreamOptions): void {
+function sendCompletionEvent(
+  res: Response,
+  agent: Agent,
+  options: StreamOptions,
+  cancelled = false
+): void {
   const context = getCurrentContext();
   const contextMeta = getContextMetadata();
   const completionEvent = {
-    type: 'serverCompletionEvent',
+    type: cancelled ? 'serverCancelledEvent' : 'serverCompletionEvent',
     metadata: {
       requestId: context?.requestId,
       duration: contextMeta.duration,
@@ -141,6 +152,12 @@ async function handleStreamError(
   res.end();
 }
 
+/** Outcome of a streamed turn, returned to the handler for post-turn orchestration. */
+export interface StreamResult {
+  /** True when the turn stopped early via cancellation (client disconnect / cancel). */
+  cancelled: boolean;
+}
+
 /**
  * Stream the agent response as NDJSON events.
  *
@@ -149,6 +166,10 @@ async function handleStreamError(
  * 2. Stream events from agent
  * 3. Send completion metadata
  * 4. Handle errors (save to session + notify client)
+ *
+ * Returns a {@link StreamResult} so the caller can react to a cancelled turn
+ * (e.g. propagate the cancel to sub-agent tasks) without this module needing to
+ * know about that machinery.
  */
 export async function streamAgentResponse(
   agent: Agent,
@@ -156,9 +177,27 @@ export async function streamAgentResponse(
   images: ImageData[] | undefined,
   res: Response,
   options: StreamOptions
-): Promise<void> {
-  const requestId = getCurrentContext()?.requestId;
+): Promise<StreamResult> {
+  const context = getCurrentContext();
+  const requestId = context?.requestId;
+  const sessionId = context?.sessionId;
   setStreamingHeaders(res);
+
+  // Register this turn's Agent so an out-of-band stop command can cancel it.
+  //
+  // WHY not client-disconnect: AgentCore Runtime does NOT propagate a client
+  // fetch abort to the container (verified in production — no `res` 'close'
+  // fires, the turn runs to completion). So cancellation is driven by a second
+  // `{ action: 'stop' }` invocation that AgentCore's session-sticky routing
+  // delivers to THIS microVM; stopDispatchMiddleware looks the Agent up in the
+  // registry and calls `agent.cancel()`. That cooperatively stops the Strands
+  // loop at its next checkpoint and the stream returns `stopReason: 'cancelled'`.
+  //
+  // Sessionless invocations (no sessionId) can't be targeted by a stop command,
+  // so registration is skipped for them.
+  if (sessionId) {
+    registerAgent(sessionId, agent);
+  }
 
   try {
     logger.info({ requestId }, 'Agent streaming started:');
@@ -182,11 +221,37 @@ export async function streamAgentResponse(
     // aggregator only works when the canonical
     // `POST → invoke_agent → execute_event_loop_cycle → chat` hierarchy
     // is preserved.
-    for await (const event of agent.stream(agentInput)) {
-      const safeEvents = serializeStreamEvent(event);
+    // Manual iteration (not `for await`) so we can read the generator's RETURN
+    // value — the `AgentResult` carrying `stopReason`. `for await` discards it.
+    // Cancellation is driven by `agent.cancel()` (from the stop command via the
+    // registry), which fires the agent's own internal signal — no external
+    // cancelSignal needed here.
+    const stream = agent.stream(agentInput);
+    let streamResult = await stream.next();
+    while (!streamResult.done) {
+      const safeEvents = serializeStreamEvent(streamResult.value);
       for (const safeEvent of safeEvents) {
         res.write(`${JSON.stringify(safeEvent)}\n`);
       }
+      streamResult = await stream.next();
+    }
+    const agentResult = streamResult.value;
+    const cancelled = agentResult?.stopReason === 'cancelled';
+
+    // A cancelled turn is a normal, expected outcome — NOT an error. The SDK has
+    // already left `agent.messages` in a reinvokable state (synthetic assistant /
+    // tool-result blocks) and the SessionPersistenceHook's AfterInvocationEvent
+    // has persisted it, so we neither write a serverErrorEvent nor save an error
+    // message here. We just tell the client the turn stopped early.
+    if (cancelled) {
+      logger.info({ requestId }, 'Agent turn cancelled:');
+      sendCompletionEvent(res, agent, options, true);
+      res.end();
+      // Signal the caller (handleInvocation) so it can propagate the cancel to
+      // any sub-agent tasks this turn spawned. Sub-agent orchestration lives in
+      // the handler, not here — keeping stream-handler free of that dependency
+      // chain (and unit-testable in isolation).
+      return { cancelled: true };
     }
 
     logger.info({ requestId }, 'Agent streaming completed:');
@@ -211,7 +276,16 @@ export async function streamAgentResponse(
 
     sendCompletionEvent(res, agent, options);
     res.end();
+    return { cancelled: false };
   } catch (streamError) {
     await handleStreamError(streamError, res, options);
+    return { cancelled: false };
+  } finally {
+    // Always remove this turn's registration. Pass `agent` so we only evict our
+    // own entry — a follow-up turn for the same session may have already
+    // re-registered by the time this finally runs.
+    if (sessionId) {
+      unregisterAgent(sessionId, agent);
+    }
   }
 }

--- a/packages/agent/src/libs/health/__tests__/agent-cancel-registry.test.ts
+++ b/packages/agent/src/libs/health/__tests__/agent-cancel-registry.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for the agent cancel registry.
+ *
+ * Backs the out-of-band stop path: a `{ action: 'stop' }` invocation arriving
+ * on the SAME microVM (session-sticky routing) looks up the in-flight Agent by
+ * sessionId and calls `agent.cancel()`. See libs/health/agent-cancel-registry.ts.
+ *
+ * A process-global map is the right scope: AgentCore pins one session to one
+ * microVM (one process), so the running turn and its stop command share this
+ * module singleton — the same reasoning as in-flight.ts.
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import {
+  registerAgent,
+  unregisterAgent,
+  cancelAgent,
+  isRegistered,
+  resetRegistry,
+} from '../agent-cancel-registry.js';
+
+/** Minimal Agent stand-in — the registry only ever calls `.cancel()`. */
+function fakeAgent() {
+  return { cancel: jest.fn() } as any;
+}
+
+describe('agent cancel registry', () => {
+  beforeEach(() => {
+    resetRegistry();
+  });
+
+  it('starts empty', () => {
+    expect(isRegistered('s1')).toBe(false);
+  });
+
+  it('registers an agent under its sessionId', () => {
+    registerAgent('s1', fakeAgent());
+    expect(isRegistered('s1')).toBe(true);
+  });
+
+  it('cancelAgent calls cancel() on the registered agent and returns true', () => {
+    const agent = fakeAgent();
+    registerAgent('s1', agent);
+
+    const result = cancelAgent('s1');
+
+    expect(result).toBe(true);
+    expect(agent.cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancelAgent returns false and is a no-op for an unknown session', () => {
+    expect(cancelAgent('nope')).toBe(false);
+  });
+
+  it('unregisterAgent removes the entry so a later cancel is a no-op', () => {
+    const agent = fakeAgent();
+    registerAgent('s1', agent);
+    unregisterAgent('s1');
+
+    expect(isRegistered('s1')).toBe(false);
+    expect(cancelAgent('s1')).toBe(false);
+    expect(agent.cancel).not.toHaveBeenCalled();
+  });
+
+  it('unregister only removes the matching agent (guards against a stale later turn evicting the current one)', () => {
+    const first = fakeAgent();
+    registerAgent('s1', first);
+    // A new turn for the same session replaces the registration.
+    const second = fakeAgent();
+    registerAgent('s1', second);
+
+    // The first turn finishing must NOT unregister the second turn's agent.
+    unregisterAgent('s1', first);
+    expect(isRegistered('s1')).toBe(true);
+
+    cancelAgent('s1');
+    expect(second.cancel).toHaveBeenCalledTimes(1);
+    expect(first.cancel).not.toHaveBeenCalled();
+  });
+
+  it('keeps registrations for different sessions independent', () => {
+    const a = fakeAgent();
+    const b = fakeAgent();
+    registerAgent('s1', a);
+    registerAgent('s2', b);
+
+    cancelAgent('s1');
+    expect(a.cancel).toHaveBeenCalledTimes(1);
+    expect(b.cancel).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent/src/libs/health/agent-cancel-registry.ts
+++ b/packages/agent/src/libs/health/agent-cancel-registry.ts
@@ -1,0 +1,73 @@
+/**
+ * In-flight agent registry for out-of-band cancellation.
+ *
+ * WHY this exists
+ * ---------------
+ * On AgentCore Runtime a client `fetch` abort is NOT propagated to the
+ * container (verified in production: no `res` 'close' fires for a disconnect,
+ * the turn runs to completion). So "stop the running turn" cannot be driven by
+ * the transport. Instead the frontend sends a SECOND invocation carrying
+ * `{ action: 'stop' }` with the SAME runtime session id. AgentCore's
+ * session-sticky routing lands that request on the SAME microVM (one session →
+ * one microVM → one process), where this module lets it find the in-flight
+ * `Agent` and call `agent.cancel()`.
+ *
+ * A process-global map is the correct scope for exactly the reason in-flight.ts
+ * gives: the running turn and its stop command are guaranteed to share this
+ * process. `cancel()` is cooperative — the Strands loop stops at its next
+ * checkpoint and the stream returns `stopReason: 'cancelled'`.
+ */
+
+import type { Agent } from '@strands-agents/sdk';
+
+/** sessionId → the Agent currently running a turn for that session. */
+const registry = new Map<string, Agent>();
+
+/**
+ * Record the Agent running a turn for `sessionId`. A later turn for the same
+ * session overwrites the entry (the newest turn is the one a stop should hit).
+ */
+export function registerAgent(sessionId: string, agent: Agent): void {
+  registry.set(sessionId, agent);
+}
+
+/**
+ * Remove the registration for `sessionId`.
+ *
+ * When `agent` is provided, the entry is removed ONLY if it still points at
+ * that same agent. This guards the race where an old turn finishes and cleans
+ * up AFTER a new turn for the same session has already registered — without the
+ * guard the finishing turn would evict the new turn's agent, silently breaking
+ * a subsequent stop.
+ */
+export function unregisterAgent(sessionId: string, agent?: Agent): void {
+  if (agent && registry.get(sessionId) !== agent) {
+    return;
+  }
+  registry.delete(sessionId);
+}
+
+/**
+ * Cancel the in-flight turn for `sessionId`, if any.
+ *
+ * @returns true if an agent was found and cancelled, false if nothing was
+ *          registered for the session (already finished, or never on this VM).
+ */
+export function cancelAgent(sessionId: string): boolean {
+  const agent = registry.get(sessionId);
+  if (!agent) {
+    return false;
+  }
+  agent.cancel();
+  return true;
+}
+
+/** True if an agent is currently registered for `sessionId`. */
+export function isRegistered(sessionId: string): boolean {
+  return registry.has(sessionId);
+}
+
+/** Clear the registry. Intended for unit tests only. */
+export function resetRegistry(): void {
+  registry.clear();
+}

--- a/packages/agent/src/libs/middleware/__tests__/stop-dispatch.test.ts
+++ b/packages/agent/src/libs/middleware/__tests__/stop-dispatch.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Unit tests for stopDispatchMiddleware.
+ *
+ * A `{ action: 'stop' }` invocation is an out-of-band cancel command: it must
+ * short-circuit BEFORE prompt validation / identity exchange / streaming, look
+ * up the in-flight Agent for the authenticated sessionId, cancel it, and return
+ * a small JSON ack. Any other body falls through to the normal chain.
+ *
+ * Uses jest.unstable_mockModule so the registry can be observed without a real
+ * Agent.
+ */
+
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+const mockCancelAgent = jest.fn<(sessionId: string) => boolean>();
+
+jest.unstable_mockModule('../../health/agent-cancel-registry.js', () => ({
+  cancelAgent: mockCancelAgent,
+}));
+jest.unstable_mockModule('../../logger/index.js', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+const mockGetCurrentContext = jest.fn<() => { sessionId?: string; requestId?: string } | undefined>();
+jest.unstable_mockModule('../../context/request-context.js', () => ({
+  getCurrentContext: mockGetCurrentContext,
+}));
+
+const { stopDispatchMiddleware } = await import('../stop-dispatch.js');
+
+function createRes() {
+  const res: any = {
+    statusCode: 200,
+    body: undefined,
+    status: jest.fn(function (this: any, code: number) {
+      this.statusCode = code;
+      return this;
+    }),
+    json: jest.fn(function (this: any, payload: unknown) {
+      this.body = payload;
+      return this;
+    }),
+  };
+  return res;
+}
+
+describe('stopDispatchMiddleware', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCurrentContext.mockReturnValue({ sessionId: 'sess-1', requestId: 'req-1' });
+  });
+
+  it('passes through (calls next) for a normal prompt request', () => {
+    const req: any = { body: { prompt: 'hello' } };
+    const res = createRes();
+    const next = jest.fn();
+
+    stopDispatchMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.json).not.toHaveBeenCalled();
+    expect(mockCancelAgent).not.toHaveBeenCalled();
+  });
+
+  it('cancels the session and acks (200) for action:stop, without calling next', () => {
+    mockCancelAgent.mockReturnValue(true);
+    const req: any = { body: { action: 'stop' } };
+    const res = createRes();
+    const next = jest.fn();
+
+    stopDispatchMiddleware(req, res, next);
+
+    expect(mockCancelAgent).toHaveBeenCalledWith('sess-1');
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ status: 'cancelled', cancelled: true });
+  });
+
+  it('reports cancelled:false when no turn was in flight (still 200)', () => {
+    mockCancelAgent.mockReturnValue(false);
+    const req: any = { body: { action: 'stop' } };
+    const res = createRes();
+    const next = jest.fn();
+
+    stopDispatchMiddleware(req, res, next);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ status: 'not_running', cancelled: false });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('rejects a stop with no sessionId (400) rather than cancelling blindly', () => {
+    mockGetCurrentContext.mockReturnValue({ requestId: 'req-1' }); // no sessionId
+    const req: any = { body: { action: 'stop' } };
+    const res = createRes();
+    const next = jest.fn();
+
+    stopDispatchMiddleware(req, res, next);
+
+    expect(res.statusCode).toBe(400);
+    expect(mockCancelAgent).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent/src/libs/middleware/index.ts
+++ b/packages/agent/src/libs/middleware/index.ts
@@ -3,6 +3,7 @@
  */
 
 export { requestContextMiddleware } from './request-context.js';
+export { stopDispatchMiddleware } from './stop-dispatch.js';
 export { corsOptions } from './cors.js';
 export { asyncHandler } from './async-handler.js';
 export { validateInvocationMiddleware } from './validate-invocation.js';

--- a/packages/agent/src/libs/middleware/stop-dispatch.ts
+++ b/packages/agent/src/libs/middleware/stop-dispatch.ts
@@ -1,0 +1,54 @@
+/**
+ * Stop-dispatch middleware.
+ *
+ * A cancel command rides the same `POST /invocations` route as a normal turn
+ * (AgentCore exposes only that endpoint) but carries `{ action: 'stop' }`
+ * instead of a prompt. Because AgentCore does NOT propagate a client fetch
+ * abort to the container, this out-of-band command is how the frontend stops a
+ * running turn: session-sticky routing lands it on the same microVM, where the
+ * process-global cancel registry holds the in-flight Agent.
+ *
+ * This middleware runs right after `requestContextMiddleware` (which has
+ * authenticated the caller and populated `ctx.sessionId` from the session
+ * header) and BEFORE prompt validation / identity exchange / streaming — a stop
+ * needs none of those. On `action: 'stop'` it cancels and acks; anything else
+ * falls through to the normal chain via `next()`.
+ */
+
+import type { Request, Response, NextFunction } from 'express';
+import { cancelAgent } from '../health/agent-cancel-registry.js';
+import { getCurrentContext } from '../context/request-context.js';
+import { logger } from '../logger/index.js';
+
+interface MaybeStopBody {
+  action?: string;
+}
+
+export function stopDispatchMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const body = req.body as MaybeStopBody | undefined;
+
+  if (body?.action !== 'stop') {
+    next();
+    return;
+  }
+
+  const ctx = getCurrentContext();
+  const sessionId = ctx?.sessionId;
+
+  // A stop is meaningless without a session to target. The cancel registry is
+  // keyed by sessionId, so refuse rather than cancel blindly.
+  if (!sessionId) {
+    logger.warn({ requestId: ctx?.requestId }, 'Stop request without a sessionId');
+    res.status(400).json({ error: 'sessionId is required to stop a session' });
+    return;
+  }
+
+  const cancelled = cancelAgent(sessionId);
+  logger.info({ requestId: ctx?.requestId, sessionId, cancelled }, 'Stop request processed');
+
+  // 200 either way: "nothing to cancel" (turn already finished, or this VM never
+  // ran it) is a successful, idempotent no-op from the client's perspective.
+  res.status(200).json(
+    cancelled ? { status: 'cancelled', cancelled: true } : { status: 'not_running', cancelled: false }
+  );
+}

--- a/packages/agent/src/runtime/tools/__tests__/call-agent.parent-session.test.ts
+++ b/packages/agent/src/runtime/tools/__tests__/call-agent.parent-session.test.ts
@@ -1,0 +1,79 @@
+/**
+ * call-agent — parentSessionId derivation.
+ *
+ * Regression test for the dead sub-agent cancel-propagation bug: start_task
+ * derived parentSessionId from `agent.appState.get('sessionId')`, which is
+ * never set, so every task got parentSessionId=undefined and
+ * cancelTasksByParentSession(sessionId) could never match. The correct source
+ * is the request context's sessionId — the same value invocations.ts passes to
+ * cancelTasksByParentSession.
+ *
+ * Uses jest.unstable_mockModule + dynamic import for ESM compatibility.
+ */
+
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+const mockCreateTask = jest.fn<any>();
+const mockGetTask = jest.fn<any>();
+const mockGetCurrentContext = jest.fn<any>();
+
+jest.unstable_mockModule('../../../services/sub-agent-task-manager.js', () => ({
+  subAgentTaskManager: { createTask: mockCreateTask, getTask: mockGetTask },
+}));
+jest.unstable_mockModule('../../../services/agent-registry.js', () => ({
+  listAgents: jest.fn(),
+}));
+jest.unstable_mockModule('../../../libs/logger/index.js', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+jest.unstable_mockModule('../../../libs/context/request-context.js', () => ({
+  getCurrentContext: mockGetCurrentContext,
+}));
+jest.unstable_mockModule('@moca/tool-definitions', () => ({
+  callAgentDefinition: { name: 'call_agent', description: 'd', zodSchema: {} },
+}));
+
+const { handleStartTask } = await import('../call-agent.js');
+
+/** A ToolContext-shaped stub with an appState map (sessionId intentionally absent). */
+function toolContextWithState(state: Record<string, unknown> = {}) {
+  return {
+    agent: {
+      appState: {
+        get: (key: string) => state[key],
+      },
+    },
+  } as any;
+}
+
+describe('handleStartTask parentSessionId', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateTask.mockResolvedValue('task-1');
+    mockGetTask.mockResolvedValue({ sessionId: 'sub-session' });
+  });
+
+  it('uses the request-context sessionId as parentSessionId', async () => {
+    // appState has NO 'sessionId' (mirrors production — only storagePath/subAgentDepth set).
+    mockGetCurrentContext.mockReturnValue({ userId: 'user-1', sessionId: 'parent-session-123' });
+
+    await handleStartTask(
+      { agentId: 'agent-a', query: 'do work' },
+      toolContextWithState({ storagePath: '/work' })
+    );
+
+    expect(mockCreateTask).toHaveBeenCalledTimes(1);
+    const opts = mockCreateTask.mock.calls[0][2];
+    // This is the value cancelTasksByParentSession(sessionId) matches against.
+    expect(opts.parentSessionId).toBe('parent-session-123');
+  });
+
+  it('leaves parentSessionId undefined when the context has no sessionId (sessionless)', async () => {
+    mockGetCurrentContext.mockReturnValue({ userId: 'user-1' });
+
+    await handleStartTask({ agentId: 'agent-a', query: 'do work' }, toolContextWithState());
+
+    const opts = mockCreateTask.mock.calls[0][2];
+    expect(opts.parentSessionId).toBeUndefined();
+  });
+});

--- a/packages/agent/src/runtime/tools/call-agent.ts
+++ b/packages/agent/src/runtime/tools/call-agent.ts
@@ -54,9 +54,12 @@ async function handleListAgents(): Promise<Record<string, unknown>> {
 }
 
 /**
- * Handle start_task action
+ * Handle start_task action.
+ *
+ * Exported for unit testing (parentSessionId derivation); not part of the
+ * tool's public surface — callers use `callAgentTool`.
  */
-async function handleStartTask(
+export async function handleStartTask(
   input: {
     agentId?: string;
     query?: string;
@@ -90,15 +93,19 @@ async function handleStartTask(
   }
 
   try {
-    // Get session ID from agent state if available
-    const parentSessionId = context?.agent?.appState?.get('sessionId') as string | undefined;
+    // Get userId and the parent turn's sessionId from the request context.
+    //
+    // parentSessionId MUST come from the request context (not
+    // `agent.appState.get('sessionId')`, which is never set): it is the value
+    // `invocations.ts` passes to `cancelTasksByParentSession` when the parent
+    // turn is stopped. Keying tasks by the same sessionId is what lets a Stop on
+    // the parent cancel the sub-agent tasks it spawned.
+    const currentContext = getCurrentContext();
+    const userId = currentContext?.userId;
+    const parentSessionId = currentContext?.sessionId as string | undefined;
 
     // Get storagePath from input or inherit from parent
     const storagePath = input.storagePath || context?.agent?.appState?.get('storagePath');
-
-    // Get userId from request context
-    const currentContext = getCurrentContext();
-    const userId = currentContext?.userId;
 
     // Create task
     const taskId = await subAgentTaskManager.createTask(input.agentId, input.query, {
@@ -192,6 +199,20 @@ async function handleStatus(
           taskId: task.taskId,
           sessionId: task.sessionId,
           status: 'failed',
+          agentId: task.agentId,
+          error: task.error,
+          elapsedTime,
+          pollCount: waitForCompletion ? pollCount : undefined,
+        };
+      }
+
+      // 'cancelled' is terminal too — without this branch a waitForCompletion
+      // poll would spin until the max-wait timeout on a task the user stopped.
+      if (task.status === 'cancelled') {
+        return {
+          taskId: task.taskId,
+          sessionId: task.sessionId,
+          status: 'cancelled',
           agentId: task.agentId,
           error: task.error,
           elapsedTime,

--- a/packages/agent/src/services/__tests__/sub-agent-task-manager.cancel.test.ts
+++ b/packages/agent/src/services/__tests__/sub-agent-task-manager.cancel.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Sub-Agent Task Manager — cancellation tests
+ *
+ * Verifies that running sub-agent tasks can be interrupted:
+ * - each task's `agent.invoke` receives a `cancelSignal`
+ * - `cancelTask(taskId)` aborts that one task
+ * - `cancelTasksByParentSession(parentSessionId)` aborts every running task
+ *   spawned by a given parent turn (the propagation path from a cancelled
+ *   main turn)
+ *
+ * Uses jest.unstable_mockModule + dynamic import for ESM compatibility, mocking
+ * the manager's heavy collaborators so the test exercises only the
+ * cancellation registry. The session-persistence / workspace-sync branches are
+ * intentionally left dormant (no AGENTCORE_MEMORY_ID, no storagePath).
+ */
+
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+
+// ── Controllable agent: invoke() parks until its cancelSignal aborts ────
+const invokeCalls: Array<{ signal?: AbortSignal }> = [];
+
+function makeParkingAgent() {
+  return {
+    appState: { set: jest.fn() },
+    invoke: jest.fn((_query: string, opts?: { cancelSignal?: AbortSignal }) => {
+      invokeCalls.push({ signal: opts?.cancelSignal });
+      return new Promise((resolve) => {
+        // Resolve with a cancelled-style result when the signal fires; otherwise
+        // stay pending, standing in for a long-running turn.
+        opts?.cancelSignal?.addEventListener('abort', () => resolve('cancelled'));
+      });
+    }),
+  };
+}
+
+const mockCreateAgent = jest.fn<any>();
+const mockGetAgentDefinition = jest.fn<any>();
+
+jest.unstable_mockModule('../../config/index.js', () => ({
+  config: { AGENTCORE_MEMORY_ID: undefined },
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+jest.unstable_mockModule('../../libs/logger/index.js', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+  createLogger: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }),
+}));
+jest.unstable_mockModule('../../agent.js', () => ({ createAgent: mockCreateAgent }));
+jest.unstable_mockModule('../agent-registry.js', () => ({
+  getAgentDefinition: mockGetAgentDefinition,
+}));
+jest.unstable_mockModule('../../libs/context/request-context.js', () => ({
+  getCurrentContext: jest.fn(() => ({ userId: 'user-1' })),
+  runWithContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}));
+jest.unstable_mockModule('../workspace-sync.js', () => ({ WorkspaceSync: class {} }));
+jest.unstable_mockModule('../workspace-sync-helper.js', () => ({
+  resolveSkillsPaths: jest.fn(async () => []),
+}));
+jest.unstable_mockModule('../session/workspace-sync-hook.js', () => ({
+  WorkspaceSyncHook: class {},
+}));
+jest.unstable_mockModule('../session/agentcore-memory-storage.js', () => ({
+  AgentCoreMemoryStorage: class {},
+}));
+jest.unstable_mockModule('../session/session-persistence-hook.js', () => ({
+  SessionPersistenceHook: class {},
+}));
+jest.unstable_mockModule('../session-persistence-deps-factory.js', () => ({
+  createSessionPersistenceDeps: jest.fn(() => ({})),
+}));
+jest.unstable_mockModule('../../libs/utils/scoped-credentials.js', () => ({
+  getIdentityId: jest.fn(async () => 'region:id'),
+  createUserScopedBedrockAgentCoreClient: jest.fn(async () => ({})),
+}));
+
+const { subAgentTaskManager } = await import('../sub-agent-task-manager.js');
+
+/** Poll until `predicate` is true or time runs out. */
+async function waitFor(predicate: () => boolean, timeoutMs = 1000): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) throw new Error('waitFor timed out');
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+describe('SubAgentTaskManager cancellation', () => {
+  beforeEach(() => {
+    invokeCalls.length = 0;
+    mockCreateAgent.mockReset().mockResolvedValue({ agent: makeParkingAgent() });
+    mockGetAgentDefinition.mockReset().mockResolvedValue({
+      systemPrompt: 'test',
+      enabledTools: [],
+      modelId: 'test-model',
+    });
+  });
+
+  afterEach(() => {
+    // Abort anything still parked so no promise leaks between tests.
+    subAgentTaskManager.cancelAllTasks?.();
+  });
+
+  it('passes a cancelSignal to agent.invoke', async () => {
+    await subAgentTaskManager.createTask('agent-a', 'do work', { parentSessionId: 'parent-1' });
+    await waitFor(() => invokeCalls.length === 1);
+    expect(invokeCalls[0].signal).toBeInstanceOf(AbortSignal);
+    expect(invokeCalls[0].signal?.aborted).toBe(false);
+  });
+
+  it('cancelTask aborts the running task and marks it cancelled', async () => {
+    const taskId = await subAgentTaskManager.createTask('agent-a', 'do work', {
+      parentSessionId: 'parent-1',
+    });
+    await waitFor(() => invokeCalls.length === 1);
+
+    subAgentTaskManager.cancelTask(taskId);
+
+    expect(invokeCalls[0].signal?.aborted).toBe(true);
+    await waitFor(async () => {
+      const t = await subAgentTaskManager.getTask(taskId);
+      return t?.status === 'cancelled';
+    });
+    const task = await subAgentTaskManager.getTask(taskId);
+    expect(task?.status).toBe('cancelled');
+  });
+
+  it('cancelTasksByParentSession aborts every running task for that parent only', async () => {
+    const a = await subAgentTaskManager.createTask('agent-a', 'q1', { parentSessionId: 'parent-1' });
+    const b = await subAgentTaskManager.createTask('agent-b', 'q2', { parentSessionId: 'parent-1' });
+    const other = await subAgentTaskManager.createTask('agent-c', 'q3', {
+      parentSessionId: 'parent-2',
+    });
+    await waitFor(() => invokeCalls.length === 3);
+
+    subAgentTaskManager.cancelTasksByParentSession('parent-1');
+
+    // The two parent-1 tasks abort; parent-2 keeps running.
+    const [sigA, sigB, sigOther] = invokeCalls.map((c) => c.signal);
+    expect(sigA?.aborted).toBe(true);
+    expect(sigB?.aborted).toBe(true);
+    expect(sigOther?.aborted).toBe(false);
+
+    const taskOther = await subAgentTaskManager.getTask(other);
+    expect(taskOther?.status).toBe('running');
+    // Silence unused-var lint for the ids we only needed to spawn tasks.
+    expect([a, b]).toHaveLength(2);
+  });
+});

--- a/packages/agent/src/services/sub-agent-task-manager.ts
+++ b/packages/agent/src/services/sub-agent-task-manager.ts
@@ -28,7 +28,7 @@ import type { CreateAgentOptions } from '../types/agent-types.js';
 /**
  * Task status
  */
-export type TaskStatus = 'pending' | 'running' | 'completed' | 'failed';
+export type TaskStatus = 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
 
 /**
  * Sub-agent task definition
@@ -58,6 +58,12 @@ export interface SubAgentTask {
   authHeader?: string;
   /** Captured Cognito ID Token from parent request context (for Identity Pool credential exchange in background) */
   idToken?: string;
+  /**
+   * Aborts this task's agent turn. Fed to `agent.invoke` as `cancelSignal` so a
+   * cancel request stops the sub-agent at the next SDK checkpoint. Not persisted
+   * / not serialized — it only lives for the duration of the background run.
+   */
+  abortController?: AbortController;
 }
 
 /**
@@ -130,6 +136,7 @@ class SubAgentTaskManager {
       storagePath: options.storagePath,
       authHeader,
       idToken,
+      abortController: new AbortController(),
     };
 
     this.tasks.set(taskId, task);
@@ -305,8 +312,20 @@ class SubAgentTaskManager {
 
       this.updateTaskStatus(taskId, 'running', 'Executing query...');
 
-      // Execute query
-      const result = await agent.invoke(task.query);
+      // Execute query. The cancelSignal lets cancelTask / cancelTasksByParentSession
+      // interrupt the turn at the SDK's next checkpoint; the SDK returns an
+      // AgentResult with stopReason 'cancelled' rather than throwing.
+      const result = await agent.invoke(task.query, {
+        cancelSignal: task.abortController?.signal,
+      });
+
+      // A cancelled turn is not a completion — reflect it distinctly so callers
+      // (and the status tool) can tell "user stopped it" from "it finished".
+      if (task.abortController?.signal.aborted || result?.stopReason === 'cancelled') {
+        this.updateTaskStatus(taskId, 'cancelled', undefined, 'Cancelled');
+        logger.info({ taskId, agentId: task.agentId }, 'Sub-agent task cancelled:');
+        return;
+      }
 
       // Update to completed
       this.updateTaskStatus(taskId, 'completed', String(result));
@@ -360,6 +379,51 @@ class SubAgentTaskManager {
   }
 
   /**
+   * Cancel a single running task by aborting its agent turn.
+   *
+   * Cooperative: the SDK stops at its next checkpoint and _executeTaskInContext
+   * transitions the task to 'cancelled'. No-op for unknown or already-settled
+   * tasks. Returns true if a cancel was actually signalled.
+   */
+  cancelTask(taskId: string): boolean {
+    const task = this.tasks.get(taskId);
+    if (!task) return false;
+    if (task.status === 'completed' || task.status === 'failed' || task.status === 'cancelled') {
+      return false;
+    }
+    task.abortController?.abort();
+    return true;
+  }
+
+  /**
+   * Cancel every not-yet-settled task spawned by a given parent session.
+   *
+   * This is the propagation path from a cancelled main turn: when the user stops
+   * the primary agent, its in-flight sub-agent tasks must stop too rather than
+   * keep billing the microVM. Returns the number of tasks signalled.
+   */
+  cancelTasksByParentSession(parentSessionId: string): number {
+    let count = 0;
+    for (const task of this.tasks.values()) {
+      if (task.parentSessionId === parentSessionId && this.cancelTask(task.taskId)) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  /**
+   * Cancel all not-yet-settled tasks. Used on shutdown paths and by tests.
+   */
+  cancelAllTasks(): number {
+    let count = 0;
+    for (const task of this.tasks.values()) {
+      if (this.cancelTask(task.taskId)) count++;
+    }
+    return count;
+  }
+
+  /**
    * Get task by ID
    */
   async getTask(taskId: string): Promise<SubAgentTask | null> {
@@ -375,7 +439,7 @@ class SubAgentTaskManager {
 
     for (const [taskId, task] of this.tasks.entries()) {
       const age = now - task.createdAt;
-      if (age > this.TASK_EXPIRATION_MS && ['completed', 'failed'].includes(task.status)) {
+      if (age > this.TASK_EXPIRATION_MS && ['completed', 'failed', 'cancelled'].includes(task.status)) {
         this.tasks.delete(taskId);
         cleanedCount++;
       }
@@ -395,6 +459,7 @@ class SubAgentTaskManager {
     running: number;
     completed: number;
     failed: number;
+    cancelled: number;
   } {
     const tasks = Array.from(this.tasks.values());
     return {
@@ -403,6 +468,7 @@ class SubAgentTaskManager {
       running: tasks.filter((t) => t.status === 'running').length,
       completed: tasks.filter((t) => t.status === 'completed').length,
       failed: tasks.filter((t) => t.status === 'failed').length,
+      cancelled: tasks.filter((t) => t.status === 'cancelled').length,
     };
   }
 }

--- a/packages/frontend/src/api/__tests__/agent.cancel.test.ts
+++ b/packages/frontend/src/api/__tests__/agent.cancel.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Unit tests for streamAgentResponse cancellation wiring.
+ *
+ * Guards two behaviours needed for the Stop button:
+ *   - the caller's AbortSignal is forwarded to agentClient.invoke, so aborting
+ *     it tears down the underlying fetch;
+ *   - an aborted read (fetch throws AbortError, or the server closes the stream)
+ *     is treated as a graceful stop via onCancel — NOT surfaced as onError, so
+ *     the UI doesn't render a spurious "An error occurred" bubble.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const invoke = vi.fn();
+
+vi.mock('../client/agent-client', () => ({
+  agentClient: { invoke: (opts: RequestInit) => invoke(opts) },
+}));
+vi.mock('../../utils/logger', () => ({
+  logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { streamAgentResponse, stopAgentTurn } from '../agent';
+
+/** Build a Response whose body streams the given NDJSON lines then closes. */
+function ndjsonResponse(lines: string[]): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    start(controller) {
+      for (const line of lines) controller.enqueue(encoder.encode(line + '\n'));
+      controller.close();
+    },
+  });
+  return { ok: true, body: stream } as unknown as Response;
+}
+
+/** Build a Response whose body errors with an AbortError mid-read. */
+function abortingResponse(): Response {
+  const stream = new ReadableStream({
+    start(controller) {
+      const err = new DOMException('The user aborted a request.', 'AbortError');
+      controller.error(err);
+    },
+  });
+  return { ok: true, body: stream } as unknown as Response;
+}
+
+describe('streamAgentResponse cancellation', () => {
+  beforeEach(() => {
+    invoke.mockReset();
+  });
+
+  it('forwards the AbortSignal to agentClient.invoke', async () => {
+    invoke.mockResolvedValue(ndjsonResponse([]));
+    const controller = new AbortController();
+
+    await streamAgentResponse('hi', 'session-1', {}, undefined, controller.signal);
+
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(invoke.mock.calls[0][0].signal).toBe(controller.signal);
+  });
+
+  it('calls onCancel (not onError) when the read is aborted', async () => {
+    invoke.mockResolvedValue(abortingResponse());
+    const onError = vi.fn();
+    const onCancel = vi.fn();
+
+    await streamAgentResponse('hi', 'session-1', { onError, onCancel });
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('treats a serverCancelledEvent as a graceful stop via onCancel', async () => {
+    invoke.mockResolvedValue(
+      ndjsonResponse([JSON.stringify({ type: 'serverCancelledEvent', metadata: {} })])
+    );
+    const onError = vi.fn();
+    const onCancel = vi.fn();
+    const onComplete = vi.fn();
+
+    await streamAgentResponse('hi', 'session-1', { onError, onCancel, onComplete });
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+});
+
+describe('stopAgentTurn', () => {
+  beforeEach(() => {
+    invoke.mockReset();
+  });
+
+  it('posts { action: stop } with the same session id header', async () => {
+    invoke.mockResolvedValue({ ok: true } as Response);
+
+    const ok = await stopAgentTurn('session-1');
+
+    expect(ok).toBe(true);
+    const opts = invoke.mock.calls[0][0];
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual({ action: 'stop' });
+    expect(opts.headers['X-Amzn-Bedrock-AgentCore-Runtime-Session-Id']).toBe('session-1');
+  });
+
+  it('returns false (never throws) when the request fails', async () => {
+    invoke.mockRejectedValue(new Error('network down'));
+
+    await expect(stopAgentTurn('session-1')).resolves.toBe(false);
+  });
+
+  it('returns false on a non-ok response', async () => {
+    invoke.mockResolvedValue({ ok: false } as Response);
+
+    await expect(stopAgentTurn('session-1')).resolves.toBe(false);
+  });
+});

--- a/packages/frontend/src/api/agent.ts
+++ b/packages/frontend/src/api/agent.ts
@@ -26,6 +26,13 @@ interface StreamingCallbacks {
   onToolResult?: (toolResult: ToolResult) => void;
   onComplete?: (metadata: Record<string, unknown>) => void;
   onError?: (error: Error) => void;
+  /**
+   * Called when the turn stopped early by user request rather than finishing or
+   * erroring — either the client aborted the fetch (AbortError) or the server
+   * emitted a serverCancelledEvent. Distinct from onError so the UI can settle
+   * the streaming message quietly instead of showing an error bubble.
+   */
+  onCancel?: (metadata?: Record<string, unknown>) => void;
 }
 
 /**
@@ -75,7 +82,8 @@ export const streamAgentResponse = async (
   prompt: string,
   sessionId: string | undefined,
   callbacks: StreamingCallbacks,
-  agentConfig?: AgentConfig
+  agentConfig?: AgentConfig,
+  signal?: AbortSignal
 ): Promise<void> => {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -93,6 +101,11 @@ export const streamAgentResponse = async (
       method: 'POST',
       headers,
       body,
+      // Aborting this signal tears down the CLIENT fetch (stops reading the
+      // stream) so the UI settles immediately. It does NOT stop the server —
+      // AgentCore keeps the turn running after a client disconnect. The actual
+      // server-side stop is done out-of-band by `stopAgentTurn` below.
+      signal,
     });
 
     if (!response.ok) {
@@ -160,11 +173,48 @@ export const streamAgentResponse = async (
       reader.releaseLock();
     }
   } catch (error) {
+    // A user-initiated abort surfaces as a DOMException named 'AbortError' (from
+    // fetch or the stream reader). That's a graceful stop, not a failure — route
+    // it to onCancel so the UI settles quietly instead of showing an error.
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      callbacks.onCancel?.();
+      return;
+    }
     if (callbacks.onError) {
       callbacks.onError(error instanceof Error ? error : new Error('Agent API error'));
     } else {
       throw error;
     }
+  }
+};
+
+/**
+ * Stop a running agent turn out-of-band.
+ *
+ * AgentCore keeps the server-side turn running after a client fetch abort, so
+ * stopping requires an explicit command. This sends a second POST to the same
+ * endpoint with the SAME session id header, carrying `{ action: 'stop' }`.
+ * AgentCore's session-sticky routing delivers it to the same microVM, where the
+ * agent looks up the in-flight turn and cancels it. The original streaming
+ * request then ends with a serverCancelledEvent.
+ *
+ * Best-effort and fast: resolves true on a 2xx ack, false otherwise. Never
+ * throws — a failed stop must not surface as a chat error.
+ */
+export const stopAgentTurn = async (sessionId: string): Promise<boolean> => {
+  try {
+    const response = await agentClient.invoke({
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id': sessionId,
+      },
+      body: JSON.stringify({ action: 'stop' }),
+    });
+    return response.ok;
+  } catch (error) {
+    logger.warn('stopAgentTurn failed:', error);
+    return false;
   }
 };
 
@@ -298,6 +348,14 @@ const handleStreamEvent = (event: AgentStreamEvent, callbacks: StreamingCallback
       if (callbacks.onComplete) {
         callbacks.onComplete(completionEvent.metadata);
       }
+      break;
+    }
+
+    case 'serverCancelledEvent': {
+      // The server stopped the turn early (client disconnect / cancel). Settle
+      // via onCancel — same metadata shape as completion, but not a full finish.
+      const cancelledEvent = event as { metadata?: Record<string, unknown> };
+      callbacks.onCancel?.(cancelledEvent.metadata);
       break;
     }
 

--- a/packages/frontend/src/components/MessageInput.tsx
+++ b/packages/frontend/src/components/MessageInput.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Send, Loader2, Paperclip, CheckCircle2 } from 'lucide-react';
+import { Send, Loader2, Paperclip, CheckCircle2, Square } from 'lucide-react';
 import { randomId } from '../utils/randomId';
 import { useChatStore } from '../stores/chatStore';
 import { useAgentStore } from '../stores/agentStore';
@@ -28,7 +28,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
   getScenarioPrompt,
 }) => {
   const { t } = useTranslation();
-  const { sendPrompt } = useChatStore();
+  const { sendPrompt, stopPrompt } = useChatStore();
   const { sendBehavior } = useSettingsStore();
   const sessionState = useChatStore((state) =>
     sessionId ? (state.sessions[sessionId] ?? null) : null
@@ -537,24 +537,35 @@ export const MessageInput: React.FC<MessageInputProps> = ({
                 </button>
               </div>
 
-              {/* Send button - fixed width, pinned to the right, never overlapped. */}
-              <button
-                type="submit"
-                disabled={
-                  (!input.trim() && attachedImages.length === 0) || isLoading || isAgentStoreLoading
-                }
-                className={`ml-auto shrink-0 w-8 h-8 rounded-md flex items-center justify-center transition-all duration-200 ${
-                  (!input.trim() && attachedImages.length === 0) || isLoading || isAgentStoreLoading
-                    ? 'text-fg-disabled cursor-not-allowed'
-                    : 'text-black hover:bg-surface-secondary'
-                }`}
-              >
-                {isLoading ? (
-                  <Loader2 className="w-4 h-4 animate-spin" />
-                ) : (
+              {/* Send / Stop button — fixed width, pinned to the right, never
+                  overlapped. While a turn is streaming this becomes an active
+                  Stop button (interrupts the agent) instead of a disabled
+                  spinner, so the user can always cancel a running turn. */}
+              {isLoading ? (
+                <button
+                  type="button"
+                  onClick={() => sessionId && stopPrompt(sessionId)}
+                  aria-label={t('chat.stopGenerating')}
+                  title={t('chat.stopGenerating')}
+                  className="ml-auto shrink-0 w-8 h-8 rounded-md flex items-center justify-center transition-all duration-200 text-black hover:bg-surface-secondary"
+                >
+                  <Square className="w-3.5 h-3.5 fill-current" />
+                </button>
+              ) : (
+                <button
+                  type="submit"
+                  disabled={
+                    (!input.trim() && attachedImages.length === 0) || isAgentStoreLoading
+                  }
+                  className={`ml-auto shrink-0 w-8 h-8 rounded-md flex items-center justify-center transition-all duration-200 ${
+                    (!input.trim() && attachedImages.length === 0) || isAgentStoreLoading
+                      ? 'text-fg-disabled cursor-not-allowed'
+                      : 'text-black hover:bg-surface-secondary'
+                  }`}
+                >
                   <Send className="w-4 h-4" />
-                )}
-              </button>
+                </button>
+              )}
             </div>
           </div>
         </div>

--- a/packages/frontend/src/locales/en.yaml
+++ b/packages/frontend/src/locales/en.yaml
@@ -193,6 +193,7 @@ chat:
   typingMessage: Type a message...
   thinking: Thinking...
   stopGenerating: Stop Generating
+  generationStopped: Generation stopped
   selectAgent: Select Agent
   changeAgent: Change Agent
   toggleWideView: Toggle wide view

--- a/packages/frontend/src/locales/ja.yaml
+++ b/packages/frontend/src/locales/ja.yaml
@@ -192,6 +192,7 @@ chat:
   typingMessage: メッセージを入力...
   thinking: 考え中...
   stopGenerating: 生成を停止
+  generationStopped: 生成を停止しました
   selectAgent: エージェントを選択
   changeAgent: エージェントを変更
   toggleWideView: 画面幅を切り替え

--- a/packages/frontend/src/stores/__tests__/chatStore.stopPrompt.test.ts
+++ b/packages/frontend/src/stores/__tests__/chatStore.stopPrompt.test.ts
@@ -1,0 +1,148 @@
+/**
+ * chatStore — stopPrompt / cancellation.
+ *
+ * Verifies the Stop button's store contract:
+ *   - sendPrompt threads an AbortSignal into streamAgentResponse;
+ *   - stopPrompt(sessionId) aborts that signal, so the in-flight fetch tears
+ *     down and the agent turn is cancelled;
+ *   - after cancellation the session settles (isLoading false) with no error.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Capture the args streamAgentResponse is called with, and hold the promise
+// open until the test releases it — mimicking an in-flight turn.
+const streamAgentResponse = vi.fn();
+const stopAgentTurn = vi.fn<(sessionId: string) => Promise<boolean>>();
+vi.mock('../../api/agent', () => ({
+  streamAgentResponse: (...args: unknown[]) => streamAgentResponse(...args),
+  stopAgentTurn: (sessionId: string) => stopAgentTurn(sessionId),
+}));
+
+// Neutralise the collaborator stores sendPrompt reads via getState().
+vi.mock('../agentStore', () => ({ useAgentStore: { getState: () => ({ selectedAgent: null }) } }));
+vi.mock('../storageStore', () => ({
+  useStorageStore: { getState: () => ({ agentWorkingDirectory: '/' }) },
+}));
+vi.mock('../sessionStore', () => ({
+  useSessionStore: {
+    getState: () => ({
+      sessions: [],
+      addOptimisticSession: vi.fn(),
+      refreshSessions: vi.fn(),
+    }),
+  },
+}));
+vi.mock('../memoryStore', () => ({ useMemoryStore: { getState: () => ({ isMemoryEnabled: false }) } }));
+vi.mock('../settingsStore', () => ({
+  useSettingsStore: {
+    getState: () => ({ selectedModelId: 'm', getReasoningDepthFor: () => 'off' }),
+  },
+}));
+vi.mock('../../utils/logger', () => ({
+  logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { useChatStore } from '../chatStore';
+
+const SESSION_ID = 'abcdefghij0123456789ABCDEFGHIJ012';
+
+describe('chatStore stopPrompt', () => {
+  beforeEach(() => {
+    streamAgentResponse.mockReset();
+    stopAgentTurn.mockReset();
+    stopAgentTurn.mockResolvedValue(true);
+    useChatStore.setState({ sessions: {}, activeSessionId: null, lastStreamCompletedAt: {} });
+  });
+
+  it('sends the out-of-band server stop command for the session', async () => {
+    let release: () => void = () => {};
+    streamAgentResponse.mockImplementation(
+      () => new Promise<void>((resolve) => (release = resolve))
+    );
+
+    const pending = useChatStore.getState().sendPrompt('hello', SESSION_ID);
+    await Promise.resolve();
+
+    useChatStore.getState().stopPrompt(SESSION_ID);
+    // The server-side stop is the only thing that actually halts the agent on
+    // AgentCore, so stopPrompt MUST issue it (not just abort the local fetch).
+    expect(stopAgentTurn).toHaveBeenCalledWith(SESSION_ID);
+
+    release();
+    await pending;
+  });
+
+  it('passes an AbortSignal to streamAgentResponse', async () => {
+    streamAgentResponse.mockResolvedValue(undefined);
+
+    await useChatStore.getState().sendPrompt('hello', SESSION_ID);
+
+    const signal = streamAgentResponse.mock.calls[0][4];
+    expect(signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('stopPrompt aborts the in-flight signal', async () => {
+    let capturedSignal: AbortSignal | undefined;
+    let release: () => void = () => {};
+    streamAgentResponse.mockImplementation((...args: unknown[]) => {
+      capturedSignal = args[4] as AbortSignal;
+      return new Promise<void>((resolve) => {
+        release = resolve;
+      });
+    });
+
+    const pending = useChatStore.getState().sendPrompt('hello', SESSION_ID);
+    // Let sendPrompt reach the streamAgentResponse call.
+    await Promise.resolve();
+
+    useChatStore.getState().stopPrompt(SESSION_ID);
+    expect(capturedSignal?.aborted).toBe(true);
+
+    release();
+    await pending;
+  });
+
+  it('settles the session (isLoading false, no error) after stopPrompt', async () => {
+    // Simulate the api layer invoking onCancel when the signal aborts.
+    streamAgentResponse.mockImplementation(async (...args: unknown[]) => {
+      const callbacks = args[2] as { onCancel?: () => void };
+      const signal = args[4] as AbortSignal;
+      await new Promise<void>((resolve) => signal.addEventListener('abort', () => resolve()));
+      callbacks.onCancel?.();
+    });
+
+    const pending = useChatStore.getState().sendPrompt('hello', SESSION_ID);
+    await Promise.resolve();
+    useChatStore.getState().stopPrompt(SESSION_ID);
+    await pending;
+
+    const state = useChatStore.getState().sessions[SESSION_ID];
+    expect(state.isLoading).toBe(false);
+    expect(state.error).toBeNull();
+  });
+
+  it('appends a "generation stopped" notice to the assistant message on cancel', async () => {
+    streamAgentResponse.mockImplementation(async (...args: unknown[]) => {
+      const callbacks = args[2] as { onCancel?: () => void };
+      const signal = args[4] as AbortSignal;
+      await new Promise<void>((resolve) => signal.addEventListener('abort', () => resolve()));
+      callbacks.onCancel?.();
+    });
+
+    const pending = useChatStore.getState().sendPrompt('hello', SESSION_ID);
+    await Promise.resolve();
+    useChatStore.getState().stopPrompt(SESSION_ID);
+    await pending;
+
+    const state = useChatStore.getState().sessions[SESSION_ID];
+    const assistant = state.messages.find((m) => m.type === 'assistant');
+    // A visible notice must be present so the user knows the turn was stopped.
+    const notice = assistant?.contents.find(
+      (c) => c.type === 'text' && typeof c.text === 'string' && c.text.length > 0
+    );
+    expect(notice).toBeDefined();
+    // Not streaming anymore, and it is not flagged as an error.
+    expect(assistant?.isStreaming).toBe(false);
+    expect(assistant?.isError).toBeFalsy();
+  });
+});

--- a/packages/frontend/src/stores/chatStore.ts
+++ b/packages/frontend/src/stores/chatStore.ts
@@ -10,7 +10,8 @@ import type {
   ToolResult,
   ImageAttachment,
 } from '../types/index';
-import { streamAgentResponse } from '../api/agent';
+import { streamAgentResponse, stopAgentTurn } from '../api/agent';
+import i18n from '../i18n';
 import type { ConversationMessage } from '../api/sessions';
 import { useAgentStore } from './agentStore';
 import { useStorageStore } from './storageStore';
@@ -18,6 +19,15 @@ import { useSessionStore } from './sessionStore';
 import { useMemoryStore } from './memoryStore';
 import { useSettingsStore } from './settingsStore';
 import { logger } from '../utils/logger';
+
+// Per-session AbortController for the in-flight turn, keyed by sessionId.
+//
+// WHY module-level (not Zustand state): AbortController is a live, non-
+// serializable object — putting it in the store would break devtools
+// serialization and persistence, and it has no bearing on rendered UI (the UI
+// keys off `isLoading`). The Stop button only needs to reach the controller by
+// sessionId, which this map provides.
+const abortControllers = new Map<string, AbortController>();
 
 // Helper function: Convert image to Base64
 const convertImageToBase64 = (file: File): Promise<string> => {
@@ -121,6 +131,8 @@ interface ChatActions {
   addMessage: (sessionId: string, message: Omit<Message, 'id' | 'timestamp'>) => string;
   updateMessage: (sessionId: string, messageId: string, updates: Partial<Message>) => void;
   sendPrompt: (prompt: string, sessionId: string, images?: ImageAttachment[]) => Promise<void>;
+  /** Abort the in-flight turn for a session (Stop button). No-op if none running. */
+  stopPrompt: (sessionId: string) => void;
   clearSession: (sessionId: string) => void;
   setLoading: (sessionId: string, loading: boolean) => void;
   setError: (sessionId: string, error: string | null) => void;
@@ -229,6 +241,11 @@ export const useChatStore = create<ChatStore>()(
 
         // Set activeSessionId (for streaming callbacks to work correctly)
         set({ activeSessionId: sessionId });
+
+        // Fresh AbortController for this turn so the Stop button (stopPrompt)
+        // can tear down the fetch. Replaces any stale controller for the session.
+        const abortController = new AbortController();
+        abortControllers.set(sessionId, abortController);
 
         // Get/create session state
         const sessionState = getOrCreateSessionState(sessions, sessionId);
@@ -510,6 +527,46 @@ export const useChatStore = create<ChatStore>()(
                   useSessionStore.getState().refreshSessions();
                 }
               },
+              onCancel: () => {
+                // The turn was stopped by the user. Settle the streaming message
+                // and clear loading WITHOUT setting an error — whatever partial
+                // content already streamed is kept as the assistant's reply, and
+                // we append a visible notice so the user can see it was stopped
+                // (not silently finished).
+                const currentMessage = get().sessions[sessionId]?.messages.find(
+                  (msg) => msg.id === assistantMessageId
+                );
+                const noticeContent = {
+                  type: 'text' as const,
+                  text: `_${i18n.t('chat.generationStopped')}_`,
+                };
+                updateMessage(sessionId, assistantMessageId, {
+                  contents: [...(currentMessage?.contents ?? []), noticeContent],
+                  isStreaming: false,
+                });
+
+                // Re-read AFTER updateMessage so we don't clobber the appended
+                // notice with a stale snapshot.
+                const { sessions, lastStreamCompletedAt } = get();
+                const currentState = sessions[sessionId] || createDefaultSessionState();
+
+                set({
+                  sessions: {
+                    ...sessions,
+                    [sessionId]: {
+                      ...currentState,
+                      isLoading: false,
+                      error: null,
+                    },
+                  },
+                  lastStreamCompletedAt: {
+                    ...lastStreamCompletedAt,
+                    [sessionId]: Date.now(),
+                  },
+                });
+
+                logger.log(`Message send cancelled (session: ${sessionId})`);
+              },
               onError: (error: Error) => {
                 // Add error message as assistant response (with isError flag)
                 const { sessions } = get();
@@ -547,7 +604,8 @@ export const useChatStore = create<ChatStore>()(
                 });
               },
             },
-            agentConfig
+            agentConfig,
+            abortController.signal
           );
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : 'Failed to send message';
@@ -565,7 +623,34 @@ export const useChatStore = create<ChatStore>()(
               },
             },
           });
+        } finally {
+          // Drop the controller once the turn settles (complete/cancel/error) so
+          // a later Stop click can't abort an already-finished — or the next —
+          // turn. Only clear if it's still the one we installed.
+          if (abortControllers.get(sessionId) === abortController) {
+            abortControllers.delete(sessionId);
+          }
         }
+      },
+
+      stopPrompt: (sessionId: string) => {
+        // Two independent effects, both needed:
+        //   1. Server-side stop — the ONLY thing that actually halts the agent.
+        //      AgentCore ignores the client disconnect, so we send an explicit
+        //      out-of-band stop command (fire-and-forget; it acks quickly).
+        //   2. Client-side abort — tears down the local fetch so the UI settles
+        //      immediately instead of waiting for the server's cancel to land.
+        //      The reader loop's AbortError routes to onCancel.
+        stopAgentTurn(sessionId).catch(() => {
+          // stopAgentTurn already swallows errors; this is just belt-and-suspenders.
+        });
+
+        const controller = abortControllers.get(sessionId);
+        if (controller) {
+          controller.abort();
+          abortControllers.delete(sessionId);
+        }
+        logger.log(`Stop requested (session: ${sessionId})`);
       },
 
       clearSession: (sessionId: string) => {


### PR DESCRIPTION
## What

Adds a **Stop button** so users can interrupt a running agent turn from the chat UI.

## Why the transport approach does not work (and what we do instead)

AgentCore Runtime does **not** propagate a client `fetch` abort to the container — verified in CloudWatch: after Stop, the turn logged `Agent streaming started → completed` with no disconnect and no cancel. AWS docs confirm the server-side turn keeps running after a client disconnect.

So cancellation is driven by an **out-of-band stop command**, relying on AgentCore's microVM stickiness (same session-id header → same microVM → same process):

1. **Frontend** — `chatStore.stopPrompt` sends `stopAgentTurn(sessionId)` (a 2nd `POST /invocations` with `{action:'stop'}` and the same session header) **and** aborts the local fetch so the UI settles immediately. `onCancel` appends a "生成を停止しました / Generation stopped" notice while keeping partial output.
2. **Agent** — `stopDispatchMiddleware` short-circuits the `{action:'stop'}` body, looks the in-flight `Agent` up in a process-global cancel registry (`agent-cancel-registry.ts`), and calls `agent.cancel()`. The streaming turn then returns `stopReason: 'cancelled'` and the handler emits a `serverCancelledEvent` (not an error).
3. **Sub-agents** — cancellable via `cancelTasksByParentSession`, keyed on the parent turn's request-context `sessionId`.

## Known limitation (by design)

Cancel is honored at SDK checkpoints (during model streaming, before/between tool calls, at loop top). If the agent is blocked **inside** a long-running tool (`execute_command`, `code_interpreter`, MCP, etc.), it stops at the next checkpoint after the tool returns — no tool threads the cancel signal into its work. The visible "stopped" notice is the agreed UX for that case.

## Tests

- Agent: `agent-cancel-registry`, `stop-dispatch`, `stream-handler` (registry + serverCancelledEvent), `sub-agent-task-manager.cancel`, `call-agent.parent-session`, plus a real-Agent `cancellation.e2e` (no AWS).
- Frontend: `agent.cancel`, `chatStore.stopPrompt`.
- Full suites green (agent 500, frontend 215), typecheck + lint clean.
- Verified end-to-end locally in a real browser: Stop mid-stream keeps partial output and shows the stopped notice.

## Notes

- Environment config (`packages/cdk/config/environments.ts`) is intentionally **not** included in this PR.
