### PR TITLE
chore(deps): combined dependabot updates (fast-uri, shell-quote/concurrently, postcss, js-yaml)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@eslint/js": "^10.0.0",
         "@types/jest": "^29.5.0",
         "@types/node": "^22.0.0",
-        "concurrently": "^9.2.3",
+        "concurrently": "^9.2.4",
         "eslint": "^10.0.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-boundaries": "^6.0.2",
@@ -12758,15 +12758,15 @@
       }
     },
     "node_modules/concurrently": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.3.tgz",
-      "integrity": "sha512-ihjs0E2SxvDgq/MK418hX6YycQgKhsqxpbZuZbHo0yKfqDWdymWMjWYIpCIzqDDLLKClHlXev8whW/8WXmJ0BA==",
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.4.tgz",
+      "integrity": "sha512-TZ0CEhyzvFjgtAvHTusDMgj7wNdihCh7LLLrzdUOXIhdlnL2JBBGA9eJxR24rtqgmdjh3OA3hrN1rCHj6HM8qA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
         "rxjs": "7.8.2",
-        "shell-quote": "1.8.4",
+        "shell-quote": "1.9.0",
         "supports-color": "8.1.1",
         "tree-kill": "1.2.2",
         "yargs": "17.7.2"
@@ -23016,9 +23016,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18419,9 +18419,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -27553,7 +27553,7 @@
         "fflate": "^0.8.2",
         "i18next": "^25.7.3",
         "i18next-browser-languagedetector": "^8.2.0",
-        "js-yaml": "^4.2.0",
+        "js-yaml": "^4.3.0",
         "katex": "^0.16.27",
         "lucide-react": "^0.562.0",
         "mermaid": "^11.12.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4161,6 +4161,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4177,6 +4178,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4193,6 +4195,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4209,6 +4212,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4225,6 +4229,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4241,6 +4246,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4257,6 +4263,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4273,6 +4280,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4289,6 +4297,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4305,6 +4314,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4321,6 +4331,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4337,6 +4348,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4353,6 +4365,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4369,6 +4382,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4385,6 +4399,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4401,6 +4416,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4417,6 +4433,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4433,6 +4450,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4449,6 +4467,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4465,6 +4484,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4481,6 +4501,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4497,6 +4518,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4513,6 +4535,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4529,6 +4552,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4545,6 +4569,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4561,6 +4586,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9027,6 +9053,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9044,6 +9071,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9061,6 +9089,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9078,6 +9107,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9095,6 +9125,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9112,6 +9143,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9129,6 +9161,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9146,6 +9179,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9163,6 +9197,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9180,6 +9215,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9197,6 +9233,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9214,6 +9251,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20279,9 +20279,9 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -21132,9 +21132,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -21151,7 +21151,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -27557,7 +27557,7 @@
         "katex": "^0.16.27",
         "lucide-react": "^0.562.0",
         "mermaid": "^11.12.2",
-        "postcss": "^8.5.6",
+        "postcss": "^8.5.23",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-hot-toast": "^2.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14962,9 +14962,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@eslint/js": "^10.0.0",
     "@types/jest": "^29.5.0",
     "@types/node": "^22.0.0",
-    "concurrently": "^9.2.3",
+    "concurrently": "^9.2.4",
     "eslint": "^10.0.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-boundaries": "^6.0.2",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -32,7 +32,7 @@
     "katex": "^0.16.27",
     "lucide-react": "^0.562.0",
     "mermaid": "^11.12.2",
-    "postcss": "^8.5.6",
+    "postcss": "^8.5.23",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-hot-toast": "^2.6.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -28,7 +28,7 @@
     "fflate": "^0.8.2",
     "i18next": "^25.7.3",
     "i18next-browser-languagedetector": "^8.2.0",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.0",
     "katex": "^0.16.27",
     "lucide-react": "^0.562.0",
     "mermaid": "^11.12.2",


### PR DESCRIPTION
Combines the four open Dependabot dependency updates into a single PR to reduce CI
runs and manual verification overhead.

## Bumped dependencies

Versions below are derived from the actual `package-lock.json` diff against `main`,
not from the Dependabot PR titles.

| Package | From | To | Kind | Manifest touched | Supersedes |
|---------|------|----|------|------------------|------------|
| `fast-uri` | 3.1.2 | 3.1.4 | transitive (security) | `package-lock.json` | #84 |
| `shell-quote` | 1.8.4 | 1.9.0 | transitive (security) | `package-lock.json` | #85 |
| `concurrently` | 9.2.3 | 9.2.4 | direct devDependency | `package.json`, `package-lock.json` | #85 |
| `postcss` | 8.5.15 | 8.5.23 | direct devDependency (frontend) | `packages/frontend/package.json`, `package-lock.json` | #86 |
| `js-yaml` | 4.2.0 | 4.3.0 | direct dependency (frontend) | `packages/frontend/package.json`, `package-lock.json` | #87 |
| `nanoid` | 3.3.12 | 3.3.16 | transitive (pulled in by postcss) | `package-lock.json` | — |

All bumps are patch/minor. No major version bumps are included.

### Notes

- `fast-uri` and `shell-quote` are security releases pulled in as ancestor updates
  (`shell-quote` comes with `concurrently`, which is why both move together).
- `js-yaml` 4.3.0 backports the `maxTotalMergeKeys` loader option. The frontend uses
  `js-yaml` only via `load()` in `packages/frontend/src/i18n/index.ts` for bundled
  locale files, so the new default limit does not affect application behaviour.
- `postcss` 8.5.23 stops loading source maps without `opts.from`. The frontend build
  goes through Vite/Tailwind, which always passes `from`, so CSS output is unaffected.
- `js-yaml` 3.14.2 and 4.0.9 remain in the tree as transitive dependencies of other
  packages and are intentionally left untouched.
- `node_modules/aws-cdk-lib/node_modules/fast-uri` stays at 3.1.2 because it is a
  bundled dependency of `aws-cdk-lib`; only the top-level copy is bumped.
- The root `package.json` `overrides` block contains no entry for any of the bumped
  packages, so no override follow-up was required.
- One extra commit normalizes `package-lock.json` (`npm install --package-lock-only`),
  which only restores `dev: true` metadata that the individual Dependabot merges dropped.

## Local verification

- [x] `npm ci`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run test` — 894 tests passed across all workspaces
- [x] `npm run build` — TypeScript project build + frontend production build succeed
- [x] `npx concurrently -n a,b "echo hello-a" "echo hello-b"` runs correctly on 9.2.4
      (used by `npm run dev`)
- [x] Frontend CSS bundle is generated as expected with postcss 8.5.23
- [ ] `npm run synth` — not run. It fails on `main` as well when `cognitoDomainPrefix`
      is left at its placeholder value, so it is unrelated to these bumps. No CDK
      dependency is touched by this PR.

## Manual verification checklist (for reviewer)

- [ ] `npm run dev` starts all three processes (frontend/backend/agent) via concurrently
- [ ] Chat send/receive, streaming and tool use behave as before
- [ ] UI styling is intact (postcss/Tailwind)
- [ ] Language switching works (js-yaml locale loading)

## Excluded from this PR

None. All four open Dependabot PRs were mergeable and are included.

Closes #84
Closes #85
Closes #86
Closes #87
