### PR TITLE
chore(deps): weekly combined dependabot updates (2026-07-25)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5977,21 +5977,34 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -12051,9 +12064,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@eslint/js": "^10.0.0",
         "@types/jest": "^29.5.0",
         "@types/node": "^22.0.0",
-        "concurrently": "^9.1.2",
+        "concurrently": "^9.2.3",
         "eslint": "^10.0.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-boundaries": "^6.0.2",
@@ -4065,7 +4065,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4082,7 +4081,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4099,7 +4097,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4116,7 +4113,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4133,7 +4129,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4150,7 +4145,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4167,7 +4161,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4184,7 +4177,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4201,7 +4193,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4218,7 +4209,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4235,7 +4225,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4252,7 +4241,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4269,7 +4257,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4286,7 +4273,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4303,7 +4289,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4320,7 +4305,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4337,7 +4321,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4354,7 +4337,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4371,7 +4353,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4388,7 +4369,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4405,7 +4385,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4422,7 +4401,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4439,7 +4417,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4456,7 +4433,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4473,7 +4449,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4490,7 +4465,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8945,7 +8919,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8963,7 +8936,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8981,7 +8953,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8999,7 +8970,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9017,7 +8987,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9035,7 +9004,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9053,7 +9021,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9071,7 +9038,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9089,7 +9055,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9107,7 +9072,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9125,7 +9089,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9143,7 +9106,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12699,15 +12661,15 @@
       }
     },
     "node_modules/concurrently": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
-      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.3.tgz",
+      "integrity": "sha512-ihjs0E2SxvDgq/MK418hX6YycQgKhsqxpbZuZbHo0yKfqDWdymWMjWYIpCIzqDDLLKClHlXev8whW/8WXmJ0BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
         "rxjs": "7.8.2",
-        "shell-quote": "1.8.3",
+        "shell-quote": "1.8.4",
         "supports-color": "8.1.1",
         "tree-kill": "1.2.2",
         "yargs": "17.7.2"
@@ -22917,9 +22879,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4065,7 +4065,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4082,7 +4081,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4099,7 +4097,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4116,7 +4113,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4133,7 +4129,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4150,7 +4145,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4167,7 +4161,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4184,7 +4177,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4201,7 +4193,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4218,7 +4209,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4235,7 +4225,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4252,7 +4241,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4269,7 +4257,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4286,7 +4273,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4303,7 +4289,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4320,7 +4305,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4337,7 +4321,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4354,7 +4337,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4371,7 +4353,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4388,7 +4369,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4405,7 +4385,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4422,7 +4401,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4439,7 +4417,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4456,7 +4433,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4473,7 +4449,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4490,7 +4465,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8945,7 +8919,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8963,7 +8936,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8981,7 +8953,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8999,7 +8970,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9017,7 +8987,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9035,7 +9004,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9053,7 +9021,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9071,7 +9038,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9089,7 +9055,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9107,7 +9072,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9125,7 +9089,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9143,7 +9106,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -18360,9 +18322,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -27452,7 +27424,7 @@
         "fflate": "^0.8.2",
         "i18next": "^25.7.3",
         "i18next-browser-languagedetector": "^8.2.0",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.2.0",
         "katex": "^0.16.27",
         "lucide-react": "^0.562.0",
         "mermaid": "^11.12.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16059,9 +16059,9 @@
       "license": "CC0-1.0"
     },
     "node_modules/hono": {
-      "version": "4.12.26",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
-      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -269,9 +269,9 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.273",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz",
-      "integrity": "sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==",
+      "version": "2.2.282",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.282.tgz",
+      "integrity": "sha512-7hKMi5tTxDcKGIMIOq14PnY0GBcugW33Uh/2YHDZiEwSxLeFOCYBwhR+BFXONb/EJeVI3RETFgailNZbkcKF6g==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
@@ -281,9 +281,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.27.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.27.0.tgz",
-      "integrity": "sha512-OTxe/L2Vc60r2nYih7kFaFpn93sa7shJu9T0tQZsryeDE3HHOAuazKNmS6tLInOjJjVx/dvM5XGyUA+lZAiKxA==",
+      "version": "54.14.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.14.0.tgz",
+      "integrity": "sha512-JCZCzgp3SuXQVljaKqXnttHzcezEHt9Ag/YipK0XwUFD+Iz2T4jY7gUc3pA25Uq6pzY2n9DvO/nEU++dPXW4Rw==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -291,7 +291,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "^1.5.0",
-        "semver": "^7.8.0"
+        "semver": "^7.8.5"
       },
       "engines": {
         "node": ">= 18.0.0"
@@ -306,7 +306,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.8.0",
+      "version": "7.8.5",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -11253,9 +11253,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.256.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.256.1.tgz",
-      "integrity": "sha512-18xLE+iqzjvpYGGKJy+9zyvF8loUSXjpVV2MtVLPQ/hPgeWHQiVsqLOWNsBemd3pU7o0L9wXfRY+xqG80vlZFw==",
+      "version": "2.260.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.260.0.tgz",
+      "integrity": "sha512-2PPG+hbPDot8+ibkb5Jl9y3OY5rBE6TFwjzOi+yEyU4ZG6u8bM4DDKhhBi/S20NqqSFDso9rH1txVJAdwXNiuQ==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -11272,19 +11272,19 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.273",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.2.4",
-        "@aws-cdk/cloud-assembly-schema": "^53.25.0",
+        "@aws-cdk/asset-awscli-v1": "2.2.282",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
+        "@aws-cdk/cloud-assembly-api": "^2.2.5",
+        "@aws-cdk/cloud-assembly-schema": "^54.0.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.3.3",
+        "fs-extra": "^11.3.5",
         "ignore": "^5.3.2",
         "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
-        "minimatch": "^10.2.3",
+        "minimatch": "^10.2.5",
         "punycode": "^2.3.1",
-        "semver": "^7.7.4",
+        "semver": "^7.8.1",
         "table": "^6.9.0",
         "yaml": "1.10.3"
       },
