### PR TITLE
fix(agent): remove contradictory and dead instructions from the system prompt

### DIFF
--- a/packages/agent/src/config/prompts/__tests__/system-prompt.test.ts
+++ b/packages/agent/src/config/prompts/__tests__/system-prompt.test.ts
@@ -1,0 +1,130 @@
+/**
+ * System prompt consistency tests.
+ *
+ * The assembled prompt is the agent's primary interface, but it is plain string
+ * concatenation across two modules and nothing type-checks its content. It had
+ * accumulated three mutually contradictory rules for rendering a file path in
+ * chat (one of them broken by a missing path separator) plus a mandate to call a
+ * tool that no longer exists.
+ *
+ * These tests encode the invariants so the contradictions cannot grow back:
+ * every chat-facing path example must equal the canonical join, and no removed
+ * mechanism may be reintroduced by prose.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import { buildSystemPrompt, toDisplayPath } from '../system-prompt.js';
+import { generateDefaultContext } from '../default-context.js';
+import { RUNTIME_TOOL_NAMES } from '@moca/tool-definitions';
+
+const ALL_TOOLS = [
+  { name: RUNTIME_TOOL_NAMES.S3_LIST_FILES },
+  { name: RUNTIME_TOOL_NAMES.CODE_INTERPRETER },
+  { name: RUNTIME_TOOL_NAMES.THINK },
+];
+
+/**
+ * [storagePath, expected prefix for every chat-facing path].
+ * Written out literally rather than derived from toDisplayPath, so a call site
+ * that bypasses the helper still fails.
+ */
+const STORAGE_CASES: ReadonlyArray<readonly [string, string]> = [
+  ['/', '/'],
+  ['/aws-ai-update', '/aws-ai-update/'],
+  ['/nested/project-a', '/nested/project-a/'],
+  ['/trailing/', '/trailing/'],
+];
+
+const STORAGE_PATHS = STORAGE_CASES.map(([storagePath]) => storagePath);
+
+/** Markdown image/link targets: ![alt](target) and [text](target). */
+function markdownTargets(prompt: string): string[] {
+  return [...prompt.matchAll(/!?\[[^\]]*\]\(([^)\s]+)\)/g)].map((m) => m[1]);
+}
+
+describe('toDisplayPath', () => {
+  it.each([
+    ['/aws-ai-update', 'plots/chart.png', '/aws-ai-update/plots/chart.png'],
+    ['/aws-ai-update', 'chart.png', '/aws-ai-update/chart.png'],
+    ['/', 'chart.png', '/chart.png'],
+    [undefined, 'chart.png', '/chart.png'],
+    ['/nested/project-a', 'report.md', '/nested/project-a/report.md'],
+    ['/trailing/', 'report.md', '/trailing/report.md'],
+  ])('joins %s + %s -> %s', (storagePath, relative, expected) => {
+    expect(toDisplayPath(storagePath, relative)).toBe(expected);
+  });
+
+  it('never emits a missing or doubled separator', () => {
+    for (const storagePath of STORAGE_PATHS) {
+      const result = toDisplayPath(storagePath, 'a/b.png');
+      expect(result).toMatch(/^\/(?!\/)/);
+      expect(result).not.toContain('//');
+      expect(result.endsWith('/a/b.png')).toBe(true);
+    }
+  });
+});
+
+describe('buildSystemPrompt file path examples', () => {
+  it.each(STORAGE_PATHS)('emits no local or internal path in a link (storagePath=%s)', (p) => {
+    const prompt = buildSystemPrompt({ tools: ALL_TOOLS, storagePath: p });
+
+    // A broken link shown in link syntax is itself copy-pasteable; anti-patterns
+    // are described as plain paths instead.
+    for (const target of markdownTargets(prompt)) {
+      expect(target.startsWith('/tmp/')).toBe(false);
+      expect(target.startsWith('/opt/')).toBe(false);
+    }
+  });
+
+  it.each(STORAGE_CASES)(
+    'emits only paths under %s in links (expected prefix %s)',
+    (storagePath, expectedPrefix) => {
+      const prompt = buildSystemPrompt({ tools: ALL_TOOLS, storagePath });
+
+      const targets = markdownTargets(prompt).filter((t) => !t.startsWith('http'));
+      expect(targets.length).toBeGreaterThan(0);
+
+      for (const target of targets) {
+        // Rejects the concatenation bug ("/aws-ai-updateplots/chart.png"), which
+        // starts with the storage path but is not separated from it.
+        expect(target.startsWith(expectedPrefix)).toBe(true);
+        expect(target).not.toContain('//');
+      }
+    }
+  );
+});
+
+describe('buildSystemPrompt removed mechanisms', () => {
+  const prompt = buildSystemPrompt({ tools: ALL_TOOLS, storagePath: '/aws-ai-update' });
+
+  it('does not reference s3_upload_file, which is not a registered tool', () => {
+    expect(Object.values(RUNTIME_TOOL_NAMES)).not.toContain('s3_upload_file');
+    expect(prompt).not.toContain('s3_upload_file');
+  });
+
+  it('does not instruct the model to produce an S3 or presigned URL', () => {
+    expect(prompt).not.toMatch(/s3[.-][a-z0-9-]*\.?amazonaws\.com/i);
+    expect(prompt).not.toMatch(/(always|must).{0,40}presigned/i);
+  });
+
+  it('does not tell downloadFiles to target a directory outside the workspace', () => {
+    const destinations = [...prompt.matchAll(/"destinationDir":\s*"([^"]+)"/g)].map((m) => m[1]);
+    expect(destinations.length).toBeGreaterThan(0);
+    for (const destination of destinations) {
+      expect(destination.startsWith('/tmp/ws')).toBe(true);
+    }
+  });
+});
+
+describe('generateDefaultContext', () => {
+  it('does not advertise an upload-then-link workflow', () => {
+    const context = generateDefaultContext([{ name: RUNTIME_TOOL_NAMES.S3_LIST_FILES }]);
+    expect(context).not.toContain('s3_upload_file');
+    expect(context).not.toMatch(/amazonaws\.com/i);
+  });
+
+  it('omits the storage section entirely when no storage tool is enabled', () => {
+    const context = generateDefaultContext([{ name: RUNTIME_TOOL_NAMES.THINK }]);
+    expect(context).not.toContain('<user_storage>');
+  });
+});

