### PR TITLE
feat(models): add Claude Opus 5 (global.anthropic.claude-opus-5)

### DIFF
--- a/packages/agent/skills/moca-guide/references/models.md
+++ b/packages/agent/skills/moca-guide/references/models.md
@@ -5,12 +5,12 @@ they start work. Extended thinking is controlled separately by reasoning depth.
 
 ## Choosing a model
 
-The default is **Claude Opus 4.8** — the strongest general model; a good default
+The default is **Claude Opus 5** — the strongest general model; a good default
 when unsure. The available catalog (deployment-dependent):
 
 | Model | Provider | Extended thinking |
 |---|---|---|
-| Claude Opus 4.8 (default), 4.7, 4.6 | Anthropic | yes (up to `max`) |
+| Claude Opus 5 (default), Opus 4.8, 4.7, 4.6 | Anthropic | yes (up to `max`) |
 | Claude Fable 5 | Anthropic | yes (up to `max`; needs data-share mode in-region) |
 | Claude Sonnet 5, Sonnet 4.6 | Anthropic | yes (capped at `high`) |
 | Nova Lite 2 | Amazon | no |

--- a/packages/cdk/config/environment-utils.ts
+++ b/packages/cdk/config/environment-utils.ts
@@ -88,7 +88,13 @@ const DEFAULT_CONFIG = {
    */
   bedrockModels: [
     {
-      // Default model. No account-level prerequisite, so it works out of the box.
+      // Default model. No account-level prerequisites, no region pin required.
+      id: 'global.anthropic.claude-opus-5',
+      name: 'Claude Opus 5',
+      provider: 'Anthropic',
+    },
+    {
+      // No account-level prerequisite, so it works out of the box.
       id: 'global.anthropic.claude-opus-4-8',
       name: 'Claude Opus 4.8',
       provider: 'Anthropic',

--- a/packages/libs/core/src/__tests__/bedrock-models.test.ts
+++ b/packages/libs/core/src/__tests__/bedrock-models.test.ts
@@ -121,18 +121,18 @@ describe('BEDROCK_MODEL_DEFINITIONS invariants', () => {
     }
   });
 
-  it('registers Claude Opus 4.8 as the default (first) model with the correct limit', () => {
+  it('registers Claude Opus 5 as the default (first) model with the correct limit', () => {
     const first = BEDROCK_MODEL_DEFINITIONS[0];
-    expect(first.id).toBe('global.anthropic.claude-opus-4-8');
-    expect(first.name).toBe('Claude Opus 4.8');
+    expect(first.id).toBe('global.anthropic.claude-opus-5');
+    expect(first.name).toBe('Claude Opus 5');
     expect(first.provider).toBe('Anthropic');
-    expect(getMaxOutputTokens('global.anthropic.claude-opus-4-8')).toBe(128000);
+    expect(getMaxOutputTokens('global.anthropic.claude-opus-5')).toBe(128000);
   });
 
-  it('does not region-pin the default model (Opus 4.8 must use the deploy region)', () => {
+  it('does not region-pin the default model (Opus 5 must use the deploy region)', () => {
     // The default model must work in any deployment region with no special
     // account setup, so it must not be pinned to a specific region.
-    expect(getModelRegion('global.anthropic.claude-opus-4-8')).toBeUndefined();
+    expect(getModelRegion('global.anthropic.claude-opus-5')).toBeUndefined();
   });
 
   it('only reasoning-capable models declare a max-effort cap', () => {

--- a/packages/libs/core/src/bedrock-models.ts
+++ b/packages/libs/core/src/bedrock-models.ts
@@ -136,8 +136,21 @@ export type BedrockEndpoint = 'bedrock-openai' | 'mantle';
  */
 export const BEDROCK_MODEL_DEFINITIONS = [
   {
-    // Default model. No account-level prerequisite (unlike Fable 5's data
-    // retention requirement), so it works out of the box in every region.
+    // Default model. GA on Bedrock 2026-07-23. 1M context window, 128k max
+    // output. Standard bedrock-runtime Converse/ConverseStream path — no
+    // special account prerequisites (unlike Fable 5's data-share requirement),
+    // so it works out of the box in every region.
+    // Adaptive thinking ON by default; Opus-tier → effort: 'max' is supported.
+    // Source: AWS Bedrock model card, 2026-07-23.
+    id: 'global.anthropic.claude-opus-5',
+    name: 'Claude Opus 5',
+    provider: 'Anthropic',
+    maxOutputTokens: 128000, // 128k (AWS Bedrock model card, 2026-07-23)
+    reasoningCapable: true, // adaptive thinking + output_config.effort; max OK (Opus-tier)
+  },
+  {
+    // No account-level prerequisite (unlike Fable 5's data retention
+    // requirement), so it works out of the box in every region.
     id: 'global.anthropic.claude-opus-4-8',
     name: 'Claude Opus 4.8',
     provider: 'Anthropic',


### PR DESCRIPTION
Closes #79

## Summary

Adds **Claude Opus 5** (`global.anthropic.claude-opus-5`, GA on Amazon Bedrock 2026-07-23) as a selectable model. It uses the standard **Converse API** and is pattern-identical to the existing Claude Opus 4.8 entry — no new API integration, endpoint type, or account prerequisites. Inserted at the **top** of the model list, so it becomes the **new default model** (as specified in the issue).

## Changes

- **`packages/libs/core/src/bedrock-models.ts`** — new `BEDROCK_MODEL_DEFINITIONS` entry at the top: `id`, `name`, `provider`, `maxOutputTokens: 128000`, `reasoningCapable: true`. No `reasoningMaxEffort` (Opus-tier defaults to `max`), no `region` pin, no `endpoint` override (standard Converse). Updated the Opus 4.8 comment (no longer the default).
- **`packages/cdk/config/environment-utils.ts`** — mirrored the entry at the top of `DEFAULT_CONFIG.bedrockModels` (`id`/`name`/`provider`), keeping the hand-synced SSoT in step.
- **`packages/agent/skills/moca-guide/references/models.md`** — updated the model table row and the default-model prose to reference Opus 5.
- **`packages/libs/core/src/__tests__/bedrock-models.test.ts`** — updated the default (first) model assertion from Opus 4.8 → Opus 5 (this test would otherwise fail after top-insertion, as flagged in the issue's feasibility comment).

## Notes

- The **frontend default** (`DEFAULT_MODEL_ID = AVAILABLE_MODELS[0]?.id`) derives positionally from the SSoT, so it picks up Opus 5 automatically — no frontend edit required.
- When `depth='off'`, `getReasoningConfig` already returns `undefined` (sends no effort field), so the model-side "effort capped at high when thinking disabled" note needs no code change.

## Verification

- `@moca/core` tests: **100 passed** (`vitest run`)
- `@moca/cdk` tests: **33 passed** (incl. `validateBedrockModels` shape/region checks)
- `npm run build:ts`: clean (typecheck OK)
- Live smoke test (invoke `global.anthropic.claude-opus-5` via Converse, confirm `effort: 'max'` accepted) still recommended before merge — see issue checklist.