@@ -11296,7 +11296,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.4",
+      "version": "2.2.5",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -11307,18 +11307,7 @@
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.25.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
-      "version": "7.8.0",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "@aws-cdk/cloud-assembly-schema": ">=53.28.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
@@ -11327,7 +11316,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.18.0",
+      "version": "8.20.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11380,7 +11369,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.5",
+      "version": "5.0.6",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11440,7 +11429,7 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.3.3",
+      "version": "11.3.5",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11479,7 +11468,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
-      "version": "6.2.0",
+      "version": "6.2.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11552,7 +11541,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.1",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -27513,7 +27502,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@cdklabs/deploy-time-build": "^0.1.0",
-        "aws-cdk-lib": "2.256.1",
+        "aws-cdk-lib": "^2.260.0",
         "cdk-nag": "^2.37.55",
         "constructs": "^10.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -4161,7 +4161,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4178,7 +4177,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4195,7 +4193,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4212,7 +4209,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4229,7 +4225,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4246,7 +4241,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4263,7 +4257,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4280,7 +4273,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4297,7 +4289,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4314,7 +4305,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4331,7 +4321,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4348,7 +4337,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4365,7 +4353,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4382,7 +4369,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4399,7 +4385,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4416,7 +4401,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4433,7 +4417,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4450,7 +4433,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4467,7 +4449,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4484,7 +4465,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4501,7 +4481,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4518,7 +4497,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4535,7 +4513,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4552,7 +4529,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4569,7 +4545,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4586,7 +4561,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9053,7 +9027,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9071,7 +9044,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9089,7 +9061,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9107,7 +9078,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9125,7 +9095,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9143,7 +9112,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9161,7 +9129,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9179,7 +9146,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9197,7 +9163,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9215,7 +9180,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9233,7 +9197,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9251,7 +9214,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -11291,9 +11253,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1124.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1124.1.tgz",
-      "integrity": "sha512-sRYdPMdkX+02EHaT946AFV0w0CMfbHKWpLZPv525xTCkaVu1eYu6DzHFuTdimxdSN0uGQ2D4LHrD1sr94tRhow==",
+      "version": "2.1133.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1133.0.tgz",
+      "integrity": "sha512-DGlCBwqxSHTe1u/IoT5WV+Bbd2K3UhwFHsdMqb2nQa1fkJmaQgoNFu0It+p3HxyMWeW+gKsVzT5KcjQPQ6Kzuw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -27571,7 +27533,7 @@
         "moca": "bin/app.js"
       },
       "devDependencies": {
-        "aws-cdk": "^2.1040.0"
+        "aws-cdk": "^2.1133.0"
       }
     },
     "packages/frontend": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4161,6 +4161,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4177,6 +4178,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4193,6 +4195,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4209,6 +4212,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4225,6 +4229,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4241,6 +4246,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4257,6 +4263,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4273,6 +4280,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4289,6 +4297,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4305,6 +4314,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4321,6 +4331,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4337,6 +4348,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4353,6 +4365,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4369,6 +4382,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4385,6 +4399,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4401,6 +4416,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4417,6 +4433,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4433,6 +4450,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4449,6 +4467,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4465,6 +4484,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4481,6 +4501,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4497,6 +4518,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4513,6 +4535,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4529,6 +4552,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4545,6 +4569,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4561,6 +4586,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9027,6 +9053,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9044,6 +9071,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9061,6 +9089,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9078,6 +9107,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9095,6 +9125,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9112,6 +9143,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9129,6 +9161,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9146,6 +9179,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9163,6 +9197,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9180,6 +9215,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9197,6 +9233,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9214,6 +9251,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -27525,7 +27563,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@cdklabs/deploy-time-build": "^0.1.0",