--- a/packages/agent/src/config/prompts/default-context.ts
+++ b/packages/agent/src/config/prompts/default-context.ts
@@ -20,7 +20,8 @@ export function generateDefaultContext(
   const markdownRules = `    This system supports the following Markdown formats:
     - Mermaid diagram notation (\`\`\`mermaid ... \`\`\`)
     - LaTeX math notation (inline: $...$, block: $$...$$)
-    - Image: ![alt](https://xxx.s3.us-east-1.amazonaws.com/<presignedUrl>)`;
+    - Image: standard Markdown image syntax, pointing at a storage-relative path
+      (see "Displaying Files in Chat" for the exact form)`;
 
   // Check if S3-related tools are enabled
   const s3ToolNames: readonly string[] = [RUNTIME_TOOL_NAMES.S3_LIST_FILES];
@@ -34,11 +35,11 @@ export function generateDefaultContext(
     userStorageSection = `
 
   ## About File Output
-  - You are running on AWS Bedrock AgentCore. Therefore, when writing files, always write them under ${WORKSPACE_DIR}.
-  - Similarly, if you need a workspace, please use the ${WORKSPACE_DIR} directory. Do not ask the user about their current workspace. It's always ${WORKSPACE_DIR}.
-  - Also, users cannot directly access files written under ${WORKSPACE_DIR}. So when submitting these files to users, *always upload them to S3 using the s3_upload_file tool and provide the S3 URL*. The S3 URL must be included in the final output.
-  - If the output file is an image file, the S3 URL output must be in Markdown format.
-  - Note: When uploading files with Japanese or non-ASCII characters, specify contentType with charset (e.g., "text/plain; charset=utf-8") to ensure proper encoding.
+  - You are running on AWS Bedrock AgentCore. Write files under ${WORKSPACE_DIR}; that is
+    always the workspace, so don't ask the user where to put them.
+  - The workspace is synced to the user's storage automatically. To hand a file to the
+    user, link it by its storage-relative path (see "Displaying Files in Chat") — no
+    upload step is needed.
 
   <user_storage>
     <description>
@@ -51,8 +52,7 @@ ${enabledToolsList}
     <usage_guidelines>
       - All paths are relative to user's root (e.g., "/code/app.py", "/docs/report.md")
       - Organize files logically using directories (e.g., /code/, /notes/, /data/)
-      - Presigned URLs are valid for 1 hour by default and can be shared externally
-      - For large files or binary content, prefer presigned URLs over inline content
+      - For large files or binary content, prefer linking the file over inlining content
     </usage_guidelines>
   </user_storage>`;
   }

--- a/packages/agent/src/config/prompts/system-prompt.ts
+++ b/packages/agent/src/config/prompts/system-prompt.ts
@@ -11,6 +11,19 @@ export interface SystemPromptOptions {
 }
 
 /**
+ * Resolve the chat-facing path for a workspace-relative file.
+ *
+ * Single source of truth for every path example in the prompt: naive template
+ * interpolation of `storagePath` silently dropped the separator
+ * ("/aws-ai-update" + "plots/chart.png" -> "/aws-ai-updateplots/chart.png") and a
+ * separate call site double-slashed it, so the prompt shipped three mutually
+ * inconsistent conventions and the model reproduced whichever example it saw.
+ */
+export function toDisplayPath(storagePath: string | undefined, relativePath: string): string {
+  return path.posix.join('/', storagePath ?? '/', relativePath);
+}
+
+/**
  * Generate system prompt
  */
 export function buildSystemPrompt(options: SystemPromptOptions): string {
@@ -39,6 +52,10 @@ ${options.longTermMemories.map((memory, index) => `${index + 1}. ${memory}`).joi
     ? path.join(WORKSPACE_DIRECTORY, normalizedStoragePath)
     : WORKSPACE_DIRECTORY;
 
+  // Every chat-facing path example must come from here (see toDisplayPath).
+  const display = (relativePath: string): string =>
+    toDisplayPath(options.storagePath, relativePath);
+
   // Add workspace and storage path information
   if (options.storagePath) {
     basePrompt += `
@@ -64,25 +81,16 @@ The workspace sync handles most file operations automatically, making your workf
 - The "${SKILLS_DIR_NAME}/" folder holds skill definitions loaded into your capabilities. Do NOT edit or delete files under "${SKILLS_DIR_NAME}/" unless the user explicitly asks you to manage skills.
 
 ### Displaying Files in Chat
-When referencing files in chat, strip "${WORKSPACE_DIRECTORY}" from the local path to get the display path:
-- Local: ${activeWorkDir}/report.md → Chat: ${options.storagePath}/report.md
-- Local: ${activeWorkDir}/plots/chart.png → Chat: ${options.storagePath}/plots/chart.png
+Chat links resolve against the user's storage root, not the local filesystem. Take the
+local path and swap the "${activeWorkDir}" prefix for "${options.storagePath}":
 
-**For images**: \`![Chart](${options.storagePath || '/'}plots/chart.png)\`
-**For videos**: \`![Video](${options.storagePath || '/'}demo.mp4)\` or \`[Video](${options.storagePath || '/'}demo.mp4)\`
-**For other files**: \`[Report](${options.storagePath || '/'}documents/report.pdf)\`
+- \`${activeWorkDir}/plots/chart.png\` → \`![Chart](${display('plots/chart.png')})\`
+- \`${activeWorkDir}/report.md\` → \`[Report](${display('report.md')})\`
 
-Supported video formats: .mp4, .webm, .mov, .avi, .mkv, .m4v
+Videos (.mp4, .webm, .mov, .avi, .mkv, .m4v) use the same form and render inline.
 
-**Rules:**
-- ✅ ALWAYS strip "${WORKSPACE_DIRECTORY}" prefix from paths when referencing files in chat
-- ✅ The frontend will automatically generate secure download URLs when needed
-- ❌ NEVER include "${WORKSPACE_DIRECTORY}" or "/tmp/" in file references shown to users
-- ❌ NEVER generate presigned URLs or full S3 URLs like "https://bucket.s3.amazonaws.com/..."
-
-**Examples** (with storage path "${options.storagePath}"):
-- ✅ Correct: \`![Chart](${options.storagePath || '/'}chart.png)\`, \`[Data](${options.storagePath || '/'}results.csv)\`
-- ❌ Wrong: \`![Chart](${activeWorkDir}/chart.png)\`, \`[Data](/tmp/ws/results.csv)\`
+A local path (\`${WORKSPACE_DIRECTORY}/...\`) or a presigned S3 URL will not resolve in a
+chat link: the frontend signs download URLs itself from the storage-relative path.
 `;
 
     // Check S3 tool availability
@@ -119,8 +127,7 @@ When using the code_interpreter tool, follow these critical guidelines for relia
 | DO ✅ | DON'T ❌ |
 |-------|----------|
 | Create file → downloadFiles → Use userPath | Reference files without downloading |
-| \`![Chart](${options.storagePath || '/'}chart.png)\` | \`![Chart](${activeWorkDir}/chart.png)\` |
-| \`![Chart](${options.storagePath || '/'}chart.png)\` | \`![Chart](/opt/amazon/.../chart.png)\` |
+| \`![Chart](${display('chart.png')})\` | a link to \`${activeWorkDir}/chart.png\` or \`/opt/amazon/.../chart.png\` |
 | Check downloadFiles result for userPath | Use localPath or internal paths |
 
 **MANDATORY WORKFLOW:**
@@ -152,7 +159,7 @@ Step 3: Use 'userPath' from result (NOT 'localPath')
 1. ✅ Create files in Code Interpreter (executeCode/executeCommand)
 2. ✅ Download files to Runtime (\`downloadFiles\` to ${activeWorkDir})
 3. ✅ Verify download success
-4. ✅ Return relative paths starting with "/" (e.g., /chart.png, /report.pdf)
+4. ✅ Reference the file by its chat path (see "Displaying Files in Chat")
 
 ### Complete File Creation Workflow (MANDATORY)
 
@@ -180,7 +187,7 @@ Step 3: Use 'userPath' from result (NOT 'localPath')
 
 **Step 3: Return correct path to user**
 \`\`\`markdown
-Here is your chart: ![Chart](/chart.png)
+Here is your chart: ![Chart](${display('chart.png')})
 \`\`\`
 
 ⚠️ **Skipping Step 2 causes broken file references and hallucination!**
@@ -198,14 +205,14 @@ Here is your chart: ![Chart](/chart.png)
 # In Code Interpreter
 plt.savefig('analysis.png')
 \`\`\`
-Then immediately: "Here is your analysis: ![Result](/analysis.png)"
+Then immediately: "Here is your analysis: ![Result](${display('analysis.png')})"
 → File wasn't downloaded to Runtime. Link is broken.
 
 ❌ **WRONG: Including workspace path in user-facing references**
 \`\`\`
 "Your file is at ${activeWorkDir}/report.pdf"
 \`\`\`
-→ Should strip "${WORKSPACE_DIRECTORY}" prefix for proper S3 integration
+→ Should be \`${display('report.pdf')}\` so the frontend can resolve it
 
 ✅ **CORRECT: Complete workflow**
 \`\`\`python
@@ -216,7 +223,7 @@ plt.savefig('analysis.png')
 // Step 2: Download
 {"action": "downloadFiles", "sourcePaths": ["analysis.png"], "destinationDir": "${activeWorkDir}"}
 \`\`\`
-"Here is your analysis: ![Result](/analysis.png)" // Step 3: Reference
+"Here is your analysis: ![Result](${display('analysis.png')})" // Step 3: Reference
 
 ### Pre-Reference Checklist (Verify Before Responding)
 
@@ -224,7 +231,7 @@ Before returning any file reference to the user, verify:
 - [ ] Did I create a file via executeCode/executeCommand?
 - [ ] Did I run \`downloadFiles\` to transfer it to ${activeWorkDir}?
 - [ ] Did the download succeed? (Check tool response)
-- [ ] Am I using relative path with "/" prefix? (e.g., ${options.storagePath || '/'}/file.png, not ${activeWorkDir}/file.png)
+- [ ] Am I using the chat path (\`${display('file.png')}\`), not \`${activeWorkDir}/file.png\`?
 - [ ] Am I NOT using Code Interpreter internal paths?
 
 If you answer "No" to any of these, DO NOT reference the file yet.
@@ -264,7 +271,7 @@ Step 4: Download results if needed
   "action": "downloadFiles",
   "sessionName": "data-analysis-20240101",
   "sourcePaths": ["results.png"],
-  "destinationDir": "/tmp/analysis-results"
+  "destinationDir": "${activeWorkDir}"
 }
 \`\`\`
 


### PR DESCRIPTION
Closes #94

## What

Removes the contradictory and dead instructions from the assembled agent system
prompt. Scope is limited to items 1-3 of the issue: no restructuring, no skill
extraction, no interface changes.

## Why

The prompt carried **three mutually contradictory rules for rendering a file path
in chat**, and one of them was broken outright by string concatenation:

```ts
`![Chart](${options.storagePath || '/'}plots/chart.png)`
// storagePath="/aws-ai-update"  ->  /aws-ai-updateplots/chart.png
```

The separator is missing. The prose two lines above showed the *correct* form, so
prose and code fence disagreed — and the model reproduces the code fence. A second
call site double-slashed (`${storagePath || '/'}/file.png`), and a third told the
model to return a bare root-relative path (`/chart.png`). This is the most likely
root cause of chat file links resolving to the wrong path.

Two mechanisms were also dead:

- **`s3_upload_file` is not a tool.** `tool-names.ts` registers only
  `s3_list_files`, and `s3_upload_file` appeared nowhere in the repo except this
  instruction string — which told the model it *must* call it before showing any
  file to the user. Workspace sync made the upload path obsolete; only the
  instruction survived.
- **The presigned-URL rule contradicted itself.** `default-context.ts` advertised
  `![alt](https://xxx.s3.us-east-1.amazonaws.com/<presignedUrl>)` as the image
  form while `system-prompt.ts` said `❌ NEVER generate presigned URLs or full S3
  URLs`.

Plus one more contradiction: the Recommended Workflow used
`"destinationDir": "/tmp/analysis-results"` twenty lines above the rule saying such
paths will not sync to S3.

Removing these cannot regress behaviour, because the current behaviour is already
undefined.

Context: Anthropic's [The new rules of context engineering for Claude 5 generation
models](https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models)
reports deleting >80% of Claude Code's system prompt with no eval loss, and calls
out precisely this failure mode — the model burning reasoning on reconciling
overlapping and conflicting instructions rather than doing the task.

## How

1. **One source of truth for paths.** New exported `toDisplayPath(storagePath, rel)`
   using `path.posix.join`, and a local `display()` closure that every chat-facing
   example in the prompt now goes through. `/aws-ai-update` + `plots/chart.png` →
   `/aws-ai-update/plots/chart.png`; `/` + `chart.png` → `/chart.png`.
2. **State the convention once.** `### Displaying Files in Chat` went from 7 example
   forms plus 4 ALWAYS/NEVER bullets (several of them the broken variant) to 2
   examples plus the reason the rule exists, so the model can apply judgement instead
   of pattern-matching a contradictory table.
3. **Delete the dead mechanisms.** `s3_upload_file`, the presigned-URL image form,
   and the presigned-URL storage guidelines are gone.
4. **Anti-patterns are no longer written in link syntax.** A broken link shown as
   `![Chart](/tmp/ws/...)` is itself copy-pasteable; it is now described as a plain
   path.

## Tests

New `src/config/prompts/__tests__/system-prompt.test.ts` (20 cases). Per AGENTS.md
("Enforce verifiable constraints with tests and linters, not prose") these are the
point of the PR — they are what stops the contradictions from growing back:

- every markdown link target equals the canonical join for the given `storagePath`
  (`/`, `/aws-ai-update`, `/nested/project-a`, `/trailing/`)
- no local (`/tmp/`) or Code Interpreter (`/opt/`) path appears in link syntax
- no `s3_upload_file`, no `*.amazonaws.com`, no "always ... presigned"
- every `destinationDir` in an example stays inside the workspace
- the storage section is omitted entirely when no storage tool is enabled

Expected prefixes are written out **literally** rather than derived from
`toDisplayPath`, so a call site that bypasses the helper still fails.

Verified the tests are not vacuous by mutation:

| Mutation | Result |
|---|---|
| `toDisplayPath` reverted to naive concatenation | 4 failed |
| one call site reverted to `${storagePath \|\| '/'}plots/...` | 2 failed |

## Verification

```
npm run lint --workspace=packages/agent      # clean
npx prettier --check ...prompts/**/*.ts      # clean
npx tsc -b tsconfig.build.json               # clean
npm run test --workspace=packages/agent      # 37 suites, 494 tests passed
```

No `libs/` changes, so no cross-package impact.

## Not in this PR

Deliberately deferred — these change behaviour and want a regression suite first
(this PR provides the beginning of one):

- Compressing the 209-line / ~2,000-token Code Interpreter block into a skill.
  It currently restates "don't forget `downloadFiles`" in **8 different formats**.
- Making `downloadFiles` unnecessary by having `executeCode` return workspace paths
  (design the interface instead of repeating the rule).
- Summarising long-term memory injection instead of inlining every record verbatim.
- Deferred loading for large tool definitions (`code-interpreter.ts` ≈3,571 tokens).
