### PR TITLE
feat(models): add OpenAI GPT-5.6 Sol/Terra/Luna (bedrock-mantle / Responses API)

### DIFF
--- a/packages/agent/skills/moca-guide/references/models.md
+++ b/packages/agent/skills/moca-guide/references/models.md
@@ -15,6 +15,7 @@ when unsure. The available catalog (deployment-dependent):
 | Claude Sonnet 5, Sonnet 4.6 | Anthropic | yes (capped at `high`) |
 | Nova Lite 2 | Amazon | no |
 | Qwen3 Coder Next | Qwen | no |
+| GPT-5.6 Sol / Terra / Luna | OpenAI | no |
 | GPT-5.5 / GPT-5.4 | OpenAI | no |
 | GPT-OSS 120B / 20B | OpenAI | no |
 

--- a/packages/cdk/config/environment-utils.ts
+++ b/packages/cdk/config/environment-utils.ts
@@ -161,6 +161,34 @@ const DEFAULT_CONFIG = {
       endpoint: 'mantle',
     },
     {
+      // OpenAI GPT-5.6 Sol via Bedrock Mantle. GA 2026-07-13; pinned to
+      // us-east-1 to match the other Mantle models (also available in
+      // us-east-2). MUST stay in sync with BEDROCK_MODEL_DEFINITIONS.
+      id: 'openai.gpt-5.6-sol',
+      name: 'GPT-5.6 Sol',
+      provider: 'OpenAI',
+      region: 'us-east-1',
+      endpoint: 'mantle',
+    },
+    {
+      // OpenAI GPT-5.6 Terra via Bedrock Mantle. Pinned to us-east-1 (also
+      // available in us-east-2 and us-west-2).
+      id: 'openai.gpt-5.6-terra',
+      name: 'GPT-5.6 Terra',
+      provider: 'OpenAI',
+      region: 'us-east-1',
+      endpoint: 'mantle',
+    },
+    {
+      // OpenAI GPT-5.6 Luna via Bedrock Mantle. Pinned to us-east-1 (also
+      // available in us-east-2 and us-west-2).
+      id: 'openai.gpt-5.6-luna',
+      name: 'GPT-5.6 Luna',
+      provider: 'OpenAI',
+      region: 'us-east-1',
+      endpoint: 'mantle',
+    },
+    {
       // OpenAI GPT-OSS (open-weight) via Bedrock's OpenAI-compatible Chat
       // Completions endpoint. Bare id → foundation-model ARN only (same IAM
       // shape as qwen.*). No region pin: available in ap-northeast-1 and

--- a/packages/libs/core/src/bedrock-models.ts
+++ b/packages/libs/core/src/bedrock-models.ts
@@ -266,6 +266,40 @@ export const BEDROCK_MODEL_DEFINITIONS = [
     endpoint: 'mantle',
   },
   {
+    // OpenAI GPT-5.6 Sol on Bedrock (Mantle). Same Responses-API path as
+    // GPT-5.5/5.4. GA on Bedrock 2026-07-13; available in us-east-1 and
+    // us-east-2. Pin to us-east-1 to match the existing Mantle region so one
+    // region serves all GPT-5.x models. maxOutputTokens mirrors GPT-5.5.
+    id: 'openai.gpt-5.6-sol',
+    name: 'GPT-5.6 Sol',
+    provider: 'OpenAI',
+    maxOutputTokens: 128000,
+    region: 'us-east-1',
+    endpoint: 'mantle',
+  },
+  {
+    // OpenAI GPT-5.6 Terra on Bedrock (Mantle). Available in us-east-1,
+    // us-east-2, and us-west-2; pinned to us-east-1 for parity with the other
+    // Mantle models.
+    id: 'openai.gpt-5.6-terra',
+    name: 'GPT-5.6 Terra',
+    provider: 'OpenAI',
+    maxOutputTokens: 128000,
+    region: 'us-east-1',
+    endpoint: 'mantle',
+  },
+  {
+    // OpenAI GPT-5.6 Luna on Bedrock (Mantle). Available in us-east-1,
+    // us-east-2, and us-west-2; pinned to us-east-1 for parity with the other
+    // Mantle models.
+    id: 'openai.gpt-5.6-luna',
+    name: 'GPT-5.6 Luna',
+    provider: 'OpenAI',
+    maxOutputTokens: 128000,
+    region: 'us-east-1',
+    endpoint: 'mantle',
+  },
+  {
     // OpenAI GPT-OSS (open-weight) on Bedrock. Invoked via the OpenAI-compatible
     // Chat Completions endpoint on the standard runtime host
     // (bedrock-runtime.{region}.amazonaws.com/openai/v1), NOT Converse and NOT


### PR DESCRIPTION
Closes #74

## Summary

Adds **OpenAI GPT-5.6 Sol, Terra, and Luna** (GA on Amazon Bedrock 2026-07-13) to the model catalog. This is a **pure config addition** — the `bedrock-mantle` / Responses API transport (base URL, `api: 'responses'`, bearer-token auth, `reasoning: { effort: 'none' }`), the `createBedrockModel()` routing, and the CDK `bedrock-mantle:` IAM grants already exist and are exercised by GPT-5.5/5.4. No new client, routing, or IAM code is required.

## Changes

- **`packages/libs/core/src/bedrock-models.ts`** (SSoT) — 3 new `BEDROCK_MODEL_DEFINITIONS` entries after GPT-5.4: `endpoint: 'mantle'`, `region: 'us-east-1'`, `maxOutputTokens: 128000`, `provider: 'OpenAI'`.
- **`packages/cdk/config/environment-utils.ts`** — mirror the 3 entries in `DEFAULT_CONFIG.bedrockModels` (CDK does not import `@moca/core`; hand-synced). The `region` pin drives the scoped Mantle inference-profile IAM ARN, so it must match the SSoT.
- **`packages/agent/skills/moca-guide/references/models.md`** — add a `GPT-5.6 Sol / Terra / Luna` row.

## What does NOT change

`bedrock-openai-model.ts`, `bedrock.ts` (`createBedrockModel`), the CDK IAM statements (`hasMantleModel()` already `true` via GPT-5.5), and the frontend selector (reads the SSoT via `FALLBACK_MODELS`) — all endpoint-agnostic / already Mantle-aware.

## Verification

- `@moca/core` tests: **100 passed** (`vitest run`)
- `@moca/cdk` tests: **33 passed** (incl. `deriveBedrockIamResources` / `hasMantleModel` / `validateBedrockModels` region-pin checks)
- `npm run build:ts`: clean (typecheck OK)

## Open items for a human before merge (external Bedrock facts, per the issue checklist)

- Confirm each model ID is `ACTIVE` on Bedrock (`aws bedrock get-foundation-model --model-identifier openai.gpt-5.6-sol` etc.).
- Verify `maxOutputTokens: 128000` against the AWS model cards (conservative value mirroring GPT-5.5; wrong value doesn't break deploy but may truncate/over-request).
- Live Responses-API round-trip in us-east-1 per model; confirm `reasoning: { effort: 'none' }` is still the correct handling for 5.6 under tool calls (current code applies it uniformly to all Mantle models, so 5.6 inherits the safe path).
- All three are pinned to `us-east-1` for parity even though Terra/Luna are also listed for us-east-2/us-west-2 — confirm us-east-1 is the intended invocation region.