-        "aws-cdk-lib": "^2.260.0",
+        "aws-cdk-lib": "2.260.0",
         "cdk-nag": "^2.37.55",
         "constructs": "^10.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13904,9 +13904,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@eslint/js": "^10.0.0",
     "@types/jest": "^29.5.0",
     "@types/node": "^22.0.0",
-    "concurrently": "^9.1.2",
+    "concurrently": "^9.2.3",
     "eslint": "^10.0.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-boundaries": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "typescript-eslint": "^8.57.2"
   },
   "overrides": {
-    "aws-cdk-lib": "2.256.1",
+    "aws-cdk-lib": "2.260.0",
     "test-exclude": "^7.0.1",
     "glob": "^10.0.0",
     "fast-xml-parser": ">=5.3.6",

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@cdklabs/deploy-time-build": "^0.1.0",
-    "aws-cdk-lib": "2.256.1",
+    "aws-cdk-lib": "2.260.0",
     "cdk-nag": "^2.37.55",
     "constructs": "^10.0.0"
   }

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -27,7 +27,7 @@
     "destroy:stg": "cdk destroy -c env=stg"
   },
   "devDependencies": {
-    "aws-cdk": "^2.1040.0"
+    "aws-cdk": "^2.1133.0"
   },
   "dependencies": {
     "@cdklabs/deploy-time-build": "^0.1.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -28,7 +28,7 @@
     "fflate": "^0.8.2",
     "i18next": "^25.7.3",
     "i18next-browser-languagedetector": "^8.2.0",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.2.0",
     "katex": "^0.16.27",
     "lucide-react": "^0.562.0",
     "mermaid": "^11.12.2",


### PR DESCRIPTION
Combines the open Dependabot dependency updates of this week into a single PR
to reduce CI runs and manual verification overhead.

## Bumped dependencies

Versions below are the actual `main` → branch deltas taken from `package-lock.json`
(the originating Dependabot PRs were opened against older lockfile states, so their
titles quote different "from" versions).

| Package | From | To | Manifest touched | Supersedes |
|---------|------|----|------------------|------------|
| shell-quote | 1.8.3 | 1.8.4 | `package-lock.json` | #64 |
| concurrently | 9.2.1 | 9.2.3 | `package.json`, `package-lock.json` | #64 |
| js-yaml | 4.1.1 | 4.2.0 | `packages/frontend/package.json`, `package-lock.json` | #65 |
| body-parser | 1.20.5 / 2.2.2 | 1.20.6 / 2.3.0 | `package-lock.json` | #75 |
| hono | 4.12.26 | 4.12.31 | `package-lock.json` | #76 |
| aws-cdk-lib | 2.256.1 | 2.260.0 | `package.json`, `packages/cdk/package.json`, `package-lock.json` | #77 |
| dompurify | 3.4.11 | 3.4.12 | `package-lock.json` | #78 |

`body-parser` is present at two major lines through different transitive paths; both
were patched. The `js-yaml` 3.x copy that other tooling pulls in is untouched.

### Root `overrides` follow-up

`overrides.aws-cdk-lib` in the root `package.json` was pinned to `2.256.1`, which would
have silently cancelled the bump from #77 — that PR only updates
`packages/cdk/package.json`, and the root override would have pulled the resolved
version straight back down. It has been aligned to `2.260.0`.

`package-lock.json` was regenerated with `npm install --package-lock-only` after all
merges to normalize the `dev`/`peer` metadata that sequential merges can skew.

## Local verification

- [x] `npm ci` — passed
- [x] `npm run lint` — passed (all workspaces)
- [x] `npm run format:check` — passed
- [x] `npm run test` — passed
- [ ] `npm run synth` — **not run: blocked by a pre-existing config issue, not by this
  change.** `cdk synth` fails with an invalid `cognitoDomainPrefix`
  (`moca-<your-unique-suffix>`, the unedited placeholder) on `main` as well. Needs to be
  run in a configured environment — see the reviewer checklist.

## Manual verification checklist (for reviewer)

- [ ] `npm run build` succeeds
- [ ] `npm run dev`: chat send/receive, tool use and streaming behave as before
      (`concurrently` drives the dev server startup)
- [ ] Markdown rendering is intact, including sanitization of untrusted content
      (dompurify 3.4.11 → 3.4.12)
- [ ] `npm run synth` / `cdk diff` in a configured environment shows only the expected
      template changes for aws-cdk-lib 2.256.1 → 2.260.0
- [ ] YAML parsing paths in the frontend still work (js-yaml 4.1.1 → 4.2.0)

## Excluded from this PR

None. All 6 Dependabot PRs open at the time of this run were eligible: all `MERGEABLE`,
no major version bumps, no failing checks.

Closes #64
Closes #65
Closes #75
Closes #76
Closes #77
Closes #78
