### PR TITLE
chore(ci): add dependabot config with grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@
 #   Grouping rules defined here also override the repository/organization
 #   "grouped security updates" UI setting.
 #
+#   Each ecosystem also sets a `cooldown` so newly published versions age before
+#   being proposed (supply-chain protection). Cooldown applies to version updates
+#   only -- security updates still open immediately.
+#
 # Docs: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
 version: 2
 updates:
@@ -25,6 +29,20 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "Asia/Tokyo"
+    # Let a release age before adopting it: if a maintainer account is
+    # compromised and a malicious version is published, most such releases are
+    # caught and yanked within a few days. The cooldown gives scanners and the
+    # community that window before Dependabot proposes the bump.
+    #
+    # This affects VERSION updates only. Security updates for known
+    # vulnerabilities still open immediately, so vulnerability fixes are never
+    # delayed by these settings. (Patches use a shorter window than minor/major
+    # since they carry the least change.)
+    cooldown:
+      default-days: 7
+      semver-major-days: 7
+      semver-minor-days: 7
+      semver-patch-days: 3
     open-pull-requests-limit: 3
     labels:
       - "dependencies"
@@ -61,6 +79,11 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "Asia/Tokyo"
+    # Same supply-chain cooldown as npm (version updates only; security updates
+    # are unaffected). Action release tags are typically major-only, so a single
+    # default window is enough here.
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 2
     labels:
       - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,79 @@
+# Dependabot configuration
+#
+# Why this file exists:
+#   Without a dependabot.yml, only security updates run and each vulnerable
+#   dependency gets its own pull request. That produced a backlog of individual
+#   `chore(deps): bump ...` PRs that all touch package-lock.json, so every one of
+#   them needed a separate CI run and a separate manual verification pass.
+#
+#   The `groups` option below collapses those into a single PR per category.
+#   Note that a single set of grouping rules cannot apply to both version updates
+#   and security updates, so each category is defined separately via `applies-to`.
+#   Grouping rules defined here also override the repository/organization
+#   "grouped security updates" UI setting.
+#
+# Docs: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+version: 2
+updates:
+  # ---------------------------------------------------------------------------
+  # npm (single lockfile at the repository root; all packages/* are workspaces)
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: "scope"
+    groups:
+      # All security updates land in one PR so a single verification pass covers
+      # the whole batch.
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      # Routine minor/patch updates are batched as well. Major bumps are
+      # deliberately excluded from this group so that Dependabot keeps raising
+      # them as individual PRs, which keeps breaking changes reviewable in
+      # isolation.
+      npm-minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ---------------------------------------------------------------------------
+  # GitHub Actions (workflow `uses:` refs are SHA-pinned, so they need bumping)
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 2
+    labels:
+      - "dependencies"
+      - "github_actions"
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"
+    groups:
+      actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      actions-all:
+        applies-to: version-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds a `.github/dependabot.yml` so that Dependabot batches its updates into a
small number of pull requests instead of opening one per dependency.

## Problem

The repository currently has no Dependabot configuration file. As a result only
security updates run, and each vulnerable dependency gets its own pull request.
At the time of writing, 6 of the 13 open PRs were individual Dependabot bumps
(#64, #65, #75, #76, #77, #78), all of them touching `package-lock.json`.

Because they overlap on the same lockfile, they cannot simply be merged one after
another, and each one triggers a full CI run plus a separate manual verification
pass. #63 already had to combine three of them by hand.

## Change

`groups` collapses the updates per category:

| Ecosystem | Group | Applies to | Scope |
|-----------|-------|------------|-------|
| npm | `npm-security` | `security-updates` | all packages |
| npm | `npm-minor-and-patch` | `version-updates` | `minor` + `patch` only |
| github-actions | `actions-security` | `security-updates` | all actions |
| github-actions | `actions-all` | `version-updates` | all actions |

Notes on the design:

- A single set of grouping rules cannot apply to both version updates and
  security updates, so each category is defined separately with `applies-to`.
- Major npm bumps are deliberately left out of `npm-minor-and-patch`, so
  Dependabot keeps raising them as individual PRs and breaking changes stay
  reviewable in isolation.
- `github-actions` is included because the workflow `uses:` refs in
  `.github/workflows/` are SHA-pinned and therefore need bumping too.
- Only one `npm` entry is needed: there is a single `package-lock.json` at the
  repository root and everything under `packages/*` is an npm workspace.
- `commit-message.prefix` is set to `chore(deps)` / `chore(deps-dev)` /
  `chore(ci)` to stay consistent with the existing commit history.
- Grouping rules defined in this file override the repository/organization
  "grouped security updates" UI setting, so the behaviour is now explicit in the
  repository.

## Verification

- `dependabot.yml` parses as valid YAML and every `groups` entry resolves as
  expected.
- `npx prettier --check .github/dependabot.yml` passes.
- No application code is touched, so runtime behaviour is unchanged.

## Follow-up

The 6 Dependabot PRs that are already open predate this configuration and will
not be regrouped retroactively; they are being combined separately.
